### PR TITLE
Add support for multi-pointer `[^]` types

### DIFF
--- a/codegen/pxbind/src/consumer.rs
+++ b/codegen/pxbind/src/consumer.rs
@@ -381,6 +381,7 @@ impl<'ast> AstConsumer<'ast> {
                 QualType::Pointer {
                     is_const: false,
                     is_pointee_const: false,
+                    is_array_like: false,
                     pointee: Box::new(QualType::Builtin(Builtin::Void)),
                 },
             );
@@ -533,6 +534,7 @@ impl<'ast> AstConsumer<'ast> {
             return Ok(QualType::Pointer {
                 is_const: false,
                 is_pointee_const,
+                is_array_like: false,
                 pointee: Box::new(pointee),
             });
         } else if let Some(ptr) = type_str.strip_suffix("*const") {
@@ -543,6 +545,7 @@ impl<'ast> AstConsumer<'ast> {
             return Ok(QualType::Pointer {
                 is_const: true,
                 is_pointee_const,
+                is_array_like: false,
                 pointee: Box::new(pointee),
             });
         } else if let Some(refer) = type_str.strip_suffix('&') {
@@ -891,6 +894,7 @@ pub enum QualType<'ast> {
     Pointer {
         is_const: bool,
         is_pointee_const: bool,
+        is_array_like: bool,
         pointee: Box<QualType<'ast>>,
     },
     Reference {

--- a/codegen/pxbind/src/consumer/functions.rs
+++ b/codegen/pxbind/src/consumer/functions.rs
@@ -25,6 +25,7 @@ impl<'ast> Param<'ast> {
             kind: QualType::Pointer {
                 is_const: false,
                 is_pointee_const: is_const,
+                is_array_like: false,
                 pointee: Box::new(rec_type),
             },
         }

--- a/codegen/pxbind/src/consumer/record.rs
+++ b/codegen/pxbind/src/consumer/record.rs
@@ -316,7 +316,7 @@ impl<'ast> super::AstConsumer<'ast> {
                     kind: QualType::Pointer {
                         is_const: false,
                         is_pointee_const: false,
-                        is_array_like: false,
+                        is_array_like: true,
                         pointee: Box::new(QualType::Record { name: hit_type }),
                     },
                     is_public: true,
@@ -341,7 +341,7 @@ impl<'ast> super::AstConsumer<'ast> {
                     kind: QualType::Pointer {
                         is_const: false,
                         is_pointee_const: false,
-                        is_array_like: false,
+                        is_array_like: true,
                         pointee: Box::new(QualType::Builtin(Builtin::UInt)),
                     },
                     is_public: false,

--- a/codegen/pxbind/src/consumer/record.rs
+++ b/codegen/pxbind/src/consumer/record.rs
@@ -316,6 +316,7 @@ impl<'ast> super::AstConsumer<'ast> {
                     kind: QualType::Pointer {
                         is_const: false,
                         is_pointee_const: false,
+                        is_array_like: false,
                         pointee: Box::new(QualType::Record { name: hit_type }),
                     },
                     is_public: true,
@@ -340,6 +341,7 @@ impl<'ast> super::AstConsumer<'ast> {
                     kind: QualType::Pointer {
                         is_const: false,
                         is_pointee_const: false,
+                        is_array_like: false,
                         pointee: Box::new(QualType::Builtin(Builtin::UInt)),
                     },
                     is_public: false,
@@ -506,6 +508,7 @@ impl<'ast> super::AstConsumer<'ast> {
                         pointee: Box::new(QualType::Record { name: inner_type }),
                         is_const: false,
                         is_pointee_const: false,
+                        is_array_like: false,
                     }),
                     len: 16,
                 },
@@ -526,6 +529,7 @@ impl<'ast> super::AstConsumer<'ast> {
                     pointee: Box::new(QualType::Record { name: inner_type }),
                     is_const: false,
                     is_pointee_const: false,
+                    is_array_like: false,
                 },
                 is_public: false,
                 is_reference: false,
@@ -576,6 +580,7 @@ impl<'ast> super::AstConsumer<'ast> {
                     kind: QualType::Pointer {
                         is_const: false,
                         is_pointee_const: false,
+                        is_array_like: false,
                         pointee: Box::new(QualType::Record {
                             name: "PxSolverBody",
                         }),
@@ -591,6 +596,7 @@ impl<'ast> super::AstConsumer<'ast> {
                     kind: QualType::Pointer {
                         is_const: false,
                         is_pointee_const: false,
+                        is_array_like: false,
                         pointee: Box::new(QualType::Record {
                             name: "PxSolverBody",
                         }),
@@ -666,6 +672,7 @@ impl<'ast> super::AstConsumer<'ast> {
                             ret: Some(QualType::Pointer {
                                 is_const: false,
                                 is_pointee_const: false,
+                                is_array_like: false,
                                 pointee: Box::new(QualType::Record { name: rname }),
                             }),
                             comment,

--- a/codegen/pxbind/src/cpp.rs
+++ b/codegen/pxbind/src/cpp.rs
@@ -15,6 +15,7 @@ impl<'qt> fmt::Display for CppType<'qt> {
                 is_const,
                 pointee,
                 is_pointee_const,
+                is_array_like: _,
             } => {
                 write!(f, "{}", pointee.cpp_type())?;
                 write!(f, "{}*", if *is_pointee_const { " const" } else { "" })?;
@@ -53,6 +54,7 @@ impl<'qt> fmt::Display for CType<'qt> {
                 is_const,
                 pointee,
                 is_pointee_const,
+                is_array_like: _,
             } => {
                 write!(f, "{}", pointee.c_type())?;
                 write!(f, "{}*", if *is_pointee_const { " const" } else { "" })?;

--- a/codegen/pxbind/src/odin_generator.rs
+++ b/codegen/pxbind/src/odin_generator.rs
@@ -272,9 +272,14 @@ impl<'ast> fmt::Display for OdinIdent<'ast> {
 impl<'qt> fmt::Display for OdinType<'qt> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.0 {
-            QualTypeValue::Pointer { pointee, .. } => {
-                match pointee.odin_type().0 {
-                    QualTypeValue::Builtin(Builtin::Void) => write!(f, "rawptr")?,
+            QualTypeValue::Pointer {
+                pointee,
+                is_array_like,
+                ..
+            } => {
+                match (pointee.odin_type().0, is_array_like) {
+                    (QualTypeValue::Builtin(Builtin::Void), _) => write!(f, "rawptr")?,
+                    (_, true) => write!(f, "[^]{}", pointee.odin_type())?,
                     _ => write!(f, "^{}", pointee.odin_type())?,
                 }
 

--- a/codegen/pxbind/src/odin_generator.rs
+++ b/codegen/pxbind/src/odin_generator.rs
@@ -279,6 +279,7 @@ impl<'qt> fmt::Display for OdinType<'qt> {
             } => {
                 match (pointee.odin_type().0, is_array_like) {
                     (QualTypeValue::Builtin(Builtin::Void), _) => write!(f, "rawptr")?,
+                    (QualTypeValue::Builtin(Builtin::Char), _) => write!(f, "cstring")?,
                     (_, true) => write!(f, "[^]{}", pointee.odin_type())?,
                     _ => write!(f, "^{}", pointee.odin_type())?,
                 }

--- a/codegen/pxbind/src/odin_generator/functions.rs
+++ b/codegen/pxbind/src/odin_generator/functions.rs
@@ -85,6 +85,21 @@ impl FuncBindingValue {
         }
 
         if let Some(ret) = &self.ret {
+            // Heuristic: Multi-pointer return value for "getXs" functions
+            let is_array_return = self.name.ends_with("s") && self.name.contains("get");
+
+            let ret = match ret {
+                QualTypeValue::Pointer { is_const, is_pointee_const, is_array_like, pointee } if is_array_return => {
+                    QualTypeValue::Pointer {
+                        is_const: *is_const,
+                        is_pointee_const: *is_pointee_const,
+                        is_array_like: true,
+                        pointee: pointee.clone(),
+                    }
+                },
+                _ => ret.clone()
+            };
+
             writes!(acc, ") -> {}", ret.odin_type());
         } else {
             writes!(acc, ")");

--- a/codegen/pxbind/src/odin_generator/functions.rs
+++ b/codegen/pxbind/src/odin_generator/functions.rs
@@ -89,7 +89,7 @@ impl FuncBindingValue {
             let is_array_return = self.name.ends_with("s") && self.name.contains("get");
 
             let ret = match ret {
-                QualTypeValue::Pointer { is_const, is_pointee_const, is_array_like, pointee } if is_array_return => {
+                QualTypeValue::Pointer { is_const, is_pointee_const, is_array_like: _, pointee } if is_array_return => {
                     QualTypeValue::Pointer {
                         is_const: *is_const,
                         is_pointee_const: *is_pointee_const,

--- a/codegen/pxbind/src/odin_generator/record.rs
+++ b/codegen/pxbind/src/odin_generator/record.rs
@@ -148,6 +148,7 @@ impl crate::type_db::RecBindingDef {
 
                 continue;
             }
+
             let name = if emitted_field.name.ends_with(']') {
                 emitted_field.name[..emitted_field.name.find('[').unwrap()].to_owned()
             } else {

--- a/codegen/pxbind/src/type_db.rs
+++ b/codegen/pxbind/src/type_db.rs
@@ -55,6 +55,7 @@ pub enum QualTypeValue {
     Pointer {
         is_const: bool,
         is_pointee_const: bool,
+        is_array_like: bool,
         pointee: Box<QualTypeValue>,
     },
     Reference {
@@ -382,10 +383,12 @@ impl<'ast> From<&crate::consumer::QualType<'ast>> for QualTypeValue {
             QualType::Pointer {
                 is_const,
                 is_pointee_const,
+                is_array_like,
                 pointee,
             } => QualTypeValue::Pointer {
                 is_const: *is_const,
                 is_pointee_const: *is_pointee_const,
+                is_array_like: *is_array_like,
                 pointee: Box::new(pointee.as_ref().into()),
             },
             QualType::Reference { is_const, pointee } => QualTypeValue::Reference {

--- a/codegen/pxbind/type-db.json
+++ b/codegen/pxbind/type-db.json
@@ -12244,7 +12244,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
-                "is_array_like": false,
+                "is_array_like": true,
                 "pointee": {
                   "Builtin": "Char"
                 }
@@ -12821,7 +12821,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
-                "is_array_like": false,
+                "is_array_like": true,
                 "pointee": {
                   "Builtin": "Char"
                 }
@@ -13420,7 +13420,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
-                "is_array_like": false,
+                "is_array_like": true,
                 "pointee": {
                   "Builtin": "Char"
                 }
@@ -13435,7 +13435,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
-                "is_array_like": false,
+                "is_array_like": true,
                 "pointee": {
                   "Builtin": "Char"
                 }
@@ -30340,7 +30340,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
-                "is_array_like": false,
+                "is_array_like": true,
                 "pointee": {
                   "Builtin": "UChar"
                 }
@@ -30355,7 +30355,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
-                "is_array_like": false,
+                "is_array_like": true,
                 "pointee": {
                   "Builtin": "UChar"
                 }
@@ -30370,7 +30370,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
-                "is_array_like": false,
+                "is_array_like": true,
                 "pointee": {
                   "Builtin": "Float"
                 }
@@ -37723,7 +37723,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
-                "is_array_like": false,
+                "is_array_like": true,
                 "pointee": {
                   "Builtin": "Char"
                 }
@@ -38054,7 +38054,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -38067,7 +38067,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -39139,7 +39139,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -39193,7 +39193,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -39277,7 +39277,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -39331,7 +39331,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -39471,7 +39471,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -39617,7 +39617,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -39716,7 +39716,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -39770,7 +39770,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -43480,7 +43480,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Float"
               }
@@ -45504,7 +45504,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -45517,7 +45517,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -45582,7 +45582,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -45595,7 +45595,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -45827,7 +45827,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -45840,7 +45840,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -46054,7 +46054,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -46067,7 +46067,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -46671,7 +46671,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Float"
               }
@@ -50688,7 +50688,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -50777,7 +50777,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -50829,7 +50829,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -52809,7 +52809,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -53800,7 +53800,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -53932,7 +53932,7 @@
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": true,
-                  "is_array_like": false,
+                  "is_array_like": true,
                   "pointee": {
                     "Builtin": "Char"
                   }
@@ -54332,7 +54332,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -55375,7 +55375,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": false,
+          "is_array_like": true,
           "pointee": {
             "Builtin": "Char"
           }
@@ -55879,7 +55879,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -55891,7 +55891,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": false,
+          "is_array_like": true,
           "pointee": {
             "Builtin": "Char"
           }
@@ -55982,7 +55982,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": false,
+          "is_array_like": true,
           "pointee": {
             "Builtin": "Char"
           }
@@ -56867,7 +56867,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -56939,7 +56939,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -57408,7 +57408,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": false,
+          "is_array_like": true,
           "pointee": {
             "Builtin": "Char"
           }
@@ -59625,7 +59625,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": false,
+          "is_array_like": true,
           "pointee": {
             "Builtin": "Char"
           }
@@ -60221,7 +60221,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": false,
+          "is_array_like": true,
           "pointee": {
             "Builtin": "Char"
           }
@@ -65194,7 +65194,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": false,
+          "is_array_like": true,
           "pointee": {
             "Builtin": "Char"
           }
@@ -68764,7 +68764,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -68818,7 +68818,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": false,
+          "is_array_like": true,
           "pointee": {
             "Builtin": "Char"
           }
@@ -69988,7 +69988,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": false,
+          "is_array_like": true,
           "pointee": {
             "Builtin": "Char"
           }
@@ -72007,7 +72007,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": false,
+          "is_array_like": true,
           "pointee": {
             "Builtin": "Char"
           }
@@ -72402,7 +72402,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": false,
+          "is_array_like": true,
           "pointee": {
             "Builtin": "Char"
           }
@@ -73144,7 +73144,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": false,
+          "is_array_like": true,
           "pointee": {
             "Builtin": "Char"
           }
@@ -73626,7 +73626,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": false,
+          "is_array_like": true,
           "pointee": {
             "Builtin": "Char"
           }
@@ -74188,7 +74188,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": false,
+          "is_array_like": true,
           "pointee": {
             "Builtin": "Char"
           }
@@ -75376,7 +75376,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -75430,7 +75430,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": false,
+          "is_array_like": true,
           "pointee": {
             "Builtin": "Char"
           }
@@ -79831,7 +79831,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": false,
+          "is_array_like": true,
           "pointee": {
             "Builtin": "Char"
           }
@@ -81399,7 +81399,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -81453,7 +81453,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": false,
+          "is_array_like": true,
           "pointee": {
             "Builtin": "Char"
           }
@@ -81493,7 +81493,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": false,
+          "is_array_like": true,
           "pointee": {
             "Builtin": "Char"
           }
@@ -84936,7 +84936,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": false,
+          "is_array_like": true,
           "pointee": {
             "Builtin": "Char"
           }
@@ -85884,7 +85884,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": false,
+          "is_array_like": true,
           "pointee": {
             "Builtin": "Char"
           }
@@ -88769,7 +88769,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -90577,7 +90577,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": false,
+          "is_array_like": true,
           "pointee": {
             "Builtin": "Char"
           }
@@ -92744,7 +92744,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
@@ -95711,7 +95711,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": false,
+          "is_array_like": true,
           "pointee": {
             "Builtin": "Char"
           }
@@ -95751,7 +95751,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": false,
+          "is_array_like": true,
           "pointee": {
             "Builtin": "Char"
           }
@@ -101004,7 +101004,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -102073,7 +102073,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
@@ -102291,7 +102291,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
@@ -106578,7 +106578,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -106698,7 +106698,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -108536,7 +108536,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -108625,7 +108625,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -109241,7 +109241,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
@@ -109321,7 +109321,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
@@ -109935,7 +109935,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": false,
+          "is_array_like": true,
           "pointee": {
             "Builtin": "Char"
           }
@@ -117059,7 +117059,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -117205,7 +117205,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -117537,7 +117537,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -117550,7 +117550,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -118783,7 +118783,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -118837,7 +118837,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": false,
+          "is_array_like": true,
           "pointee": {
             "Builtin": "Char"
           }
@@ -120012,7 +120012,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": false,
+          "is_array_like": true,
           "pointee": {
             "Builtin": "Char"
           }
@@ -120654,7 +120654,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": false,
+          "is_array_like": true,
           "pointee": {
             "Builtin": "Char"
           }
@@ -120886,7 +120886,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": false,
+          "is_array_like": true,
           "pointee": {
             "Builtin": "Char"
           }
@@ -122329,7 +122329,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": false,
+          "is_array_like": true,
           "pointee": {
             "Builtin": "Char"
           }
@@ -123128,7 +123128,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": false,
+          "is_array_like": true,
           "pointee": {
             "Builtin": "Char"
           }
@@ -123622,7 +123622,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": false,
+          "is_array_like": true,
           "pointee": {
             "Builtin": "Char"
           }
@@ -125248,7 +125248,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": false,
+          "is_array_like": true,
           "pointee": {
             "Builtin": "Char"
           }
@@ -125572,7 +125572,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": false,
+          "is_array_like": true,
           "pointee": {
             "Builtin": "Char"
           }
@@ -125972,7 +125972,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": false,
+          "is_array_like": true,
           "pointee": {
             "Builtin": "Char"
           }
@@ -126784,7 +126784,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -126797,7 +126797,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -135693,7 +135693,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -135860,7 +135860,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": false,
+          "is_array_like": true,
           "pointee": {
             "Builtin": "Char"
           }
@@ -136811,7 +136811,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -136871,7 +136871,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "Char"
               }

--- a/codegen/pxbind/type-db.json
+++ b/codegen/pxbind/type-db.json
@@ -9903,469 +9903,469 @@
     }
   ],
   "enum_map": {
-    "PxConvexMeshCookingType::Enum": [
-      "Int",
-      "PxConvexMeshCookingType"
-    ],
-    "PxGeometryQueryFlag::Enum": [
-      "Int",
-      "PxGeometryQueryFlag"
-    ],
-    "PxPairFlag::Enum": [
-      "Int",
-      "PxPairFlag"
-    ],
-    "PxBVHBuildStrategy::Enum": [
-      "Int",
-      "PxBVHBuildStrategy"
-    ],
-    "PxArticulationJointType::Enum": [
-      "Int",
-      "PxArticulationJointType"
-    ],
-    "PxPairFilteringMode::Enum": [
-      "Int",
-      "PxPairFilteringMode"
-    ],
-    "PxHeightFieldTessFlag::Enum": [
-      "Int",
-      "PxHeightFieldTessFlag"
-    ],
-    "PxTriangleMeshCookingResult::Enum": [
-      "Int",
-      "PxTriangleMeshCookingResult"
-    ],
-    "PxErrorCode::Enum": [
-      "Int",
-      "PxErrorCode"
-    ],
-    "PxSimulationStatistics::RbPairStatsType": [
-      "Int",
-      "RbPairStatsType"
-    ],
-    "PxConvexMeshCookingResult::Enum": [
-      "Int",
-      "PxConvexMeshCookingResult"
-    ],
-    "PxBatchQueryStatus::Enum": [
-      "Int",
-      "PxBatchQueryStatus"
-    ],
-    "PxMeshGeometryFlag::Enum": [
-      "Int",
-      "PxMeshGeometryFlag"
-    ],
-    "PxHeightFieldMaterial::Enum": [
-      "Int",
-      "PxHeightFieldMaterial"
-    ],
-    "PxHairSystemData::Enum": [
-      "Int",
-      "PxHairSystemData"
-    ],
-    "PxD6JointDriveFlag::Enum": [
-      "Int",
-      "PxD6JointDriveFlag"
-    ],
-    "PxMaterialFlag::Enum": [
-      "Int",
-      "PxMaterialFlag"
-    ],
-    "PxHitFlag::Enum": [
-      "Int",
-      "PxHitFlag"
-    ],
-    "PxRigidBodyFlag::Enum": [
-      "Int",
-      "PxRigidBodyFlag"
-    ],
-    "PxConcreteType::Enum": [
-      "Int",
-      "PxConcreteType"
-    ],
-    "PxSceneFlag::Enum": [
-      "Int",
-      "PxSceneFlag"
-    ],
-    "PxTriggerPairFlag::Enum": [
-      "Int",
-      "PxTriggerPairFlag"
-    ],
-    "PxForceMode::Enum": [
-      "Int",
-      "PxForceMode"
-    ],
     "PxActorTypeFlag::Enum": [
       "Int",
       "PxActorTypeFlag"
-    ],
-    "PxConvexMeshGeometryFlag::Enum": [
-      "Int",
-      "PxConvexMeshGeometryFlag"
-    ],
-    "PxPruningStructureType::Enum": [
-      "Int",
-      "PxPruningStructureType"
-    ],
-    "PxBroadPhaseType::Enum": [
-      "Int",
-      "PxBroadPhaseType"
-    ],
-    "PxTaskType::Enum": [
-      "Int",
-      "PxTaskType"
-    ],
-    "PxBaseFlag::Enum": [
-      "Int",
-      "PxBaseFlag"
-    ],
-    "PxQueryFlag::Enum": [
-      "Int",
-      "PxQueryFlag"
-    ],
-    "PxArticulationFlag::Enum": [
-      "Int",
-      "PxArticulationFlag"
-    ],
-    "PxDataAccessFlag::Enum": [
-      "Int",
-      "PxDataAccessFlag"
-    ],
-    "PxGeometryType::Enum": [
-      "Int",
-      "PxGeometryType"
-    ],
-    "PxHeightFieldFlag::Enum": [
-      "Int",
-      "PxHeightFieldFlag"
-    ],
-    "PxMeshMeshQueryFlag::Enum": [
-      "Int",
-      "PxMeshMeshQueryFlag"
-    ],
-    "PxControllerDebugRenderFlag::Enum": [
-      "UInt",
-      "PxControllerDebugRenderFlag"
-    ],
-    "PxFilterFlag::Enum": [
-      "Int",
-      "PxFilterFlag"
-    ],
-    "PxTetrahedronMeshDesc::PxMeshFormat": [
-      "Int",
-      "PxMeshFormat"
-    ],
-    "PxCombineMode::Enum": [
-      "Int",
-      "PxCombineMode"
-    ],
-    "PxActorFlag::Enum": [
-      "Int",
-      "PxActorFlag"
-    ],
-    "PxMeshMidPhase::Enum": [
-      "Int",
-      "PxMeshMidPhase"
-    ],
-    "PxSolverType::Enum": [
-      "Int",
-      "PxSolverType"
-    ],
-    "PxDefaultCpuDispatcherWaitForWorkMode::Enum": [
-      "Int",
-      "PxDefaultCpuDispatcherWaitForWorkMode"
-    ],
-    "PxContactPairHeaderFlag::Enum": [
-      "Int",
-      "PxContactPairHeaderFlag"
-    ],
-    "PxContactPatch::PxContactPatchFlags": [
-      "Int",
-      "PxContactPatchFlags"
-    ],
-    "PxHeightFieldFormat::Enum": [
-      "Int",
-      "PxHeightFieldFormat"
-    ],
-    "PxControllerShapeType::Enum": [
-      "Int",
-      "PxControllerShapeType"
-    ],
-    "PxSphericalJointFlag::Enum": [
-      "Int",
-      "PxSphericalJointFlag"
-    ],
-    "PxCapsuleClimbingMode::Enum": [
-      "Int",
-      "PxCapsuleClimbingMode"
-    ],
-    "PxConvexFlag::Enum": [
-      "Int",
-      "PxConvexFlag"
-    ],
-    "PxParticleSolverType::Enum": [
-      "Int",
-      "PxParticleSolverType"
-    ],
-    "PxAggregateType::Enum": [
-      "Int",
-      "PxAggregateType"
-    ],
-    "PxTriangleMeshFlag::Enum": [
-      "Int",
-      "PxTriangleMeshFlag"
-    ],
-    "PxPvdUpdateType::Enum": [
-      "Int",
-      "PxPvdUpdateType"
-    ],
-    "PxArticulationMotion::Enum": [
-      "Int",
-      "PxArticulationMotion"
-    ],
-    "PxD6Drive::Enum": [
-      "Int",
-      "PxD6Drive"
-    ],
-    "PxActorType::Enum": [
-      "Int",
-      "PxActorType"
-    ],
-    "PxArticulationCacheFlag::Enum": [
-      "Int",
-      "PxArticulationCacheFlag"
-    ],
-    "PxD6Axis::Enum": [
-      "Int",
-      "PxD6Axis"
-    ],
-    "PxFilterOp::Enum": [
-      "Int",
-      "PxFilterOp"
-    ],
-    "PxSdfBitsPerSubgridPixel::Enum": [
-      "Int",
-      "PxSdfBitsPerSubgridPixel"
-    ],
-    "PxFilterObjectFlag::Enum": [
-      "Int",
-      "PxFilterObjectFlag"
-    ],
-    "Px1DConstraintFlag::Type": [
-      "Int",
-      "Px1DConstraintFlag"
-    ],
-    "PxControllerNonWalkableMode::Enum": [
-      "Int",
-      "PxControllerNonWalkableMode"
-    ],
-    "PxDistanceJointFlag::Enum": [
-      "Int",
-      "PxDistanceJointFlag"
-    ],
-    "PxFrictionType::Enum": [
-      "Int",
-      "PxFrictionType"
-    ],
-    "PxConstraintFlag::Enum": [
-      "Int",
-      "PxConstraintFlag"
-    ],
-    "PxSceneQueryUpdateMode::Enum": [
-      "Int",
-      "PxSceneQueryUpdateMode"
-    ],
-    "PxVisualizationParameter::Enum": [
-      "Int",
-      "PxVisualizationParameter"
-    ],
-    "PxEMPTY": [
-      "Int",
-      "PxEMPTY"
-    ],
-    "PxContactPairFlag::Enum": [
-      "Int",
-      "PxContactPairFlag"
-    ],
-    "PxSoftBodyData::Enum": [
-      "Int",
-      "PxSoftBodyData"
-    ],
-    "PxDeletionEventFlag::Enum": [
-      "Int",
-      "PxDeletionEventFlag"
-    ],
-    "PxJointActorIndex::Enum": [
-      "Int",
-      "PxJointActorIndex"
-    ],
-    "PxQueryHitType::Enum": [
-      "Int",
-      "PxQueryHitType"
-    ],
-    "PxSoftBodyFlag::Enum": [
-      "Int",
-      "PxSoftBodyFlag"
-    ],
-    "PxMetaDataFlag::Enum": [
-      "Int",
-      "PxMetaDataFlag"
-    ],
-    "PxParticlePhaseFlag::Enum": [
-      "UInt",
-      "PxParticlePhaseFlag"
-    ],
-    "PxContactStreamIterator::StreamFormat": [
-      "Int",
-      "StreamFormat"
     ],
     "PxConstraintExtIDs::Enum": [
       "Int",
       "PxConstraintExtIDs"
     ],
-    "PxArticulationKinematicFlag::Enum": [
+    "PxSolverConstraintDesc::ConstraintType": [
       "Int",
-      "PxArticulationKinematicFlag"
+      "ConstraintType"
     ],
-    "PxRevoluteJointFlag::Enum": [
+    "PxTetrahedronMeshDesc::PxMeshFormat": [
       "Int",
-      "PxRevoluteJointFlag"
+      "PxMeshFormat"
     ],
-    "PxD6Motion::Enum": [
+    "PxMeshGeometryFlag::Enum": [
       "Int",
-      "PxD6Motion"
+      "PxMeshGeometryFlag"
     ],
-    "PxThreadPriority::Enum": [
+    "PxD6JointDriveFlag::Enum": [
+      "Int",
+      "PxD6JointDriveFlag"
+    ],
+    "PxPruningStructureType::Enum": [
+      "Int",
+      "PxPruningStructureType"
+    ],
+    "PxSolverType::Enum": [
+      "Int",
+      "PxSolverType"
+    ],
+    "PxGeometryType::Enum": [
+      "Int",
+      "PxGeometryType"
+    ],
+    "PxParticlePhaseFlag::Enum": [
       "UInt",
-      "PxThreadPriority"
+      "PxParticlePhaseFlag"
     ],
-    "PxRigidDynamicLockFlag::Enum": [
+    "PxJointActorIndex::Enum": [
       "Int",
-      "PxRigidDynamicLockFlag"
+      "PxJointActorIndex"
     ],
-    "PxContactPairExtraDataType::Enum": [
+    "PxConvexMeshCookingResult::Enum": [
       "Int",
-      "PxContactPairExtraDataType"
+      "PxConvexMeshCookingResult"
     ],
-    "PxPrismaticJointFlag::Enum": [
+    "PxMeshMeshQueryFlag::Enum": [
       "Int",
-      "PxPrismaticJointFlag"
-    ],
-    "PxMeshFlag::Enum": [
-      "Int",
-      "PxMeshFlag"
-    ],
-    "PxSoftBodyDataFlag::Enum": [
-      "Int",
-      "PxSoftBodyDataFlag"
-    ],
-    "PxActorCacheFlag::Enum": [
-      "Int",
-      "PxActorCacheFlag"
-    ],
-    "PxFilterObjectType::Enum": [
-      "Int",
-      "PxFilterObjectType"
-    ],
-    "PxArticulationSensorFlag::Enum": [
-      "Int",
-      "PxArticulationSensorFlag"
-    ],
-    "PxIDENTITY": [
-      "Int",
-      "PxIDENTITY"
-    ],
-    "PxTetrahedronMeshFlag::Enum": [
-      "Int",
-      "PxTetrahedronMeshFlag"
-    ],
-    "PxArticulationAxis::Enum": [
-      "Int",
-      "PxArticulationAxis"
+      "PxMeshMeshQueryFlag"
     ],
     "PxShapeFlag::Enum": [
       "Int",
       "PxShapeFlag"
     ],
-    "PxPvdInstrumentationFlag::Enum": [
+    "PxTriggerPairFlag::Enum": [
       "Int",
-      "PxPvdInstrumentationFlag"
+      "PxTriggerPairFlag"
+    ],
+    "PxContactPatch::PxContactPatchFlags": [
+      "Int",
+      "PxContactPatchFlags"
+    ],
+    "PxControllerNonWalkableMode::Enum": [
+      "Int",
+      "PxControllerNonWalkableMode"
     ],
     "PxConstraintSolveHint::Enum": [
       "Int",
       "PxConstraintSolveHint"
     ],
-    "PxConstraintVisualizationFlag::Enum": [
+    "PxActorFlag::Enum": [
       "Int",
-      "PxConstraintVisualizationFlag"
+      "PxActorFlag"
     ],
-    "PxSolverConstraintDesc::ConstraintType": [
+    "PxEMPTY": [
       "Int",
-      "ConstraintType"
+      "PxEMPTY"
     ],
-    "PxJointConcreteType::Enum": [
+    "PxErrorCode::Enum": [
       "Int",
-      "PxJointConcreteType"
+      "PxErrorCode"
     ],
-    "PxControllerCollisionFlag::Enum": [
+    "PxActorCacheFlag::Enum": [
       "Int",
-      "PxControllerCollisionFlag"
+      "PxActorCacheFlag"
     ],
-    "PxSolverConstraintPrepDescBase::BodyState": [
+    "PxCombineMode::Enum": [
       "Int",
-      "BodyState"
+      "PxCombineMode"
     ],
-    "PxBufferType::Enum": [
+    "PxSoftBodyData::Enum": [
       "Int",
-      "PxBufferType"
-    ],
-    "PxDynamicTreeSecondaryPruner::Enum": [
-      "Int",
-      "PxDynamicTreeSecondaryPruner"
+      "PxSoftBodyData"
     ],
     "PxDebugColor::Enum": [
       "UInt",
       "PxDebugColor"
     ],
-    "PxParticleBufferFlag::Enum": [
+    "PxControllerShapeType::Enum": [
       "Int",
-      "PxParticleBufferFlag"
+      "PxControllerShapeType"
     ],
-    "PxControllerBehaviorFlag::Enum": [
+    "PxBatchQueryStatus::Enum": [
       "Int",
-      "PxControllerBehaviorFlag"
+      "PxBatchQueryStatus"
     ],
-    "PxArticulationDriveType::Enum": [
+    "PxSoftBodyFlag::Enum": [
       "Int",
-      "PxArticulationDriveType"
+      "PxSoftBodyFlag"
     ],
-    "PxBVH34BuildStrategy::Enum": [
+    "PxConvexMeshGeometryFlag::Enum": [
       "Int",
-      "PxBVH34BuildStrategy"
+      "PxConvexMeshGeometryFlag"
     ],
-    "PxArticulationGpuDataType::Enum": [
+    "PxD6Drive::Enum": [
       "Int",
-      "PxArticulationGpuDataType"
+      "PxD6Drive"
     ],
-    "PxZERO": [
+    "PxSimulationStatistics::RbPairStatsType": [
       "Int",
-      "PxZERO"
+      "RbPairStatsType"
     ],
-    "PxPvdSceneFlag::Enum": [
+    "PxArticulationSensorFlag::Enum": [
       "Int",
-      "PxPvdSceneFlag"
+      "PxArticulationSensorFlag"
     ],
-    "PxHairSystemFlag::Enum": [
+    "PxRigidDynamicLockFlag::Enum": [
       "Int",
-      "PxHairSystemFlag"
+      "PxRigidDynamicLockFlag"
+    ],
+    "PxAggregateType::Enum": [
+      "Int",
+      "PxAggregateType"
+    ],
+    "PxFilterObjectFlag::Enum": [
+      "Int",
+      "PxFilterObjectFlag"
+    ],
+    "PxIDENTITY": [
+      "Int",
+      "PxIDENTITY"
+    ],
+    "PxScenePrunerIndex": [
+      "UInt",
+      "PxScenePrunerIndex"
+    ],
+    "PxD6Axis::Enum": [
+      "Int",
+      "PxD6Axis"
+    ],
+    "PxTetrahedronMeshFlag::Enum": [
+      "Int",
+      "PxTetrahedronMeshFlag"
+    ],
+    "PxForceMode::Enum": [
+      "Int",
+      "PxForceMode"
+    ],
+    "PxConvexFlag::Enum": [
+      "Int",
+      "PxConvexFlag"
+    ],
+    "PxDefaultCpuDispatcherWaitForWorkMode::Enum": [
+      "Int",
+      "PxDefaultCpuDispatcherWaitForWorkMode"
+    ],
+    "PxContactPairExtraDataType::Enum": [
+      "Int",
+      "PxContactPairExtraDataType"
     ],
     "PxMeshPreprocessingFlag::Enum": [
       "Int",
       "PxMeshPreprocessingFlag"
     ],
-    "PxScenePrunerIndex": [
+    "PxHeightFieldFormat::Enum": [
+      "Int",
+      "PxHeightFieldFormat"
+    ],
+    "PxMaterialFlag::Enum": [
+      "Int",
+      "PxMaterialFlag"
+    ],
+    "PxPvdSceneFlag::Enum": [
+      "Int",
+      "PxPvdSceneFlag"
+    ],
+    "PxArticulationCacheFlag::Enum": [
+      "Int",
+      "PxArticulationCacheFlag"
+    ],
+    "PxParticleBufferFlag::Enum": [
+      "Int",
+      "PxParticleBufferFlag"
+    ],
+    "PxSolverConstraintPrepDescBase::BodyState": [
+      "Int",
+      "BodyState"
+    ],
+    "PxSceneQueryUpdateMode::Enum": [
+      "Int",
+      "PxSceneQueryUpdateMode"
+    ],
+    "PxSoftBodyDataFlag::Enum": [
+      "Int",
+      "PxSoftBodyDataFlag"
+    ],
+    "PxDeletionEventFlag::Enum": [
+      "Int",
+      "PxDeletionEventFlag"
+    ],
+    "PxArticulationMotion::Enum": [
+      "Int",
+      "PxArticulationMotion"
+    ],
+    "PxDistanceJointFlag::Enum": [
+      "Int",
+      "PxDistanceJointFlag"
+    ],
+    "PxHeightFieldFlag::Enum": [
+      "Int",
+      "PxHeightFieldFlag"
+    ],
+    "PxContactStreamIterator::StreamFormat": [
+      "Int",
+      "StreamFormat"
+    ],
+    "PxMeshFlag::Enum": [
+      "Int",
+      "PxMeshFlag"
+    ],
+    "PxConstraintFlag::Enum": [
+      "Int",
+      "PxConstraintFlag"
+    ],
+    "PxVisualizationParameter::Enum": [
+      "Int",
+      "PxVisualizationParameter"
+    ],
+    "PxMetaDataFlag::Enum": [
+      "Int",
+      "PxMetaDataFlag"
+    ],
+    "PxConcreteType::Enum": [
+      "Int",
+      "PxConcreteType"
+    ],
+    "PxParticleSolverType::Enum": [
+      "Int",
+      "PxParticleSolverType"
+    ],
+    "PxControllerCollisionFlag::Enum": [
+      "Int",
+      "PxControllerCollisionFlag"
+    ],
+    "PxRigidBodyFlag::Enum": [
+      "Int",
+      "PxRigidBodyFlag"
+    ],
+    "PxHairSystemFlag::Enum": [
+      "Int",
+      "PxHairSystemFlag"
+    ],
+    "PxBroadPhaseType::Enum": [
+      "Int",
+      "PxBroadPhaseType"
+    ],
+    "PxRevoluteJointFlag::Enum": [
+      "Int",
+      "PxRevoluteJointFlag"
+    ],
+    "PxContactPairHeaderFlag::Enum": [
+      "Int",
+      "PxContactPairHeaderFlag"
+    ],
+    "PxConvexMeshCookingType::Enum": [
+      "Int",
+      "PxConvexMeshCookingType"
+    ],
+    "PxBufferType::Enum": [
+      "Int",
+      "PxBufferType"
+    ],
+    "PxConstraintVisualizationFlag::Enum": [
+      "Int",
+      "PxConstraintVisualizationFlag"
+    ],
+    "PxHeightFieldMaterial::Enum": [
+      "Int",
+      "PxHeightFieldMaterial"
+    ],
+    "PxTaskType::Enum": [
+      "Int",
+      "PxTaskType"
+    ],
+    "Px1DConstraintFlag::Type": [
+      "Int",
+      "Px1DConstraintFlag"
+    ],
+    "PxBVH34BuildStrategy::Enum": [
+      "Int",
+      "PxBVH34BuildStrategy"
+    ],
+    "PxZERO": [
+      "Int",
+      "PxZERO"
+    ],
+    "PxFilterFlag::Enum": [
+      "Int",
+      "PxFilterFlag"
+    ],
+    "PxHeightFieldTessFlag::Enum": [
+      "Int",
+      "PxHeightFieldTessFlag"
+    ],
+    "PxArticulationDriveType::Enum": [
+      "Int",
+      "PxArticulationDriveType"
+    ],
+    "PxPvdUpdateType::Enum": [
+      "Int",
+      "PxPvdUpdateType"
+    ],
+    "PxControllerDebugRenderFlag::Enum": [
       "UInt",
-      "PxScenePrunerIndex"
+      "PxControllerDebugRenderFlag"
+    ],
+    "PxActorType::Enum": [
+      "Int",
+      "PxActorType"
+    ],
+    "PxHairSystemData::Enum": [
+      "Int",
+      "PxHairSystemData"
+    ],
+    "PxJointConcreteType::Enum": [
+      "Int",
+      "PxJointConcreteType"
+    ],
+    "PxSceneFlag::Enum": [
+      "Int",
+      "PxSceneFlag"
+    ],
+    "PxSdfBitsPerSubgridPixel::Enum": [
+      "Int",
+      "PxSdfBitsPerSubgridPixel"
+    ],
+    "PxD6Motion::Enum": [
+      "Int",
+      "PxD6Motion"
+    ],
+    "PxArticulationAxis::Enum": [
+      "Int",
+      "PxArticulationAxis"
+    ],
+    "PxPairFlag::Enum": [
+      "Int",
+      "PxPairFlag"
+    ],
+    "PxDataAccessFlag::Enum": [
+      "Int",
+      "PxDataAccessFlag"
+    ],
+    "PxQueryHitType::Enum": [
+      "Int",
+      "PxQueryHitType"
+    ],
+    "PxFrictionType::Enum": [
+      "Int",
+      "PxFrictionType"
+    ],
+    "PxArticulationFlag::Enum": [
+      "Int",
+      "PxArticulationFlag"
+    ],
+    "PxHitFlag::Enum": [
+      "Int",
+      "PxHitFlag"
+    ],
+    "PxArticulationKinematicFlag::Enum": [
+      "Int",
+      "PxArticulationKinematicFlag"
+    ],
+    "PxTriangleMeshCookingResult::Enum": [
+      "Int",
+      "PxTriangleMeshCookingResult"
+    ],
+    "PxTriangleMeshFlag::Enum": [
+      "Int",
+      "PxTriangleMeshFlag"
+    ],
+    "PxGeometryQueryFlag::Enum": [
+      "Int",
+      "PxGeometryQueryFlag"
+    ],
+    "PxPvdInstrumentationFlag::Enum": [
+      "Int",
+      "PxPvdInstrumentationFlag"
+    ],
+    "PxBVHBuildStrategy::Enum": [
+      "Int",
+      "PxBVHBuildStrategy"
+    ],
+    "PxThreadPriority::Enum": [
+      "UInt",
+      "PxThreadPriority"
+    ],
+    "PxFilterOp::Enum": [
+      "Int",
+      "PxFilterOp"
+    ],
+    "PxPrismaticJointFlag::Enum": [
+      "Int",
+      "PxPrismaticJointFlag"
+    ],
+    "PxBaseFlag::Enum": [
+      "Int",
+      "PxBaseFlag"
+    ],
+    "PxControllerBehaviorFlag::Enum": [
+      "Int",
+      "PxControllerBehaviorFlag"
+    ],
+    "PxFilterObjectType::Enum": [
+      "Int",
+      "PxFilterObjectType"
+    ],
+    "PxCapsuleClimbingMode::Enum": [
+      "Int",
+      "PxCapsuleClimbingMode"
+    ],
+    "PxDynamicTreeSecondaryPruner::Enum": [
+      "Int",
+      "PxDynamicTreeSecondaryPruner"
+    ],
+    "PxArticulationGpuDataType::Enum": [
+      "Int",
+      "PxArticulationGpuDataType"
+    ],
+    "PxSphericalJointFlag::Enum": [
+      "Int",
+      "PxSphericalJointFlag"
+    ],
+    "PxContactPairFlag::Enum": [
+      "Int",
+      "PxContactPairFlag"
+    ],
+    "PxPairFilteringMode::Enum": [
+      "Int",
+      "PxPairFilteringMode"
+    ],
+    "PxMeshMidPhase::Enum": [
+      "Int",
+      "PxMeshMidPhase"
+    ],
+    "PxQueryFlag::Enum": [
+      "Int",
+      "PxQueryFlag"
+    ],
+    "PxArticulationJointType::Enum": [
+      "Int",
+      "PxArticulationJointType"
     ]
   },
   "flags": [
@@ -10626,94 +10626,91 @@
     }
   ],
   "flags_map": {
-    "PxRigidDynamicLockFlags": "UChar",
-    "PxConvexFlags": "UShort",
-    "PxContactPairFlags": "UShort",
-    "PxActorCacheFlags": "UShort",
-    "PxHairSystemDataFlags": "UInt",
-    "PxQueryFlags": "UShort",
-    "PxControllerDebugRenderFlags": "UInt",
-    "PxFilterFlags": "UShort",
-    "PxMeshPreprocessingFlags": "UInt",
-    "PxArticulationMotions": "UChar",
+    "PxConstraintFlags": "UShort",
+    "PxTetrahedronMeshFlags": "UChar",
+    "PxTriggerPairFlags": "UChar",
+    "PxActorTypeFlags": "UShort",
     "PxRigidBodyFlags": "UShort",
     "PxBaseFlags": "UShort",
-    "PxArticulationKinematicFlags": "UChar",
-    "PxMaterialFlags": "UShort",
-    "PxHairSystemFlags": "UInt",
-    "PxHeightFieldFlags": "UShort",
-    "PxSceneFlags": "UInt",
-    "PxPrismaticJointFlags": "UShort",
-    "PxSoftBodyDataFlags": "UInt",
-    "PxParticlePhaseFlags": "UInt",
-    "PxArticulationSensorFlags": "UChar",
-    "PxMeshMeshQueryFlags": "UInt",
-    "PxTetrahedronMeshFlags": "UChar",
+    "PxActorCacheFlags": "UShort",
+    "PxSoftBodyFlags": "UInt",
+    "PxParticleBufferFlags": "UInt",
+    "PxPvdInstrumentationFlags": "UChar",
     "PxRevoluteJointFlags": "UShort",
-    "PxConstraintFlags": "UShort",
-    "PxControllerCollisionFlags": "UChar",
-    "PxArticulationCacheFlags": "UInt",
-    "PxPvdSceneFlags": "UChar",
-    "PxActorFlags": "UChar",
-    "PxGeometryQueryFlags": "UInt",
-    "PxControllerBehaviorFlags": "UChar",
-    "PxMeshGeometryFlags": "UChar",
-    "PxConvexMeshGeometryFlags": "UChar",
-    "PxArticulationFlags": "UChar",
-    "PxDistanceJointFlags": "UShort",
     "PxContactPairHeaderFlags": "UShort",
     "PxDataAccessFlags": "UChar",
-    "PxDeletionEventFlags": "UChar",
-    "PxMeshFlags": "UShort",
-    "PxSoftBodyFlags": "UInt",
-    "PxActorTypeFlags": "UShort",
-    "PxD6JointDriveFlags": "UInt",
-    "PxParticleBufferFlags": "UInt",
-    "PxPairFlags": "UShort",
-    "PxSphericalJointFlags": "UShort",
-    "PxPvdInstrumentationFlags": "UChar",
-    "PxTriangleMeshFlags": "UChar",
     "PxHitFlags": "UShort",
-    "PxTriggerPairFlags": "UChar",
     "PxShapeFlags": "UChar",
-    "Px1DConstraintFlags": "UShort"
+    "PxSphericalJointFlags": "UShort",
+    "PxArticulationFlags": "UChar",
+    "PxArticulationSensorFlags": "UChar",
+    "PxControllerCollisionFlags": "UChar",
+    "PxArticulationKinematicFlags": "UChar",
+    "PxMeshMeshQueryFlags": "UInt",
+    "PxPrismaticJointFlags": "UShort",
+    "PxMeshPreprocessingFlags": "UInt",
+    "PxMeshFlags": "UShort",
+    "PxControllerDebugRenderFlags": "UInt",
+    "PxGeometryQueryFlags": "UInt",
+    "PxPvdSceneFlags": "UChar",
+    "PxMeshGeometryFlags": "UChar",
+    "PxMaterialFlags": "UShort",
+    "PxDeletionEventFlags": "UChar",
+    "PxArticulationMotions": "UChar",
+    "PxSoftBodyDataFlags": "UInt",
+    "PxArticulationCacheFlags": "UInt",
+    "PxRigidDynamicLockFlags": "UChar",
+    "PxSceneFlags": "UInt",
+    "PxActorFlags": "UChar",
+    "PxFilterFlags": "UShort",
+    "PxHairSystemFlags": "UInt",
+    "PxPairFlags": "UShort",
+    "PxDistanceJointFlags": "UShort",
+    "PxHairSystemDataFlags": "UInt",
+    "PxConvexFlags": "UShort",
+    "Px1DConstraintFlags": "UShort",
+    "PxControllerBehaviorFlags": "UChar",
+    "PxTriangleMeshFlags": "UChar",
+    "PxContactPairFlags": "UShort",
+    "PxHeightFieldFlags": "UShort",
+    "PxConvexMeshGeometryFlags": "UChar",
+    "PxD6JointDriveFlags": "UInt",
+    "PxQueryFlags": "UShort",
+    "PxParticlePhaseFlags": "UInt"
   },
   "type_defs": {
-    "PxSceneQueryHit": {
+    "PxU16": {
+      "Builtin": "UShort"
+    },
+    "PxI16": {
+      "Builtin": "Short"
+    },
+    "PxTransform32": {
       "Record": {
-        "name": "PxQueryHit"
+        "name": "PxTransformPadded"
       }
     },
-    "PxI32": {
-      "Builtin": "Int"
+    "PxBpFilterGroup": {
+      "Builtin": "UInt"
     },
-    "PxPhysicsInsertionCallback": {
+    "PxSweepThreadContext": {
       "Record": {
-        "name": "PxInsertionCallback"
+        "name": "PxQueryThreadContext"
+      }
+    },
+    "PxObstacleHandle": {
+      "Builtin": "UInt"
+    },
+    "PxSceneQueryCache": {
+      "Record": {
+        "name": "PxQueryCache"
       }
     },
     "PxSQCompoundHandle": {
       "Builtin": "UInt"
     },
-    "PxTriangleID": {
+    "PxAggregateFilterHint": {
       "Builtin": "UInt"
-    },
-    "PxType": {
-      "Builtin": "UShort"
-    },
-    "PxDominanceGroup": {
-      "Builtin": "UChar"
-    },
-    "PxU64": {
-      "Builtin": "ULong"
-    },
-    "PxF64": {
-      "Builtin": "Double"
-    },
-    "PxSceneQueryFlag": {
-      "Record": {
-        "name": "PxHitFlag"
-      }
     },
     "PxSQBuildStepHandle": {
       "Pointer": {
@@ -10725,25 +10722,40 @@
         }
       }
     },
-    "PxFilterObjectAttributes": {
-      "Builtin": "UInt"
+    "PxSceneQueryFilterData": {
+      "Record": {
+        "name": "PxQueryFilterData"
+      }
     },
-    "PxTaskID": {
-      "Builtin": "UInt"
+    "PxI8": {
+      "Builtin": "Char"
     },
-    "PxConstraintSolverPrep": "FunctionPointer",
     "PxRaycastThreadContext": {
       "Record": {
         "name": "PxQueryThreadContext"
       }
+    },
+    "PxU64": {
+      "Builtin": "ULong"
+    },
+    "PxSceneQueryHit": {
+      "Record": {
+        "name": "PxQueryHit"
+      }
+    },
+    "PxFEMMaterialTableIndex": {
+      "Builtin": "UShort"
+    },
+    "PxIntBool": {
+      "Builtin": "Int"
     },
     "PxSceneQueryFilterCallback": {
       "Record": {
         "name": "PxQueryFilterCallback"
       }
     },
-    "PxExtended": {
-      "Builtin": "Double"
+    "PxTaskID": {
+      "Builtin": "UInt"
     },
     "PxSceneQueryFlags": {
       "Flags": {
@@ -10751,41 +10763,86 @@
         "repr": "UShort"
       }
     },
-    "PxBpFilterGroup": {
+    "PxSerialObjectId": {
+      "Builtin": "ULong"
+    },
+    "PxType": {
+      "Builtin": "UShort"
+    },
+    "PxFilterObjectAttributes": {
       "Builtin": "UInt"
     },
-    "PxSceneQueryFilterData": {
+    "PxI32": {
+      "Builtin": "Int"
+    },
+    "PxSQPrunerHandle": {
+      "Builtin": "UInt"
+    },
+    "PxPhysicsInsertionCallback": {
       "Record": {
-        "name": "PxQueryFilterData"
+        "name": "PxInsertionCallback"
       }
+    },
+    "PxMaterialTableIndex": {
+      "Builtin": "UShort"
+    },
+    "PxReal": {
+      "Builtin": "Float"
+    },
+    "PxExtended": {
+      "Builtin": "Double"
+    },
+    "PxF64": {
+      "Builtin": "Double"
+    },
+    "PxConstraintVisualize": "FunctionPointer",
+    "PxF32": {
+      "Builtin": "Float"
+    },
+    "PxTriangleID": {
+      "Builtin": "UInt"
+    },
+    "PxSceneQueryFlag": {
+      "Record": {
+        "name": "PxHitFlag"
+      }
+    },
+    "PxClientID": {
+      "Builtin": "UChar"
+    },
+    "PxI64": {
+      "Builtin": "Long"
+    },
+    "PxU32": {
+      "Builtin": "UInt"
+    },
+    "PxBpIndex": {
+      "Builtin": "UInt"
+    },
+    "PxSimulationFilterShader": "FunctionPointer",
+    "PxAgain": {
+      "Builtin": "Bool"
+    },
+    "PxU8": {
+      "Builtin": "UChar"
     },
     "PxOverlapThreadContext": {
       "Record": {
         "name": "PxQueryThreadContext"
       }
     },
-    "PxSweepThreadContext": {
+    "PxVec3p": {
       "Record": {
-        "name": "PxQueryThreadContext"
+        "name": "PxVec3Padded"
       }
     },
-    "PxClientID": {
-      "Builtin": "UChar"
-    },
-    "PxConstraintVisualize": "FunctionPointer",
-    "PxAgain": {
-      "Builtin": "Bool"
-    },
-    "PxSceneQueryCache": {
-      "Record": {
-        "name": "PxQueryCache"
+    "PxCompileTimeAssert_Dummy": {
+      "Array": {
+        "element": {
+          "Builtin": "Char"
+        },
+        "len": 1
       }
-    },
-    "PxU32": {
-      "Builtin": "UInt"
-    },
-    "PxMaterialTableIndex": {
-      "Builtin": "UShort"
     },
     "PxFileHandle": {
       "Pointer": {
@@ -10797,66 +10854,9 @@
         }
       }
     },
-    "PxFEMMaterialTableIndex": {
-      "Builtin": "UShort"
-    },
-    "PxSimulationFilterShader": "FunctionPointer",
-    "PxBpIndex": {
-      "Builtin": "UInt"
-    },
-    "PxTransform32": {
-      "Record": {
-        "name": "PxTransformPadded"
-      }
-    },
-    "PxSQPrunerHandle": {
-      "Builtin": "UInt"
-    },
-    "PxReal": {
-      "Builtin": "Float"
-    },
-    "PxObstacleHandle": {
-      "Builtin": "UInt"
-    },
-    "PxIntBool": {
-      "Builtin": "Int"
-    },
-    "PxU16": {
-      "Builtin": "UShort"
-    },
-    "PxSerialObjectId": {
-      "Builtin": "ULong"
-    },
-    "PxI16": {
-      "Builtin": "Short"
-    },
-    "PxVec3p": {
-      "Record": {
-        "name": "PxVec3Padded"
-      }
-    },
-    "PxAggregateFilterHint": {
-      "Builtin": "UInt"
-    },
-    "PxI64": {
-      "Builtin": "Long"
-    },
-    "PxI8": {
-      "Builtin": "Char"
-    },
-    "PxU8": {
+    "PxConstraintSolverPrep": "FunctionPointer",
+    "PxDominanceGroup": {
       "Builtin": "UChar"
-    },
-    "PxCompileTimeAssert_Dummy": {
-      "Array": {
-        "element": {
-          "Builtin": "Char"
-        },
-        "len": 1
-      }
-    },
-    "PxF32": {
-      "Builtin": "Float"
     }
   },
   "recs": [
@@ -11254,7 +11254,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
-                "is_array_like": false,
+                "is_array_like": true,
                 "pointee": {
                   "Builtin": "UInt"
                 }
@@ -11278,7 +11278,7 @@
         "ast_tag_used": "class",
         "def_data": {
           "dtor": {
-            "irrelevant": true,
+            "irrelevant": false,
             "simple": false
           },
           "isAbstract": false,
@@ -12244,7 +12244,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
-                "is_array_like": true,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Char"
                 }
@@ -12821,7 +12821,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
-                "is_array_like": true,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Char"
                 }
@@ -13420,7 +13420,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
-                "is_array_like": true,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Char"
                 }
@@ -13435,7 +13435,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
-                "is_array_like": true,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Char"
                 }
@@ -26361,7 +26361,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
-                "is_array_like": false,
+                "is_array_like": true,
                 "pointee": {
                   "Record": {
                     "name": "PxRaycastHit"
@@ -26395,7 +26395,7 @@
         "ast_tag_used": "struct",
         "def_data": {
           "dtor": {
-            "irrelevant": true,
+            "irrelevant": false,
             "simple": false
           },
           "isAbstract": true,
@@ -26432,7 +26432,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
-                "is_array_like": false,
+                "is_array_like": true,
                 "pointee": {
                   "Record": {
                     "name": "PxOverlapHit"
@@ -26466,7 +26466,7 @@
         "ast_tag_used": "struct",
         "def_data": {
           "dtor": {
-            "irrelevant": true,
+            "irrelevant": false,
             "simple": false
           },
           "isAbstract": true,
@@ -26503,7 +26503,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
-                "is_array_like": false,
+                "is_array_like": true,
                 "pointee": {
                   "Record": {
                     "name": "PxSweepHit"
@@ -26537,7 +26537,7 @@
         "ast_tag_used": "struct",
         "def_data": {
           "dtor": {
-            "irrelevant": true,
+            "irrelevant": false,
             "simple": false
           },
           "isAbstract": true,
@@ -26574,7 +26574,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
-                "is_array_like": false,
+                "is_array_like": true,
                 "pointee": {
                   "Record": {
                     "name": "PxRaycastHit"
@@ -26608,7 +26608,7 @@
         "ast_tag_used": "struct",
         "def_data": {
           "dtor": {
-            "irrelevant": true,
+            "irrelevant": false,
             "simple": false
           },
           "isAbstract": false,
@@ -26645,7 +26645,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
-                "is_array_like": false,
+                "is_array_like": true,
                 "pointee": {
                   "Record": {
                     "name": "PxOverlapHit"
@@ -26679,7 +26679,7 @@
         "ast_tag_used": "struct",
         "def_data": {
           "dtor": {
-            "irrelevant": true,
+            "irrelevant": false,
             "simple": false
           },
           "isAbstract": false,
@@ -26716,7 +26716,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
-                "is_array_like": false,
+                "is_array_like": true,
                 "pointee": {
                   "Record": {
                     "name": "PxSweepHit"
@@ -26750,7 +26750,7 @@
         "ast_tag_used": "struct",
         "def_data": {
           "dtor": {
-            "irrelevant": true,
+            "irrelevant": false,
             "simple": false
           },
           "isAbstract": false,
@@ -30340,7 +30340,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
-                "is_array_like": true,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "UChar"
                 }
@@ -30355,7 +30355,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
-                "is_array_like": true,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "UChar"
                 }
@@ -30370,7 +30370,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
-                "is_array_like": true,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Float"
                 }
@@ -37723,7 +37723,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
-                "is_array_like": true,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Char"
                 }
@@ -38054,7 +38054,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -38067,7 +38067,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -39139,7 +39139,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -39193,7 +39193,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -39277,7 +39277,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -39331,7 +39331,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -39471,7 +39471,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -39617,7 +39617,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -39716,7 +39716,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -39770,7 +39770,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -43480,7 +43480,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Float"
               }
@@ -45504,7 +45504,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -45517,7 +45517,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -45582,7 +45582,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -45595,7 +45595,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -45827,7 +45827,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -45840,7 +45840,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -46054,7 +46054,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -46067,7 +46067,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -46671,7 +46671,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Float"
               }
@@ -50688,7 +50688,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -50777,7 +50777,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -50829,7 +50829,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -52809,7 +52809,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -52914,7 +52914,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": true,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxDebugPoint"
@@ -53033,7 +53033,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": true,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxDebugLine"
@@ -53125,7 +53125,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
-          "is_array_like": true,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxDebugLine"
@@ -53173,7 +53173,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
-          "is_array_like": true,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxDebugPoint"
@@ -53248,7 +53248,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": true,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxDebugTriangle"
@@ -53800,7 +53800,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -53932,7 +53932,7 @@
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": true,
-                  "is_array_like": true,
+                  "is_array_like": false,
                   "pointee": {
                     "Builtin": "Char"
                   }
@@ -54332,7 +54332,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -55125,7 +55125,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "ULong"
               }
@@ -55375,7 +55375,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -55879,7 +55879,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -55891,7 +55891,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -55982,7 +55982,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -56867,7 +56867,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -56939,7 +56939,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -57408,7 +57408,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -59304,7 +59304,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": true,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxBounds3"
@@ -59625,7 +59625,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -59804,7 +59804,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Vec3"
           }
@@ -60221,7 +60221,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -65194,7 +65194,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -66528,7 +66528,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Vec3"
           }
@@ -66758,7 +66758,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Void"
           }
@@ -67580,7 +67580,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Vec3"
           }
@@ -67680,7 +67680,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Void"
           }
@@ -68764,7 +68764,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -68818,7 +68818,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -69830,7 +69830,7 @@
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": false,
-                  "is_array_like": true,
+                  "is_array_like": false,
                   "pointee": {
                     "Record": {
                       "name": "PxActor"
@@ -69988,7 +69988,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -72007,7 +72007,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -72402,7 +72402,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -73144,7 +73144,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -73626,7 +73626,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -74188,7 +74188,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -75376,7 +75376,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -75430,7 +75430,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -79831,7 +79831,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -80417,7 +80417,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
@@ -81399,7 +81399,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -81453,7 +81453,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -81493,7 +81493,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -84936,7 +84936,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -85884,7 +85884,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -88769,7 +88769,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -90577,7 +90577,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -92942,7 +92942,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
@@ -93683,7 +93683,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
@@ -93770,7 +93770,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
@@ -95711,7 +95711,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -95751,7 +95751,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -97680,7 +97680,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
@@ -98721,7 +98721,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBroadPhaseRegionInfo"
@@ -101004,7 +101004,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -102710,7 +102710,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
-          "is_array_like": false,
+          "is_array_like": true,
           "pointee": {
             "Pointer": {
               "is_const": false,
@@ -104111,7 +104111,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
@@ -106303,7 +106303,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBroadPhaseRegionInfo"
@@ -106578,7 +106578,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -106698,7 +106698,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -107533,7 +107533,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
@@ -107654,7 +107654,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
@@ -108536,7 +108536,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -108625,7 +108625,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -108911,7 +108911,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactPairPoint"
@@ -109548,7 +109548,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
@@ -109935,7 +109935,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -117059,7 +117059,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -117205,7 +117205,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -117537,7 +117537,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -117550,7 +117550,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -118783,7 +118783,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -118837,7 +118837,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -120012,7 +120012,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -120654,7 +120654,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -120886,7 +120886,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -122329,7 +122329,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -123128,7 +123128,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -123622,7 +123622,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -125248,7 +125248,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -125572,7 +125572,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -125972,7 +125972,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -126784,7 +126784,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -126797,7 +126797,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -126893,7 +126893,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
@@ -127997,7 +127997,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": false,
+              "is_array_like": true,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
@@ -135693,7 +135693,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -135860,7 +135860,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
-          "is_array_like": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -136811,7 +136811,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -136871,7 +136871,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
-              "is_array_like": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -136894,377 +136894,407 @@
     }
   ],
   "classes": {
-    "PxCustomSceneQuerySystemAdapter": true,
-    "PxBroadPhaseResults": true,
-    "PxDebugTriangle": true,
-    "PxContactStreamIterator": true,
-    "PxHairSystemGeometry": true,
-    "PxControllerObstacleHit": true,
-    "PxSoftBodySimulationData": true,
-    "PxBitAndByte": true,
-    "PxMassProperties": true,
-    "Px1DConstraintMods": true,
-    "PxConstraintConnector": true,
-    "PxProfileScoped": true,
-    "PxInsertionCallback": true,
-    "PxRawAllocator": true,
-    "PxContactPairPoint": true,
-    "PxSDFDesc": true,
-    "PxTaskManager": true,
-    "PxParticleSystemGeometry": true,
-    "PxRigidBodyExt": true,
-    "PxCpuDispatcher": true,
-    "PxConstraintInvMassScale": true,
-    "PxCustomGeometry": true,
-    "PxContactPairExtraDataItem": true,
-    "PxArticulationSpatialTendon": true,
-    "PxDefaultErrorCallback": true,
-    "PxRigidActor": true,
-    "PxDefaultMemoryInputData": true,
-    "PxParticleRigidBuffer": false,
-    "PxUnConst": false,
-    "PxSamplingExt": true,
-    "PxLightCpuTask": true,
-    "PxCudaContextManager": false,
-    "PxBroadPhaseRegionInfo": true,
-    "PxVehicleDrivableSurfaceToTireFrictionPairs": false,
-    "PxSimulationStatistics": true,
-    "PxBroadPhaseCallback": true,
-    "PxArticulationCache": true,
-    "PxContactModifyPair": true,
-    "PxBroadPhaseRegions": true,
-    "PxRigidDynamic": true,
-    "PxAggregate": true,
-    "PxCollection": true,
-    "PxContactPairHeader": true,
-    "PxSoftBodySimulationDataDesc": true,
-    "PxTGSSolverBodyTxInertia": true,
-    "PxSimulationFilterCallback": true,
-    "PxTriangleMeshGeometry": true,
-    "PxMeshOverlapUtil": true,
-    "PxgDynamicsMemoryConfig": true,
-    "PxBVHDesc": true,
-    "PxSerializer": true,
-    "PxFilterData": true,
-    "PxSolverConstraintPrepDescBase": true,
-    "PxTetrahedronMeshGeometry": true,
-    "PxOverlapCallback": true,
-    "PxTetrahedronMesh": true,
-    "PxRenderOutput": false,
-    "PxIndexDataPair": true,
-    "PxLogTwo": false,
-    "PxParticleAndDiffuseBuffer": false,
-    "PxFEMSoftBodyMaterial": false,
-    "PxControllerShapeHit": true,
-    "PxSpringModifiers": true,
-    "PxParticleRigidFilterPair": true,
-    "PxArticulationDrive": true,
-    "PxScene": true,
-    "PxFEMMaterial": true,
-    "PxSolverBodyData": true,
-    "PxFEMClothMaterial": false,
-    "PxTetrahedronMeshExt": true,
-    "PxFEMParameters": true,
-    "PxVehicleTelemetryData": false,
-    "PxConstraintShaderTable": true,
-    "PxSerializationRegistry": true,
-    "PxDistanceJoint": true,
-    "PxActorShape": true,
-    "PxHullPolygon": true,
-    "PxNodeIndex": true,
-    "PxActor": true,
-    "PxMat44": true,
-    "PxUserControllerHitReport": true,
-    "PxControllersHit": true,
-    "PxConvexMesh": true,
-    "PxBVH33TriangleMesh": false,
-    "PxSweepCallback": true,
-    "PxTetrahedronMeshData": true,
-    "PxSolverContactDesc": true,
-    "PxSimpleTriangleMesh": true,
-    "PxRefCounted": true,
-    "PxLockedData": true,
-    "PxCounterFrequencyToTensOfNanos": true,
-    "PxArticulationTendonLimit": true,
-    "PxGeometryHolder": true,
-    "PxDim3": true,
-    "PxStridedData": true,
-    "PxOverlapHit": true,
-    "PxConvexMeshDesc": true,
-    "PxSListEntry": true,
-    "PxLocationHit": true,
-    "PxBitMap": true,
-    "PxSceneQueryExt": true,
-    "PxArticulationTendonJoint": true,
-    "PxMat34": false,
-    "PxTriggerPair": true,
-    "PxControllerBehaviorCallback": true,
-    "PxSoftBodyAuxData": true,
-    "PxSerialization": true,
-    "PxSceneQuerySystem": true,
-    "PxSweepBuffer": true,
-    "PxSpatialForce": true,
-    "PxSolverConstraintPrepDesc": true,
-    "PxPhysics": true,
     "PxHeightFieldDesc": true,
-    "PxBoundedData": true,
-    "PxVec2": true,
-    "PxGpuContactPair": true,
-    "PxPvdTransport": true,
-    "PxControllerState": true,
-    "PxPruningStructure": true,
-    "PxContact": true,
-    "PxQueryFilterData": true,
-    "PxJointLimitParameters": true,
-    "PxCustomSceneQuerySystem": true,
-    "PxContactPairExtraDataIterator": true,
-    "PxContactPairPose": true,
-    "PxArticulationFixedTendon": true,
-    "PxPoissonSampler": true,
-    "PxHash": false,
-    "PxJointLinearLimit": true,
-    "PxDefaultMemoryOutputStream": true,
-    "PxTGSSolverBodyVel": true,
-    "PxBoxControllerDesc": true,
-    "PxParticleMaterial": true,
-    "PxCCDContactModifyCallback": true,
-    "PxContactPairVelocity": true,
-    "PxParticleVolume": true,
-    "PxBroadPhase": true,
-    "PxAssertHandler": true,
-    "PxSceneReadLock": true,
-    "PxPlaneGeometry": true,
-    "PxExtendedVec3": true,
-    "PxBinaryConverter": false,
-    "PxParticleSystem": false,
-    "PxTGSSolverBodyData": true,
-    "PxArticulationLimit": true,
-    "PxTempAllocator": true,
-    "PxBatchQueryExt": true,
-    "PxInputStream": true,
-    "PxTransformPadded": true,
-    "PxTriangleMeshPoissonSampler": true,
-    "PxFixedJoint": true,
-    "PxCapsuleControllerDesc": true,
-    "PxBVHRaycastCallback": true,
-    "PxBroadPhaseDesc": true,
-    "PxVirtualAllocatorCallback": true,
-    "PxParticleClothBuffer": false,
-    "PxSceneSQSystem": true,
-    "PxRunnable": true,
-    "PxConstraintInfo": true,
-    "PxSweepHit": true,
-    "PxPBDParticleSystem": false,
-    "PxDebugText": true,
-    "PxSoftBody": false,
-    "PxContactPair": true,
-    "PxTetrahedronMeshDesc": true,
-    "PxDiffuseParticleParams": true,
-    "PxSolverConstraintDesc": true,
-    "PxVehicleWheels4DynData": false,
-    "PxSerializationContext": true,
-    "PxGearJoint": true,
-    "PxContactBuffer": false,
-    "PxPvd": true,
-    "PxJointLinearLimitPair": true,
-    "PxTriangleMeshDesc": true,
-    "PxRigidBody": true,
-    "PxSoftBodyCollisionData": true,
-    "PxSpring": true,
-    "PxControllerFilters": true,
-    "PxSListImpl": true,
-    "PxBroadPhaseUpdateData": true,
-    "PxRaycastCallback": true,
-    "PxBroadPhasePair": true,
-    "PxBVHOverlapCallback": true,
-    "PxConstraint": true,
-    "PxBVH": true,
-    "PxRepXInstantiationArgs": true,
-    "PxConeLimitParams": true,
-    "PxCapsuleGeometry": true,
-    "PxContactModifyCallback": true,
-    "PxFoundation": true,
-    "PxRepXSerializer": true,
-    "PxControllerDesc": true,
-    "PxContactPoint": true,
-    "PxD6Joint": true,
-    "PxSimulationTetrahedronMeshData": true,
-    "PxSyncImpl": true,
-    "PxTolerancesScale": true,
-    "PxArticulationSensor": true,
-    "PxFLIPMaterial": false,
-    "PxMeshScale": true,
-    "PxRaycastHit": true,
-    "PxPlane": true,
-    "PxDefaultFileOutputStream": true,
-    "PxProfilerCallback": true,
-    "PxTrianglePadded": true,
-    "PxDebugLine": true,
-    "PxRenderBuffer": true,
-    "PxParticleBuffer": false,
-    "PxBroadPhaseExt": true,
-    "PxBroadcastingAllocator": true,
-    "XmlReader": false,
-    "PxTriangleMesh": true,
-    "PxConeLimitedConstraint": true,
-    "PxArticulationLink": true,
-    "PxBase": true,
-    "PxTGSSolverConstraintPrepDesc": true,
-    "PxJointLimitPyramid": true,
-    "PxCookingParams": true,
-    "PxMeshQuery": true,
-    "PxArticulationRootLinkData": true,
-    "PxControllerManager": true,
-    "PxBaseTask": true,
-    "PxOmniPvd": false,
-    "PxDefaultCpuDispatcher": true,
-    "PxTypeInfo": false,
-    "PxQueryHit": true,
-    "PxMassModificationProps": true,
-    "PxConstraintAllocator": true,
-    "PxConstraintBatchHeader": true,
-    "PxRigidStatic": true,
-    "PxBoxController": true,
-    "PxRigidActorExt": true,
-    "PxParticleSpring": true,
-    "PxBoxObstacle": true,
-    "PxCustomGeometryCallbacks": true,
-    "PxBVH34TriangleMesh": true,
-    "PxMidphaseDesc": true,
-    "PxTime": true,
-    "PxCustomMaterial": false,
-    "PxOverlapBuffer": true,
-    "PxRackAndPinionJoint": true,
-    "PxTask": true,
-    "PxObstacle": true,
-    "PxPrismaticJoint": true,
-    "PxDominanceGroupPair": true,
-    "PxStringTable": true,
-    "PxProcessPxBaseCallback": true,
-    "PxGeomSweepHit": true,
-    "PxInputData": true,
-    "PxModifiableContact": true,
-    "PxHeightFieldGeometry": true,
-    "PxTGSSolverContactDesc": true,
-    "PxObstacleContext": true,
-    "PxCollisionTetrahedronMeshData": true,
-    "PxTransform": true,
-    "PxStringTableExt": true,
-    "PxGeomOverlapHit": true,
-    "PxDeletionListener": true,
-    "PxXmlMiscParameter": true,
-    "PxAllocatorCallback": true,
-    "PxBounds3": true,
-    "PxFEMCloth": false,
-    "PxUserAllocated": true,
-    "PxRestitutionModifiers": true,
-    "PxVirtualAllocator": true,
-    "PxParticleRigidAttachment": false,
-    "PxMPMParticleSystem": false,
-    "PxFLIPParticleSystem": false,
-    "PxGroupsMask": true,
-    "PxMaterial": true,
-    "PxVehicleWheels4SimData": false,
-    "MemoryBuffer": false,
-    "PxSphericalJoint": true,
-    "PxSpatialVelocity": true,
-    "PxCustomParticleSystem": false,
-    "PxSimulationEventCallback": true,
-    "PxPBDMaterial": false,
-    "Interpolation": true,
-    "PxAllocationListener": true,
-    "PxDebugPoint": true,
-    "PxArticulationTendon": true,
-    "PxControllerFilterCallback": true,
-    "PxTetrahedron": true,
-    "PxSoftBodyMesh": true,
-    "PxConstraintVisualizer": true,
-    "PxSceneLimits": true,
-    "PxRevoluteJoint": true,
-    "PxGeometryQuery": true,
-    "PxHeightField": true,
-    "PxControllerStats": true,
-    "PxVec3": true,
-    "PxVec3Padded": true,
-    "PxTGSSolverConstraintPrepDescBase": true,
-    "PxDefaultAllocator": true,
-    "PxVehicleTireForceCalculator": false,
-    "PxArticulationAttachment": true,
-    "PxDefaultFileInputData": true,
-    "PxCustomGeometryType": true,
-    "PxMutexImpl": true,
-    "PxAllocator": true,
-    "PxBroadPhaseRegion": true,
-    "PxOutputStream": true,
-    "PxJointAngularLimitPair": true,
-    "PxContactJoint": true,
-    "PxQueryFilterCallback": true,
-    "PxGeomRaycastHit": true,
-    "PxPvdSceneClient": true,
-    "PxBVHTraversalCallback": true,
-    "PxConvexMeshGeometry": true,
-    "PxHairSystem": false,
-    "PxCollisionMeshMappingData": true,
-    "PxControllerHit": true,
-    "PxMetaDataEntry": true,
-    "PxSolverBody": true,
-    "PxBroadcastingErrorCallback": true,
     "PxContactSet": true,
-    "PxMat33": true,
-    "PxAABBManager": true,
-    "PxBaseMaterial": true,
-    "PxBoxGeometry": true,
-    "PxGeomIndexPair": true,
-    "PxSceneDesc": true,
-    "PxSceneQuerySystemBase": true,
-    "PxShapeExt": true,
-    "PxArticulationReducedCoordinate": true,
-    "PxContactPatch": true,
-    "PxJoint": true,
-    "PxCooking": false,
-    "PxController": true,
-    "XmlWriter": false,
-    "PxContactPairIndex": true,
-    "PxJointLimitCone": true,
-    "PxShape": true,
-    "PxQuat": true,
-    "PxD6JointDrive": true,
+    "PxBVH": true,
     "PxSphereGeometry": true,
-    "PxHeightFieldSample": true,
-    "PxArticulationJointReducedCoordinate": true,
-    "PxTempAllocatorChunk": true,
-    "PxMPMMaterial": false,
-    "PxQueryCache": true,
-    "PxCapsuleObstacle": true,
-    "PxCapsuleController": true,
-    "PxGeometry": true,
-    "PxRepXObject": true,
-    "PxQueryThreadContext": true,
-    "PxGpuParticleBufferIndexPair": true,
-    "PxRaycastBuffer": true,
-    "PxReadWriteLock": true,
-    "PxSceneWriteLock": true,
-    "Px1DConstraint": true,
-    "PxDeserializationContext": true,
-    "PxTriangle": true,
-    "PxJacobianRow": true,
-    "PxErrorCallback": true,
-    "PxExtendedContact": true,
+    "PxBounds3": true,
+    "PxBroadPhase": true,
+    "PxDebugTriangle": true,
+    "PxContactPatch": true,
+    "PxPhysics": true,
+    "PxTime": true,
+    "PxSamplingExt": true,
+    "PxStringTable": true,
+    "PxD6JointDrive": true,
+    "PxBoundedData": true,
+    "PxCustomGeometryCallbacks": true,
+    "PxCustomGeometryType": true,
+    "PxModifiableContact": true,
+    "PxSpatialVelocity": true,
+    "PxCustomSceneQuerySystemAdapter": true,
+    "PxContactPairVelocity": true,
+    "PxBroadPhaseCallback": true,
+    "PxParticleVolume": true,
+    "PxParticleSpring": true,
+    "PxSimpleTriangleMesh": true,
+    "PxHeightField": true,
+    "PxMassModificationProps": true,
+    "PxPvdSceneClient": true,
+    "PxVehicleWheels4SimData": false,
+    "PxDefaultFileInputData": true,
+    "PxBVH34TriangleMesh": true,
+    "PxCounterFrequencyToTensOfNanos": true,
+    "PxVec2": true,
+    "PxRefCounted": true,
+    "PxBoxObstacle": true,
     "PxGpuBodyData": true,
+    "PxRaycastCallback": true,
+    "PxVec3Padded": true,
+    "PxContactModifyPair": true,
+    "PxBitAndByte": true,
     "XmlMemoryAllocator": false,
+    "PxSoftBody": false,
+    "PxProcessPxBaseCallback": true,
+    "PxCapsuleController": true,
+    "Interpolation": true,
+    "PxParticleRigidBuffer": false,
+    "PxContactPairExtraDataItem": true,
+    "PxGeomSweepHit": true,
+    "PxRigidDynamic": true,
+    "PxUnConst": false,
+    "PxTrianglePadded": true,
+    "PxDiffuseParticleParams": true,
+    "PxControllerBehaviorCallback": true,
+    "PxPBDMaterial": false,
+    "PxSolverConstraintPrepDescBase": true,
+    "PxAssertHandler": true,
+    "PxSListImpl": true,
+    "PxPvdTransport": true,
+    "PxDominanceGroupPair": true,
+    "PxParticleSystemGeometry": true,
+    "PxHeightFieldSample": true,
+    "PxProfilerCallback": true,
+    "PxSimulationTetrahedronMeshData": true,
+    "PxCustomSceneQuerySystem": true,
+    "PxHeightFieldGeometry": true,
+    "PxMeshQuery": true,
+    "PxTGSSolverBodyVel": true,
+    "PxTetrahedronMeshDesc": true,
+    "PxGeometryQuery": true,
+    "PxContactBuffer": false,
+    "PxSerialization": true,
+    "PxConvexMeshDesc": true,
+    "PxObstacle": true,
+    "Px1DConstraintMods": true,
+    "PxBroadPhaseResults": true,
+    "PxGeomRaycastHit": true,
+    "PxUserControllerHitReport": true,
+    "PxSweepBuffer": true,
+    "PxMassProperties": true,
+    "PxRenderBuffer": true,
+    "PxPlaneGeometry": true,
+    "PxJointLinearLimitPair": true,
+    "PxDebugText": true,
+    "PxPrismaticJoint": true,
+    "PxControllerShapeHit": true,
+    "PxNodeIndex": true,
+    "PxQueryCache": true,
+    "PxConstraintBatchHeader": true,
+    "PxFEMParameters": true,
+    "PxBaseTask": true,
+    "PxJointLimitParameters": true,
+    "PxFLIPMaterial": false,
+    "PxArticulationRootLinkData": true,
+    "PxConeLimitedConstraint": true,
+    "PxVehicleTireForceCalculator": false,
+    "PxgDynamicsMemoryConfig": true,
+    "PxRackAndPinionJoint": true,
+    "PxHullPolygon": true,
+    "PxSceneDesc": true,
+    "PxSerializationRegistry": true,
+    "PxSimulationFilterCallback": true,
+    "PxOmniPvd": false,
+    "PxContactPoint": true,
+    "PxArticulationSpatialTendon": true,
+    "PxSceneWriteLock": true,
+    "PxBVHTraversalCallback": true,
+    "PxBroadPhaseRegions": true,
+    "PxJointLimitPyramid": true,
+    "PxTransformPadded": true,
+    "PxDim3": true,
+    "PxAllocator": true,
+    "PxLocationHit": true,
+    "PxVehicleDrivableSurfaceToTireFrictionPairs": false,
+    "PxSpringModifiers": true,
     "PxSceneQueryDesc": true,
-    "PxBVH34MidphaseDesc": true,
+    "PxBoxController": true,
+    "PxGeomOverlapHit": true,
+    "PxSceneQuerySystem": true,
+    "PxCpuDispatcher": true,
+    "PxConstraint": true,
+    "PxShapeExt": true,
+    "PxTaskManager": true,
+    "PxFEMCloth": false,
+    "PxSDFDesc": true,
+    "PxArticulationFixedTendon": true,
+    "PxVehicleWheels4DynData": false,
+    "PxGearJoint": true,
     "PxVec4": true,
+    "PxSListEntry": true,
+    "PxBVH33TriangleMesh": false,
+    "PxContactModifyCallback": true,
+    "PxMPMMaterial": false,
+    "PxDeserializationContext": true,
+    "PxContactStreamIterator": true,
+    "PxCustomParticleSystem": false,
+    "PxDefaultFileOutputStream": true,
+    "PxIndexDataPair": true,
+    "PxTetrahedron": true,
+    "PxCookingParams": true,
+    "PxUserAllocated": true,
+    "PxCCDContactModifyCallback": true,
+    "PxSpatialForce": true,
+    "PxArticulationTendonJoint": true,
+    "PxCustomGeometry": true,
+    "PxFEMClothMaterial": false,
+    "PxGeometryHolder": true,
+    "PxDefaultErrorCallback": true,
+    "PxBatchQueryExt": true,
+    "PxSerializationContext": true,
+    "PxSoftBodyAuxData": true,
+    "PxMeshOverlapUtil": true,
+    "PxMetaDataEntry": true,
+    "PxTypeInfo": false,
+    "PxRepXObject": true,
+    "PxGroupsMask": true,
+    "PxArticulationSensor": true,
+    "PxSolverConstraintDesc": true,
+    "PxRenderOutput": false,
+    "PxConstraintConnector": true,
+    "MemoryBuffer": false,
+    "PxParticleAndDiffuseBuffer": false,
+    "PxRigidStatic": true,
+    "PxMPMParticleSystem": false,
+    "PxOverlapCallback": true,
+    "PxErrorCallback": true,
+    "PxMeshScale": true,
+    "PxJointAngularLimitPair": true,
+    "PxSweepHit": true,
+    "PxConstraintVisualizer": true,
+    "PxRigidActor": true,
+    "PxAllocatorCallback": true,
+    "PxSpring": true,
+    "PxContact": true,
+    "PxCooking": false,
+    "PxParticleRigidAttachment": false,
+    "PxSphericalJoint": true,
+    "PxContactPairPoint": true,
+    "PxBroadPhasePair": true,
+    "PxBVH34MidphaseDesc": true,
+    "PxOverlapHit": true,
+    "PxControllerHit": true,
+    "PxTetrahedronMeshGeometry": true,
+    "PxDebugPoint": true,
+    "PxSerializer": true,
+    "PxTriangleMeshGeometry": true,
+    "PxHash": false,
+    "PxCapsuleControllerDesc": true,
+    "PxParticleRigidFilterPair": true,
+    "PxMutexImpl": true,
+    "PxReadWriteLock": true,
+    "PxPlane": true,
+    "PxContactPair": true,
+    "PxTolerancesScale": true,
+    "PxConvexMeshGeometry": true,
+    "PxFEMSoftBodyMaterial": false,
+    "PxTriangleMesh": true,
+    "PxPBDParticleSystem": false,
+    "PxTriangleMeshPoissonSampler": true,
+    "PxDefaultAllocator": true,
+    "PxTGSSolverBodyData": true,
+    "PxControllerDesc": true,
+    "PxSolverContactDesc": true,
+    "PxSoftBodyCollisionData": true,
+    "PxXmlMiscParameter": true,
+    "PxArticulationLink": true,
+    "PxQueryHit": true,
+    "PxVirtualAllocatorCallback": true,
+    "PxPruningStructure": true,
+    "PxArticulationTendonLimit": true,
+    "PxSolverConstraintPrepDesc": true,
+    "PxAllocationListener": true,
+    "PxStridedData": true,
+    "PxGpuParticleBufferIndexPair": true,
+    "PxRaycastHit": true,
+    "PxGeomIndexPair": true,
+    "PxMat44": true,
+    "PxBroadPhaseRegion": true,
+    "PxTGSSolverConstraintPrepDesc": true,
+    "PxBroadPhaseExt": true,
+    "PxRigidBodyExt": true,
+    "PxExtendedContact": true,
+    "PxTransform": true,
+    "PxCustomMaterial": false,
+    "PxParticleMaterial": true,
+    "PxJointLimitCone": true,
+    "PxOverlapBuffer": true,
+    "PxBVHDesc": true,
+    "PxLightCpuTask": true,
+    "PxPoissonSampler": true,
+    "PxDistanceJoint": true,
+    "PxSceneReadLock": true,
+    "PxRaycastBuffer": true,
+    "PxCapsuleGeometry": true,
+    "PxRevoluteJoint": true,
+    "PxAggregate": true,
+    "PxFEMMaterial": true,
+    "PxContactPairHeader": true,
+    "PxRepXSerializer": true,
+    "PxArticulationJointReducedCoordinate": true,
+    "PxFoundation": true,
+    "PxContactPairExtraDataIterator": true,
+    "PxCudaContextManager": false,
+    "PxD6Joint": true,
+    "PxBoxGeometry": true,
+    "PxMat33": true,
+    "PxRawAllocator": true,
+    "PxTGSSolverBodyTxInertia": true,
     "PxBroadPhaseCaps": true,
-    "PxGpuActorPair": true
+    "PxInputData": true,
+    "PxControllersHit": true,
+    "PxSceneQuerySystemBase": true,
+    "PxTask": true,
+    "PxSceneLimits": true,
+    "PxConeLimitParams": true,
+    "PxSoftBodySimulationDataDesc": true,
+    "PxSceneQueryExt": true,
+    "PxShape": true,
+    "PxControllerManager": true,
+    "PxGpuActorPair": true,
+    "PxBaseMaterial": true,
+    "XmlReader": false,
+    "PxDeletionListener": true,
+    "PxBroadPhaseRegionInfo": true,
+    "PxHairSystemGeometry": true,
+    "PxFLIPParticleSystem": false,
+    "PxExtendedVec3": true,
+    "PxHairSystem": false,
+    "PxParticleBuffer": false,
+    "PxRunnable": true,
+    "PxActor": true,
+    "PxInputStream": true,
+    "PxTriggerPair": true,
+    "PxAABBManager": true,
+    "PxArticulationCache": true,
+    "PxGeometry": true,
+    "PxBroadcastingErrorCallback": true,
+    "PxBVHOverlapCallback": true,
+    "PxTetrahedronMeshData": true,
+    "PxTGSSolverConstraintPrepDescBase": true,
+    "PxMat34": false,
+    "PxBroadcastingAllocator": true,
+    "PxBoxControllerDesc": true,
+    "PxTGSSolverContactDesc": true,
+    "PxQueryFilterData": true,
+    "PxController": true,
+    "PxArticulationDrive": true,
+    "PxTriangleMeshDesc": true,
+    "PxOutputStream": true,
+    "PxSoftBodySimulationData": true,
+    "PxCollisionMeshMappingData": true,
+    "PxContactJoint": true,
+    "PxPvd": true,
+    "PxFilterData": true,
+    "PxControllerFilters": true,
+    "PxSweepCallback": true,
+    "PxArticulationReducedCoordinate": true,
+    "PxBinaryConverter": false,
+    "PxQuat": true,
+    "PxConstraintShaderTable": true,
+    "PxBitMap": true,
+    "PxVehicleTelemetryData": false,
+    "PxProfileScoped": true,
+    "PxJacobianRow": true,
+    "PxBase": true,
+    "PxBroadPhaseDesc": true,
+    "PxVec3": true,
+    "PxCapsuleObstacle": true,
+    "PxParticleSystem": false,
+    "PxTempAllocator": true,
+    "PxStringTableExt": true,
+    "PxSolverBodyData": true,
+    "PxCollection": true,
+    "PxRepXInstantiationArgs": true,
+    "PxDebugLine": true,
+    "PxConvexMesh": true,
+    "PxCollisionTetrahedronMeshData": true,
+    "PxArticulationLimit": true,
+    "PxArticulationAttachment": true,
+    "PxConstraintAllocator": true,
+    "PxSyncImpl": true,
+    "PxJointLinearLimit": true,
+    "PxControllerObstacleHit": true,
+    "PxSimulationEventCallback": true,
+    "PxControllerState": true,
+    "PxQueryFilterCallback": true,
+    "PxControllerFilterCallback": true,
+    "PxJoint": true,
+    "PxFixedJoint": true,
+    "PxDefaultMemoryInputData": true,
+    "PxTriangle": true,
+    "PxRestitutionModifiers": true,
+    "PxTetrahedronMeshExt": true,
+    "PxDefaultMemoryOutputStream": true,
+    "PxConstraintInfo": true,
+    "PxRigidActorExt": true,
+    "PxLogTwo": false,
+    "PxScene": true,
+    "Px1DConstraint": true,
+    "PxSolverBody": true,
+    "PxMidphaseDesc": true,
+    "PxSoftBodyMesh": true,
+    "PxContactPairIndex": true,
+    "PxLockedData": true,
+    "PxBVHRaycastCallback": true,
+    "PxDefaultCpuDispatcher": true,
+    "PxTempAllocatorChunk": true,
+    "PxQueryThreadContext": true,
+    "PxActorShape": true,
+    "PxObstacleContext": true,
+    "PxVirtualAllocator": true,
+    "PxConstraintInvMassScale": true,
+    "PxMaterial": true,
+    "PxTetrahedronMesh": true,
+    "PxRigidBody": true,
+    "PxParticleClothBuffer": false,
+    "PxSimulationStatistics": true,
+    "PxInsertionCallback": true,
+    "XmlWriter": false,
+    "PxContactPairPose": true,
+    "PxGpuContactPair": true,
+    "PxArticulationTendon": true,
+    "PxControllerStats": true,
+    "PxSceneSQSystem": true,
+    "PxBroadPhaseUpdateData": true
   },
   "derived": {
-    "PxQueryHit": [
-      "PxLocationHit",
-      "PxGeomOverlapHit"
+    "PxUserAllocated": [
+      "PxCollisionMeshMappingData",
+      "PxSoftBodyCollisionData",
+      "PxTetrahedronMeshData",
+      "PxSoftBodySimulationData",
+      "PxCollisionTetrahedronMeshData",
+      "PxSimulationTetrahedronMeshData",
+      "PxPoissonSampler"
+    ],
+    "PxSpring": [
+      "PxD6JointDrive"
     ],
     "PxPoissonSampler": [
       "PxTriangleMeshPoissonSampler"
+    ],
+    "PxLocationHit": [
+      "PxGeomRaycastHit",
+      "PxGeomSweepHit"
+    ],
+    "PxSolverConstraintPrepDescBase": [
+      "PxSolverConstraintPrepDesc"
+    ],
+    "PxSceneQuerySystem": [
+      "PxCustomSceneQuerySystem"
+    ],
+    "PxInputData": [
+      "PxDefaultMemoryInputData",
+      "PxDefaultFileInputData"
+    ],
+    "PxSceneQuerySystemBase": [
+      "PxSceneSQSystem",
+      "PxSceneQuerySystem"
+    ],
+    "PxControllerDesc": [
+      "PxBoxControllerDesc",
+      "PxCapsuleControllerDesc"
     ],
     "PxRefCounted": [
       "PxConvexMesh",
@@ -137276,8 +137306,117 @@
       "PxShape",
       "PxBaseMaterial"
     ],
+    "PxSceneSQSystem": [
+      "PxScene"
+    ],
+    "PxActorShape": [
+      "PxRaycastHit",
+      "PxOverlapHit",
+      "PxSweepHit"
+    ],
+    "PxStridedData": [
+      "PxBoundedData"
+    ],
+    "PxController": [
+      "PxBoxController",
+      "PxCapsuleController"
+    ],
+    "PxOutputStream": [
+      "PxDefaultMemoryOutputStream",
+      "PxDefaultFileOutputStream"
+    ],
+    "PxArticulationTendon": [
+      "PxArticulationSpatialTendon",
+      "PxArticulationFixedTendon"
+    ],
+    "PxContact": [
+      "PxExtendedContact"
+    ],
+    "PxInputStream": [
+      "PxInputData"
+    ],
+    "PxGeomOverlapHit": [
+      "PxOverlapHit"
+    ],
+    "PxErrorCallback": [
+      "PxBroadcastingErrorCallback",
+      "PxDefaultErrorCallback"
+    ],
     "PxCpuDispatcher": [
       "PxDefaultCpuDispatcher"
+    ],
+    "PxJointLimitParameters": [
+      "PxJointLinearLimit",
+      "PxJointLinearLimitPair",
+      "PxJointAngularLimitPair",
+      "PxJointLimitCone",
+      "PxJointLimitPyramid"
+    ],
+    "PxBaseMaterial": [
+      "PxFEMMaterial",
+      "PxMaterial",
+      "PxParticleMaterial"
+    ],
+    "PxGeomSweepHit": [
+      "PxSweepHit"
+    ],
+    "PxGeomRaycastHit": [
+      "PxRaycastHit"
+    ],
+    "PxExtendedContact": [
+      "PxModifiableContact"
+    ],
+    "PxQueryHit": [
+      "PxLocationHit",
+      "PxGeomOverlapHit"
+    ],
+    "PxBaseTask": [
+      "PxTask",
+      "PxLightCpuTask"
+    ],
+    "PxSimpleTriangleMesh": [
+      "PxTriangleMeshDesc"
+    ],
+    "PxAllocatorCallback": [
+      "PxBroadcastingAllocator",
+      "PxDefaultAllocator"
+    ],
+    "PxContactPairExtraDataItem": [
+      "PxContactPairVelocity",
+      "PxContactPairPose",
+      "PxContactPairIndex"
+    ],
+    "PxTriangle": [
+      "PxTrianglePadded"
+    ],
+    "PxRigidBody": [
+      "PxArticulationLink",
+      "PxRigidDynamic"
+    ],
+    "PxObstacle": [
+      "PxBoxObstacle",
+      "PxCapsuleObstacle"
+    ],
+    "PxActor": [
+      "PxRigidActor"
+    ],
+    "PxSceneQueryDesc": [
+      "PxSceneDesc"
+    ],
+    "PxControllerHit": [
+      "PxControllerShapeHit",
+      "PxControllersHit",
+      "PxControllerObstacleHit"
+    ],
+    "PxProfilerCallback": [
+      "PxPvd"
+    ],
+    "PxTriangleMesh": [
+      "PxBVH34TriangleMesh"
+    ],
+    "PxRigidActor": [
+      "PxRigidBody",
+      "PxRigidStatic"
     ],
     "PxBase": [
       "PxRefCounted",
@@ -137294,105 +137433,6 @@
       "PxPruningStructure",
       "PxJoint"
     ],
-    "PxSimpleTriangleMesh": [
-      "PxTriangleMeshDesc"
-    ],
-    "PxProfilerCallback": [
-      "PxPvd"
-    ],
-    "PxBaseTask": [
-      "PxTask",
-      "PxLightCpuTask"
-    ],
-    "PxSolverConstraintPrepDescBase": [
-      "PxSolverConstraintPrepDesc"
-    ],
-    "PxGeomOverlapHit": [
-      "PxOverlapHit"
-    ],
-    "PxUserAllocated": [
-      "PxCollisionMeshMappingData",
-      "PxSoftBodyCollisionData",
-      "PxTetrahedronMeshData",
-      "PxSoftBodySimulationData",
-      "PxCollisionTetrahedronMeshData",
-      "PxSimulationTetrahedronMeshData",
-      "PxPoissonSampler"
-    ],
-    "PxContact": [
-      "PxExtendedContact"
-    ],
-    "PxTriangle": [
-      "PxTrianglePadded"
-    ],
-    "PxActor": [
-      "PxRigidActor"
-    ],
-    "PxOutputStream": [
-      "PxDefaultMemoryOutputStream",
-      "PxDefaultFileOutputStream"
-    ],
-    "PxAllocatorCallback": [
-      "PxBroadcastingAllocator",
-      "PxDefaultAllocator"
-    ],
-    "PxBaseMaterial": [
-      "PxFEMMaterial",
-      "PxMaterial",
-      "PxParticleMaterial"
-    ],
-    "PxSceneQueryDesc": [
-      "PxSceneDesc"
-    ],
-    "PxControllerDesc": [
-      "PxBoxControllerDesc",
-      "PxCapsuleControllerDesc"
-    ],
-    "PxObstacle": [
-      "PxBoxObstacle",
-      "PxCapsuleObstacle"
-    ],
-    "PxInputStream": [
-      "PxInputData"
-    ],
-    "PxTriangleMesh": [
-      "PxBVH34TriangleMesh"
-    ],
-    "PxActorShape": [
-      "PxRaycastHit",
-      "PxOverlapHit",
-      "PxSweepHit"
-    ],
-    "PxSceneQuerySystemBase": [
-      "PxSceneSQSystem",
-      "PxSceneQuerySystem"
-    ],
-    "PxContactPairExtraDataItem": [
-      "PxContactPairVelocity",
-      "PxContactPairPose",
-      "PxContactPairIndex"
-    ],
-    "PxInputData": [
-      "PxDefaultMemoryInputData",
-      "PxDefaultFileInputData"
-    ],
-    "PxSceneQuerySystem": [
-      "PxCustomSceneQuerySystem"
-    ],
-    "PxStridedData": [
-      "PxBoundedData"
-    ],
-    "PxArticulationTendon": [
-      "PxArticulationSpatialTendon",
-      "PxArticulationFixedTendon"
-    ],
-    "PxGeomRaycastHit": [
-      "PxRaycastHit"
-    ],
-    "PxRigidActor": [
-      "PxRigidBody",
-      "PxRigidStatic"
-    ],
     "PxGeometry": [
       "PxBoxGeometry",
       "PxCapsuleGeometry",
@@ -137406,41 +137446,8 @@
       "PxTetrahedronMeshGeometry",
       "PxCustomGeometry"
     ],
-    "PxLocationHit": [
-      "PxGeomRaycastHit",
-      "PxGeomSweepHit"
-    ],
-    "PxJointLimitParameters": [
-      "PxJointLinearLimit",
-      "PxJointLinearLimitPair",
-      "PxJointAngularLimitPair",
-      "PxJointLimitCone",
-      "PxJointLimitPyramid"
-    ],
-    "PxExtendedContact": [
-      "PxModifiableContact"
-    ],
-    "PxSceneSQSystem": [
-      "PxScene"
-    ],
-    "PxRigidBody": [
-      "PxArticulationLink",
-      "PxRigidDynamic"
-    ],
-    "PxControllerHit": [
-      "PxControllerShapeHit",
-      "PxControllersHit",
-      "PxControllerObstacleHit"
-    ],
-    "PxSpring": [
-      "PxD6JointDrive"
-    ],
     "PxVec3": [
       "PxVec3Padded"
-    ],
-    "PxErrorCallback": [
-      "PxBroadcastingErrorCallback",
-      "PxDefaultErrorCallback"
     ],
     "PxJoint": [
       "PxDistanceJoint",
@@ -137452,13 +137459,6 @@
       "PxD6Joint",
       "PxGearJoint",
       "PxRackAndPinionJoint"
-    ],
-    "PxGeomSweepHit": [
-      "PxSweepHit"
-    ],
-    "PxController": [
-      "PxBoxController",
-      "PxCapsuleController"
     ]
   }
 }

--- a/codegen/pxbind/type-db.json
+++ b/codegen/pxbind/type-db.json
@@ -10719,6 +10719,7 @@
       "Pointer": {
         "is_const": false,
         "is_pointee_const": false,
+        "is_array_like": false,
         "pointee": {
           "Builtin": "Void"
         }
@@ -10790,6 +10791,7 @@
       "Pointer": {
         "is_const": false,
         "is_pointee_const": false,
+        "is_array_like": false,
         "pointee": {
           "Builtin": "Void"
         }
@@ -11073,6 +11075,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxVirtualAllocatorCallback"
@@ -11136,6 +11139,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxTempAllocatorChunk"
@@ -11250,6 +11254,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "UInt"
                 }
@@ -11710,6 +11715,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": false,
+                    "is_array_like": false,
                     "pointee": {
                       "Record": {
                         "name": "PxAllocationListener"
@@ -11737,6 +11743,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxAllocationListener"
@@ -11809,6 +11816,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": false,
+                    "is_array_like": false,
                     "pointee": {
                       "Record": {
                         "name": "PxErrorCallback"
@@ -11836,6 +11844,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxErrorCallback"
@@ -12164,6 +12173,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -12217,6 +12227,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxProfilerCallback"
@@ -12233,6 +12244,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Char"
                 }
@@ -12247,6 +12259,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -12297,6 +12310,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxSListEntry"
@@ -12498,6 +12512,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -12554,6 +12569,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": true,
+                    "is_array_like": false,
                     "pointee": {
                       "Builtin": "Void"
                     }
@@ -12592,6 +12608,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -12804,6 +12821,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Char"
                 }
@@ -12925,6 +12943,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "UChar"
                 }
@@ -13401,6 +13420,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Char"
                 }
@@ -13415,6 +13435,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Char"
                 }
@@ -13582,6 +13603,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxTaskManager"
@@ -13640,6 +13662,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": false,
+                    "is_array_like": false,
                     "pointee": {
                       "Record": {
                         "name": "PxTaskManager"
@@ -13680,6 +13703,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxTaskManager"
@@ -13714,6 +13738,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxBaseTask"
@@ -13752,6 +13777,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": false,
+                    "is_array_like": false,
                     "pointee": {
                       "Record": {
                         "name": "PxTaskManager"
@@ -13792,6 +13818,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxTaskManager"
@@ -14441,6 +14468,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxConvexMesh"
@@ -14736,6 +14764,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxTriangleMesh"
@@ -14832,6 +14861,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxHeightField"
@@ -15134,6 +15164,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxTetrahedronMesh"
@@ -15844,6 +15875,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxCustomGeometryCallbacks"
@@ -17444,6 +17476,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -17552,6 +17585,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -18299,6 +18333,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxSolverBody"
@@ -18315,6 +18350,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxSolverBody"
@@ -18363,6 +18399,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "UChar"
                 }
@@ -18377,6 +18414,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -18458,6 +18496,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxSolverConstraintDesc"
@@ -18474,6 +18513,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxSolverBody"
@@ -18490,6 +18530,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxSolverBody"
@@ -18506,6 +18547,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxSolverBodyData"
@@ -18522,6 +18564,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxSolverBodyData"
@@ -18602,6 +18645,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "Px1DConstraint"
@@ -18650,6 +18694,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -18730,6 +18775,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": false,
+                    "is_array_like": false,
                     "pointee": {
                       "Record": {
                         "name": "PxSolverConstraintDesc"
@@ -18746,6 +18792,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": true,
+                    "is_array_like": false,
                     "pointee": {
                       "Record": {
                         "name": "PxSolverBody"
@@ -18762,6 +18809,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": true,
+                    "is_array_like": false,
                     "pointee": {
                       "Record": {
                         "name": "PxSolverBody"
@@ -18778,6 +18826,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": true,
+                    "is_array_like": false,
                     "pointee": {
                       "Record": {
                         "name": "PxSolverBodyData"
@@ -18794,6 +18843,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": true,
+                    "is_array_like": false,
                     "pointee": {
                       "Record": {
                         "name": "PxSolverBodyData"
@@ -18880,6 +18930,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxSolverConstraintDesc"
@@ -18896,6 +18947,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxSolverBody"
@@ -18912,6 +18964,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxSolverBody"
@@ -18928,6 +18981,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxSolverBodyData"
@@ -18944,6 +18998,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxSolverBodyData"
@@ -19032,6 +19087,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxSolverConstraintDesc"
@@ -19048,6 +19104,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxSolverBody"
@@ -19064,6 +19121,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxSolverBody"
@@ -19080,6 +19138,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxSolverBodyData"
@@ -19096,6 +19155,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxSolverBodyData"
@@ -19156,6 +19216,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -19170,6 +19231,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxContactPoint"
@@ -19234,6 +19296,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "UChar"
                 }
@@ -19256,6 +19319,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Float"
                 }
@@ -19689,6 +19753,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxSolverConstraintDesc"
@@ -19705,6 +19770,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxTGSSolverBodyVel"
@@ -19721,6 +19787,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxTGSSolverBodyVel"
@@ -19737,6 +19804,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxTGSSolverBodyTxInertia"
@@ -19753,6 +19821,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxTGSSolverBodyTxInertia"
@@ -19769,6 +19838,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxTGSSolverBodyData"
@@ -19785,6 +19855,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxTGSSolverBodyData"
@@ -19875,6 +19946,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxSolverConstraintDesc"
@@ -19891,6 +19963,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxTGSSolverBodyVel"
@@ -19907,6 +19980,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxTGSSolverBodyVel"
@@ -19923,6 +19997,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxTGSSolverBodyTxInertia"
@@ -19939,6 +20014,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxTGSSolverBodyTxInertia"
@@ -19955,6 +20031,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxTGSSolverBodyData"
@@ -19971,6 +20048,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxTGSSolverBodyData"
@@ -20031,6 +20109,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "Px1DConstraint"
@@ -20079,6 +20158,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -20193,6 +20273,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxSolverConstraintDesc"
@@ -20209,6 +20290,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxTGSSolverBodyVel"
@@ -20225,6 +20307,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxTGSSolverBodyVel"
@@ -20241,6 +20324,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxTGSSolverBodyTxInertia"
@@ -20257,6 +20341,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxTGSSolverBodyTxInertia"
@@ -20273,6 +20358,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxTGSSolverBodyData"
@@ -20289,6 +20375,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxTGSSolverBodyData"
@@ -20349,6 +20436,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -20363,6 +20451,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxContactPoint"
@@ -20427,6 +20516,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "UChar"
                 }
@@ -20449,6 +20539,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Float"
                 }
@@ -20601,6 +20692,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -20709,6 +20801,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -20817,6 +20910,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -20930,6 +21024,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": false,
+                    "is_array_like": false,
                     "pointee": {
                       "Builtin": "Void"
                     }
@@ -21061,6 +21156,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -21098,6 +21194,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": false,
+                    "is_array_like": false,
                     "pointee": {
                       "Builtin": "Void"
                     }
@@ -21229,6 +21326,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -21427,6 +21525,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxSpatialForce"
@@ -21443,6 +21542,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Float"
                 }
@@ -21457,6 +21557,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Float"
                 }
@@ -21471,6 +21572,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Float"
                 }
@@ -21485,6 +21587,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Float"
                 }
@@ -21499,6 +21602,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Float"
                 }
@@ -21513,6 +21617,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Float"
                 }
@@ -21527,6 +21632,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Float"
                 }
@@ -21541,6 +21647,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxSpatialVelocity"
@@ -21557,6 +21664,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxSpatialVelocity"
@@ -21573,6 +21681,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxArticulationRootLinkData"
@@ -21589,6 +21698,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxSpatialForce"
@@ -21605,6 +21715,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Float"
                 }
@@ -21619,6 +21730,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Float"
                 }
@@ -21633,6 +21745,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -21647,6 +21760,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -21689,6 +21803,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -21797,6 +21912,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -21905,6 +22021,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -22023,6 +22140,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -22182,6 +22300,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": false,
+                    "is_array_like": false,
                     "pointee": {
                       "Builtin": "Void"
                     }
@@ -22313,6 +22432,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -22383,6 +22503,7 @@
                       "Pointer": {
                         "is_const": false,
                         "is_pointee_const": false,
+                        "is_array_like": false,
                         "pointee": {
                           "Builtin": "Void"
                         }
@@ -22514,6 +22635,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": false,
+                    "is_array_like": false,
                     "pointee": {
                       "Builtin": "Void"
                     }
@@ -22569,6 +22691,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -22616,6 +22739,7 @@
                           "Pointer": {
                             "is_const": false,
                             "is_pointee_const": false,
+                            "is_array_like": false,
                             "pointee": {
                               "Builtin": "Void"
                             }
@@ -22747,6 +22871,7 @@
                       "Pointer": {
                         "is_const": false,
                         "is_pointee_const": false,
+                        "is_array_like": false,
                         "pointee": {
                           "Builtin": "Void"
                         }
@@ -22802,6 +22927,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": false,
+                    "is_array_like": false,
                     "pointee": {
                       "Builtin": "Void"
                     }
@@ -22857,6 +22983,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -23021,6 +23148,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -23640,6 +23768,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxContactPatch"
@@ -23656,6 +23785,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxContact"
@@ -23672,6 +23802,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "UInt"
                 }
@@ -23790,6 +23921,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "UChar"
                 }
@@ -23804,6 +23936,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "UChar"
                 }
@@ -23818,6 +23951,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Float"
                 }
@@ -23868,6 +24002,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxActor"
@@ -23884,6 +24019,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxActor"
@@ -23944,6 +24080,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxModifiableContact"
@@ -23982,6 +24119,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": true,
+                    "is_array_like": false,
                     "pointee": {
                       "Record": {
                         "name": "PxRigidActor"
@@ -24003,6 +24141,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": true,
+                    "is_array_like": false,
                     "pointee": {
                       "Record": {
                         "name": "PxShape"
@@ -24124,6 +24263,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -24283,6 +24423,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": false,
+                    "is_array_like": false,
                     "pointee": {
                       "Builtin": "Void"
                     }
@@ -24460,6 +24601,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -24623,6 +24765,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": false,
+                    "is_array_like": false,
                     "pointee": {
                       "Builtin": "Void"
                     }
@@ -24800,6 +24943,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -25097,6 +25241,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": false,
+                    "is_array_like": false,
                     "pointee": {
                       "Builtin": "Void"
                     }
@@ -25274,6 +25419,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -25340,6 +25486,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxRigidActor"
@@ -25356,6 +25503,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxShape"
@@ -25565,6 +25713,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": false,
+                    "is_array_like": false,
                     "pointee": {
                       "Record": {
                         "name": "PxRigidActor"
@@ -25581,6 +25730,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": false,
+                    "is_array_like": false,
                     "pointee": {
                       "Record": {
                         "name": "PxShape"
@@ -25672,6 +25822,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxRigidActor"
@@ -25688,6 +25839,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxShape"
@@ -25780,6 +25932,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": false,
+                    "is_array_like": false,
                     "pointee": {
                       "Record": {
                         "name": "PxRigidActor"
@@ -25796,6 +25949,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": false,
+                    "is_array_like": false,
                     "pointee": {
                       "Record": {
                         "name": "PxShape"
@@ -25836,6 +25990,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxRigidActor"
@@ -25852,6 +26007,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxShape"
@@ -26042,6 +26198,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": false,
+                    "is_array_like": false,
                     "pointee": {
                       "Record": {
                         "name": "PxRigidActor"
@@ -26058,6 +26215,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": false,
+                    "is_array_like": false,
                     "pointee": {
                       "Record": {
                         "name": "PxShape"
@@ -26133,6 +26291,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxRigidActor"
@@ -26149,6 +26308,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxShape"
@@ -26201,6 +26361,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxRaycastHit"
@@ -26271,6 +26432,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxOverlapHit"
@@ -26341,6 +26503,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxSweepHit"
@@ -26411,6 +26574,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxRaycastHit"
@@ -26481,6 +26645,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxOverlapHit"
@@ -26551,6 +26716,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxSweepHit"
@@ -26603,6 +26769,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxShape"
@@ -26619,6 +26786,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxRigidActor"
@@ -26738,6 +26906,7 @@
                           "Pointer": {
                             "is_const": false,
                             "is_pointee_const": false,
+                            "is_array_like": false,
                             "pointee": {
                               "Builtin": "Void"
                             }
@@ -26869,6 +27038,7 @@
                       "Pointer": {
                         "is_const": false,
                         "is_pointee_const": false,
+                        "is_array_like": false,
                         "pointee": {
                           "Builtin": "Void"
                         }
@@ -26924,6 +27094,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": false,
+                    "is_array_like": false,
                     "pointee": {
                       "Builtin": "Void"
                     }
@@ -26979,6 +27150,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -27021,6 +27193,7 @@
                       "Pointer": {
                         "is_const": false,
                         "is_pointee_const": false,
+                        "is_array_like": false,
                         "pointee": {
                           "Builtin": "Void"
                         }
@@ -27152,6 +27325,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": false,
+                    "is_array_like": false,
                     "pointee": {
                       "Builtin": "Void"
                     }
@@ -27207,6 +27381,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -27463,6 +27638,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -27651,6 +27827,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "UInt"
                 }
@@ -27673,6 +27850,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "UInt"
                 }
@@ -27695,6 +27873,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "UInt"
                 }
@@ -27717,6 +27896,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxBounds3"
@@ -27733,6 +27913,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "UInt"
                 }
@@ -27747,6 +27928,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Float"
                 }
@@ -27833,6 +28015,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxBroadPhasePair"
@@ -27857,6 +28040,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxBroadPhasePair"
@@ -28168,6 +28352,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxSimulationEventCallback"
@@ -28184,6 +28369,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxContactModifyCallback"
@@ -28200,6 +28386,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxCCDContactModifyCallback"
@@ -28216,6 +28403,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -28244,6 +28432,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxSimulationFilterCallback"
@@ -28296,6 +28485,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxBroadPhaseCallback"
@@ -28381,6 +28571,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxCpuDispatcher"
@@ -28397,6 +28588,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -28543,6 +28735,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxSceneQuerySystem"
@@ -29342,6 +29535,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -29455,6 +29649,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -29840,6 +30035,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "UChar"
                 }
@@ -29854,6 +30050,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "UChar"
                 }
@@ -29868,6 +30065,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxContactPairVelocity"
@@ -29884,6 +30082,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxContactPairVelocity"
@@ -29900,6 +30099,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxContactPairPose"
@@ -29951,6 +30151,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": false,
+                    "is_array_like": false,
                     "pointee": {
                       "Record": {
                         "name": "PxActor"
@@ -29970,6 +30171,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "UChar"
                 }
@@ -30003,6 +30205,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxContactPair"
@@ -30117,6 +30320,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": false,
+                    "is_array_like": false,
                     "pointee": {
                       "Record": {
                         "name": "PxShape"
@@ -30136,6 +30340,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "UChar"
                 }
@@ -30150,6 +30355,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "UChar"
                 }
@@ -30164,6 +30370,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Float"
                 }
@@ -30265,6 +30472,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxShape"
@@ -30281,6 +30489,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxActor"
@@ -30297,6 +30506,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxShape"
@@ -30313,6 +30523,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxActor"
@@ -30372,6 +30583,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxConstraint"
@@ -30388,6 +30600,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -30671,6 +30884,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -30751,6 +30965,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": false,
+                    "is_array_like": false,
                     "pointee": {
                       "Builtin": "Void"
                     }
@@ -30813,6 +31028,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -30899,6 +31115,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": false,
+                    "is_array_like": false,
                     "pointee": {
                       "Builtin": "Void"
                     }
@@ -30961,6 +31178,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -31050,6 +31268,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxShape"
@@ -31066,6 +31285,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxRigidActor"
@@ -31194,6 +31414,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxController"
@@ -31264,6 +31485,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxShape"
@@ -31280,6 +31502,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxRigidActor"
@@ -31310,6 +31533,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": false,
+                    "is_array_like": false,
                     "pointee": {
                       "Record": {
                         "name": "PxController"
@@ -31376,6 +31600,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxController"
@@ -31444,6 +31669,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxController"
@@ -31466,6 +31692,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": false,
+                    "is_array_like": false,
                     "pointee": {
                       "Record": {
                         "name": "PxController"
@@ -31532,6 +31759,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxController"
@@ -31600,6 +31828,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -31620,6 +31849,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": false,
+                    "is_array_like": false,
                     "pointee": {
                       "Record": {
                         "name": "PxController"
@@ -31686,6 +31916,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxController"
@@ -31792,6 +32023,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxFilterData"
@@ -31808,6 +32040,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxQueryFilterCallback"
@@ -31835,6 +32068,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxControllerFilterCallback"
@@ -31953,6 +32187,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxUserControllerHitReport"
@@ -31969,6 +32204,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxControllerBehaviorCallback"
@@ -31997,6 +32233,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxMaterial"
@@ -32029,6 +32266,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -32206,6 +32444,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": false,
+                    "is_array_like": false,
                     "pointee": {
                       "Record": {
                         "name": "PxUserControllerHitReport"
@@ -32222,6 +32461,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": false,
+                    "is_array_like": false,
                     "pointee": {
                       "Record": {
                         "name": "PxControllerBehaviorCallback"
@@ -32250,6 +32490,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": false,
+                    "is_array_like": false,
                     "pointee": {
                       "Record": {
                         "name": "PxMaterial"
@@ -32282,6 +32523,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": false,
+                    "is_array_like": false,
                     "pointee": {
                       "Builtin": "Void"
                     }
@@ -32406,6 +32648,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxUserControllerHitReport"
@@ -32422,6 +32665,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxControllerBehaviorCallback"
@@ -32450,6 +32694,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxMaterial"
@@ -32482,6 +32727,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -32679,6 +32925,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": false,
+                    "is_array_like": false,
                     "pointee": {
                       "Record": {
                         "name": "PxUserControllerHitReport"
@@ -32695,6 +32942,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": false,
+                    "is_array_like": false,
                     "pointee": {
                       "Record": {
                         "name": "PxControllerBehaviorCallback"
@@ -32723,6 +32971,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": false,
+                    "is_array_like": false,
                     "pointee": {
                       "Record": {
                         "name": "PxMaterial"
@@ -32755,6 +33004,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": false,
+                    "is_array_like": false,
                     "pointee": {
                       "Builtin": "Void"
                     }
@@ -32879,6 +33129,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxUserControllerHitReport"
@@ -32895,6 +33146,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxControllerBehaviorCallback"
@@ -32923,6 +33175,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxMaterial"
@@ -32955,6 +33208,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -33331,6 +33585,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxSDFDesc"
@@ -33380,6 +33635,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxSDFDesc"
@@ -33893,6 +34149,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "UChar"
                 }
@@ -33969,6 +34226,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "UChar"
                 }
@@ -34047,6 +34305,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -34099,6 +34358,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -34264,6 +34524,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -34413,6 +34674,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": false,
+                    "is_array_like": false,
                     "pointee": {
                       "Builtin": "Void"
                     }
@@ -34544,6 +34806,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -34633,6 +34896,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": false,
+                    "is_array_like": false,
                     "pointee": {
                       "Builtin": "Void"
                     }
@@ -34764,6 +35028,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -34801,6 +35066,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": false,
+                    "is_array_like": false,
                     "pointee": {
                       "Builtin": "Void"
                     }
@@ -34932,6 +35198,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -35717,6 +35984,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": false,
+                    "is_array_like": false,
                     "pointee": {
                       "Builtin": "Void"
                     }
@@ -35848,6 +36116,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -35885,6 +36154,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": false,
+                    "is_array_like": false,
                     "pointee": {
                       "Builtin": "Void"
                     }
@@ -36016,6 +36286,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -36053,6 +36324,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": false,
+                    "is_array_like": false,
                     "pointee": {
                       "Builtin": "Void"
                     }
@@ -36184,6 +36456,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -36312,6 +36585,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": false,
+                    "is_array_like": false,
                     "pointee": {
                       "Builtin": "Void"
                     }
@@ -36443,6 +36717,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -36480,6 +36755,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": false,
+                    "is_array_like": false,
                     "pointee": {
                       "Builtin": "Void"
                     }
@@ -36611,6 +36887,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -36648,6 +36925,7 @@
                   "Pointer": {
                     "is_const": false,
                     "is_pointee_const": false,
+                    "is_array_like": false,
                     "pointee": {
                       "Builtin": "Void"
                     }
@@ -36779,6 +37057,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -37001,6 +37280,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "UInt"
                 }
@@ -37443,6 +37723,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Char"
                 }
@@ -37457,6 +37738,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": true,
+                "is_array_like": false,
                 "pointee": {
                   "Builtin": "Void"
                 }
@@ -37519,6 +37801,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxCooking"
@@ -37535,6 +37818,7 @@
               "Pointer": {
                 "is_const": false,
                 "is_pointee_const": false,
+                "is_array_like": false,
                 "pointee": {
                   "Record": {
                     "name": "PxStringTable"
@@ -37700,6 +37984,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxAllocatorCallback"
@@ -37748,6 +38033,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxAllocatorCallback"
@@ -37768,6 +38054,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -37780,6 +38067,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -37797,6 +38085,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Void"
           }
@@ -37835,6 +38124,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxAllocatorCallback"
@@ -37849,6 +38139,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -37871,6 +38162,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxAssertHandler"
@@ -37964,6 +38256,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxFoundation"
@@ -38003,6 +38296,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxFoundation"
@@ -38051,6 +38345,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxFoundation"
@@ -38096,6 +38391,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxFoundation"
@@ -38137,6 +38433,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxFoundation"
@@ -38185,6 +38482,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxFoundation"
@@ -38228,6 +38526,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxFoundation"
@@ -38264,6 +38563,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxFoundation"
@@ -38307,6 +38607,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxFoundation"
@@ -38350,6 +38651,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxFoundation"
@@ -38393,6 +38695,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxFoundation"
@@ -38481,6 +38784,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxFoundation"
@@ -38565,6 +38869,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxProfilerCallback"
@@ -38600,6 +38905,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxProfilerCallback"
@@ -38636,6 +38942,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxAllocatorCallback"
@@ -38669,6 +38976,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxAllocatorCallback"
@@ -38702,6 +39010,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxErrorCallback"
@@ -38735,6 +39044,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxErrorCallback"
@@ -38829,6 +39139,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -38861,6 +39172,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxAllocator"
@@ -38881,6 +39193,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -38898,6 +39211,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Void"
           }
@@ -38923,6 +39237,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxAllocator"
@@ -38937,6 +39252,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -38961,6 +39277,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -38993,6 +39310,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRawAllocator"
@@ -39013,6 +39331,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -39030,6 +39349,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Void"
           }
@@ -39055,6 +39375,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRawAllocator"
@@ -39069,6 +39390,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -39091,6 +39413,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVirtualAllocatorCallback"
@@ -39121,6 +39444,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVirtualAllocatorCallback"
@@ -39147,6 +39471,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -39164,6 +39489,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Void"
           }
@@ -39189,6 +39515,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVirtualAllocatorCallback"
@@ -39203,6 +39530,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -39227,6 +39555,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVirtualAllocatorCallback"
@@ -39267,6 +39596,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVirtualAllocator"
@@ -39287,6 +39617,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -39304,6 +39635,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Void"
           }
@@ -39329,6 +39661,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVirtualAllocator"
@@ -39343,6 +39676,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -39382,6 +39716,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -39414,6 +39749,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTempAllocator"
@@ -39434,6 +39770,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -39451,6 +39788,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Void"
           }
@@ -39476,6 +39814,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTempAllocator"
@@ -39490,6 +39829,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -39528,6 +39868,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -39545,6 +39886,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Void"
           }
@@ -39580,6 +39922,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -39603,6 +39946,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Void"
           }
@@ -39640,6 +39984,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -39652,6 +39997,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -39669,6 +40015,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Void"
           }
@@ -39706,6 +40053,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -39718,6 +40066,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -39735,6 +40084,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Void"
           }
@@ -39769,6 +40119,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -39921,6 +40272,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -39964,6 +40316,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -40298,6 +40651,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVec3"
@@ -40339,6 +40693,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVec3"
@@ -40380,6 +40735,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVec3"
@@ -40423,6 +40779,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVec3"
@@ -40464,6 +40821,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVec3"
@@ -40505,6 +40863,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVec3"
@@ -40557,6 +40916,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVec3"
@@ -40609,6 +40969,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVec3"
@@ -40650,6 +41011,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVec3"
@@ -40692,6 +41054,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVec3"
@@ -40734,6 +41097,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVec3"
@@ -40775,6 +41139,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVec3"
@@ -40827,6 +41192,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVec3"
@@ -40879,6 +41245,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVec3"
@@ -40920,6 +41287,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVec3"
@@ -40972,6 +41340,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVec3"
@@ -41013,6 +41382,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVec3"
@@ -41039,6 +41409,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxVec3Padded"
@@ -41060,6 +41431,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVec3Padded"
@@ -41096,6 +41468,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxVec3Padded"
@@ -41124,6 +41497,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxVec3Padded"
@@ -41384,6 +41758,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQuat"
@@ -41425,6 +41800,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQuat"
@@ -41466,6 +41842,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQuat"
@@ -41508,6 +41885,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQuat"
@@ -41549,6 +41927,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQuat"
@@ -41613,6 +41992,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQuat"
@@ -41657,6 +42037,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQuat"
@@ -41711,6 +42092,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQuat"
@@ -41752,6 +42134,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQuat"
@@ -41797,6 +42180,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQuat"
@@ -41831,6 +42215,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQuat"
@@ -41872,6 +42257,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQuat"
@@ -41904,6 +42290,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQuat"
@@ -41938,6 +42325,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQuat"
@@ -41979,6 +42367,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQuat"
@@ -42020,6 +42409,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQuat"
@@ -42061,6 +42451,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQuat"
@@ -42102,6 +42493,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQuat"
@@ -42154,6 +42546,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQuat"
@@ -42403,6 +42796,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTransform"
@@ -42437,6 +42831,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTransform"
@@ -42480,6 +42875,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTransform"
@@ -42523,6 +42919,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTransform"
@@ -42566,6 +42963,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTransform"
@@ -42618,6 +43016,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTransform"
@@ -42674,6 +43073,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTransform"
@@ -42716,6 +43116,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTransform"
@@ -42757,6 +43158,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTransform"
@@ -42798,6 +43200,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTransform"
@@ -42854,6 +43257,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTransform"
@@ -43076,6 +43480,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Float"
               }
@@ -43242,6 +43647,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMat33"
@@ -43283,6 +43689,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMat33"
@@ -43324,6 +43731,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMat33"
@@ -43365,6 +43773,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMat33"
@@ -43417,6 +43826,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMat33"
@@ -43460,6 +43870,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMat33"
@@ -43473,6 +43884,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Float"
           }
@@ -44049,6 +44461,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBounds3"
@@ -44088,6 +44501,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBounds3"
@@ -44127,6 +44541,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBounds3"
@@ -44177,6 +44592,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBounds3"
@@ -44220,6 +44636,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBounds3"
@@ -44261,6 +44678,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBounds3"
@@ -44315,6 +44733,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBounds3"
@@ -44375,6 +44794,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBounds3"
@@ -44427,6 +44847,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBounds3"
@@ -44481,6 +44902,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBounds3"
@@ -44522,6 +44944,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBounds3"
@@ -44569,6 +44992,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBounds3"
@@ -44616,6 +45040,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBounds3"
@@ -44657,6 +45082,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBounds3"
@@ -44700,6 +45126,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBounds3"
@@ -44747,6 +45174,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBounds3"
@@ -44794,6 +45222,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBounds3"
@@ -44841,6 +45270,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBounds3"
@@ -44886,6 +45316,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBounds3"
@@ -44927,6 +45358,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBounds3"
@@ -44969,6 +45401,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBounds3"
@@ -45006,6 +45439,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxErrorCallback"
@@ -45045,6 +45479,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxErrorCallback"
@@ -45069,6 +45504,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -45081,6 +45517,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -45124,6 +45561,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxAllocationListener"
@@ -45144,6 +45582,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -45156,6 +45595,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -45174,6 +45614,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -45211,6 +45652,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxAllocationListener"
@@ -45225,6 +45667,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -45283,6 +45726,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxBroadcastingAllocator"
@@ -45313,6 +45757,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBroadcastingAllocator"
@@ -45361,6 +45806,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBroadcastingAllocator"
@@ -45381,6 +45827,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -45393,6 +45840,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -45410,6 +45858,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Void"
           }
@@ -45448,6 +45897,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBroadcastingAllocator"
@@ -45462,6 +45912,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -45507,6 +45958,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxBroadcastingErrorCallback"
@@ -45537,6 +45989,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBroadcastingErrorCallback"
@@ -45576,6 +46029,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBroadcastingErrorCallback"
@@ -45600,6 +46054,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -45612,6 +46067,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -45703,6 +46159,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxInputStream"
@@ -45717,6 +46174,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -45747,6 +46205,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxInputStream"
@@ -45788,6 +46247,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxInputData"
@@ -45829,6 +46289,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxInputData"
@@ -45876,6 +46337,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxInputData"
@@ -45902,6 +46364,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxInputData"
@@ -45943,6 +46406,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxOutputStream"
@@ -45957,6 +46421,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -45987,6 +46452,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxOutputStream"
@@ -46205,6 +46671,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Float"
               }
@@ -46246,6 +46713,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVec4"
@@ -46287,6 +46755,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVec4"
@@ -46328,6 +46797,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVec4"
@@ -46371,6 +46841,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVec4"
@@ -46412,6 +46883,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVec4"
@@ -46453,6 +46925,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVec4"
@@ -46505,6 +46978,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVec4"
@@ -46546,6 +47020,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVec4"
@@ -46587,6 +47062,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVec4"
@@ -46639,6 +47115,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVec4"
@@ -46691,6 +47168,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVec4"
@@ -46734,6 +47212,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVec4"
@@ -47034,6 +47513,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Float"
               }
@@ -47225,6 +47705,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMat44"
@@ -47266,6 +47747,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMat44"
@@ -47318,6 +47800,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMat44"
@@ -47370,6 +47853,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMat44"
@@ -47422,6 +47906,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMat44"
@@ -47465,6 +47950,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMat44"
@@ -47503,6 +47989,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMat44"
@@ -47535,6 +48022,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMat44"
@@ -47576,6 +48064,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMat44"
@@ -47589,6 +48078,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Float"
           }
@@ -47614,6 +48104,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMat44"
@@ -47655,6 +48146,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMat44"
@@ -47687,6 +48179,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMat44"
@@ -47939,6 +48432,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPlane"
@@ -47982,6 +48476,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPlane"
@@ -48034,6 +48529,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPlane"
@@ -48086,6 +48582,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPlane"
@@ -48127,6 +48624,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPlane"
@@ -48166,6 +48664,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPlane"
@@ -48222,6 +48721,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPlane"
@@ -48394,6 +48894,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Float"
               }
@@ -49558,6 +50059,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Float"
               }
@@ -49656,6 +50158,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Float"
               }
@@ -49769,6 +50272,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxMutexImpl"
@@ -49799,6 +50303,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMutexImpl"
@@ -49840,6 +50345,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMutexImpl"
@@ -49880,6 +50386,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMutexImpl"
@@ -49921,6 +50428,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMutexImpl"
@@ -49971,6 +50479,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxReadWriteLock"
@@ -49992,6 +50501,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxReadWriteLock"
@@ -50022,6 +50532,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxReadWriteLock"
@@ -50058,6 +50569,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxReadWriteLock"
@@ -50088,6 +50600,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxReadWriteLock"
@@ -50118,6 +50631,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxReadWriteLock"
@@ -50159,6 +50673,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxProfilerCallback"
@@ -50173,6 +50688,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -50196,6 +50712,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Void"
           }
@@ -50232,6 +50749,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxProfilerCallback"
@@ -50246,6 +50764,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -50258,6 +50777,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -50294,6 +50814,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxProfilerCallback"
@@ -50308,6 +50829,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -50331,6 +50853,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxProfileScoped"
@@ -50352,6 +50875,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxProfileScoped"
@@ -50397,6 +50921,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSListEntry"
@@ -50410,6 +50935,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxSListEntry"
@@ -50431,6 +50957,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxSListImpl"
@@ -50452,6 +50979,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSListImpl"
@@ -50482,6 +51010,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSListImpl"
@@ -50496,6 +51025,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSListEntry"
@@ -50526,6 +51056,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSListImpl"
@@ -50539,6 +51070,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxSListEntry"
@@ -50566,6 +51098,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSListImpl"
@@ -50579,6 +51112,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxSListEntry"
@@ -50617,6 +51151,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxSyncImpl"
@@ -50638,6 +51173,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSyncImpl"
@@ -50679,6 +51215,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSyncImpl"
@@ -50726,6 +51263,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSyncImpl"
@@ -50765,6 +51303,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSyncImpl"
@@ -50815,6 +51354,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxRunnable"
@@ -50836,6 +51376,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRunnable"
@@ -50866,6 +51407,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRunnable"
@@ -50937,6 +51479,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Void"
           }
@@ -50990,6 +51533,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -51077,6 +51621,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCounterFrequencyToTensOfNanos"
@@ -51207,6 +51752,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTime"
@@ -51239,6 +51785,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTime"
@@ -51271,6 +51818,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTime"
@@ -51441,6 +51989,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVec2"
@@ -51482,6 +52031,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVec2"
@@ -51523,6 +52073,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVec2"
@@ -51566,6 +52117,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVec2"
@@ -51607,6 +52159,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVec2"
@@ -51648,6 +52201,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVec2"
@@ -51702,6 +52256,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVec2"
@@ -51745,6 +52300,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVec2"
@@ -51786,6 +52342,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVec2"
@@ -51842,6 +52399,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVec2"
@@ -51898,6 +52456,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVec2"
@@ -51939,6 +52498,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVec2"
@@ -51995,6 +52555,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxVec2"
@@ -52248,6 +52809,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -52274,6 +52836,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRenderBuffer"
@@ -52304,6 +52867,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRenderBuffer"
@@ -52336,6 +52900,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRenderBuffer"
@@ -52349,6 +52914,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": true,
           "pointee": {
             "Record": {
               "name": "PxDebugPoint"
@@ -52376,6 +52942,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRenderBuffer"
@@ -52419,6 +52986,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRenderBuffer"
@@ -52451,6 +53019,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRenderBuffer"
@@ -52464,6 +53033,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": true,
           "pointee": {
             "Record": {
               "name": "PxDebugLine"
@@ -52491,6 +53061,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRenderBuffer"
@@ -52534,6 +53105,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRenderBuffer"
@@ -52553,6 +53125,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": true,
           "pointee": {
             "Record": {
               "name": "PxDebugLine"
@@ -52580,6 +53153,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRenderBuffer"
@@ -52599,6 +53173,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": true,
           "pointee": {
             "Record": {
               "name": "PxDebugPoint"
@@ -52626,6 +53201,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRenderBuffer"
@@ -52658,6 +53234,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRenderBuffer"
@@ -52671,6 +53248,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": true,
           "pointee": {
             "Record": {
               "name": "PxDebugTriangle"
@@ -52698,6 +53276,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRenderBuffer"
@@ -52741,6 +53320,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRenderBuffer"
@@ -52784,6 +53364,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRenderBuffer"
@@ -52814,6 +53395,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRenderBuffer"
@@ -52855,6 +53437,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRenderBuffer"
@@ -52881,6 +53464,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxProcessPxBaseCallback"
@@ -52911,6 +53495,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxProcessPxBaseCallback"
@@ -52975,6 +53560,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSerializationContext"
@@ -53039,6 +53625,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSerializationContext"
@@ -53089,6 +53676,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSerializationContext"
@@ -53103,6 +53691,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -53148,6 +53737,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSerializationContext"
@@ -53195,6 +53785,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSerializationContext"
@@ -53209,6 +53800,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -53257,6 +53849,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDeserializationContext"
@@ -53282,6 +53875,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxBase"
@@ -53320,6 +53914,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDeserializationContext"
@@ -53337,6 +53932,7 @@
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": true,
+                  "is_array_like": false,
                   "pointee": {
                     "Builtin": "Char"
                   }
@@ -53378,6 +53974,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDeserializationContext"
@@ -53423,6 +54020,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSerializationRegistry"
@@ -53483,6 +54081,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSerializationRegistry"
@@ -53502,6 +54101,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxSerializer"
@@ -53540,6 +54140,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSerializationRegistry"
@@ -53559,6 +54160,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxSerializer"
@@ -53595,6 +54197,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSerializationRegistry"
@@ -53655,6 +54258,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSerializationRegistry"
@@ -53674,6 +54278,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxRepXSerializer"
@@ -53712,6 +54317,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSerializationRegistry"
@@ -53726,6 +54332,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -53737,6 +54344,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxRepXSerializer"
@@ -53776,6 +54384,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSerializationRegistry"
@@ -53821,6 +54430,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCollection"
@@ -53881,6 +54491,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCollection"
@@ -53935,6 +54546,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCollection"
@@ -53993,6 +54605,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCollection"
@@ -54053,6 +54666,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCollection"
@@ -54101,6 +54715,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCollection"
@@ -54156,6 +54771,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCollection"
@@ -54210,6 +54826,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCollection"
@@ -54253,6 +54870,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCollection"
@@ -54309,6 +54927,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCollection"
@@ -54323,10 +54942,12 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": true,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": false,
+                  "is_array_like": false,
                   "pointee": {
                     "Record": {
                       "name": "PxBase"
@@ -54386,6 +55007,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCollection"
@@ -54405,6 +55027,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxBase"
@@ -54443,6 +55066,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCollection"
@@ -54486,6 +55110,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCollection"
@@ -54500,6 +55125,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": true,
               "pointee": {
                 "Builtin": "ULong"
               }
@@ -54555,6 +55181,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCollection"
@@ -54612,6 +55239,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCollection"
@@ -54654,6 +55282,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxCollection"
@@ -54690,6 +55319,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBase"
@@ -54731,6 +55361,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBase"
@@ -54744,6 +55375,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -54780,6 +55412,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBase"
@@ -54821,6 +55454,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBase"
@@ -54876,6 +55510,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBase"
@@ -54926,6 +55561,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBase"
@@ -54974,6 +55610,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBase"
@@ -55015,6 +55652,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRefCounted"
@@ -55059,6 +55697,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRefCounted"
@@ -55102,6 +55741,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRefCounted"
@@ -55180,6 +55820,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTolerancesScale"
@@ -55223,6 +55864,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxStringTable"
@@ -55237,6 +55879,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -55248,6 +55891,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -55282,6 +55926,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxStringTable"
@@ -55323,6 +55968,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSerializer"
@@ -55336,6 +55982,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -55372,6 +56019,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSerializer"
@@ -55441,6 +56089,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSerializer"
@@ -55482,6 +56131,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSerializer"
@@ -55547,6 +56197,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSerializer"
@@ -55612,6 +56263,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSerializer"
@@ -55679,6 +56331,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSerializer"
@@ -55722,6 +56375,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSerializer"
@@ -55739,6 +56393,7 @@
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": false,
+                  "is_array_like": false,
                   "pointee": {
                     "Builtin": "UChar"
                   }
@@ -55765,6 +56420,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxBase"
@@ -55795,6 +56451,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSerializer"
@@ -55836,6 +56493,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxInsertionCallback"
@@ -55860,6 +56518,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -55871,6 +56530,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxBase"
@@ -55907,6 +56567,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTaskManager"
@@ -55961,6 +56622,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTaskManager"
@@ -55974,6 +56636,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxCpuDispatcher"
@@ -56012,6 +56675,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTaskManager"
@@ -56053,6 +56717,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTaskManager"
@@ -56092,6 +56757,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTaskManager"
@@ -56131,6 +56797,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTaskManager"
@@ -56185,6 +56852,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTaskManager"
@@ -56199,6 +56867,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -56240,6 +56909,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTaskManager"
@@ -56254,6 +56924,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTask"
@@ -56268,6 +56939,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -56319,6 +56991,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTaskManager"
@@ -56385,6 +57058,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTaskManager"
@@ -56404,6 +57078,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxTask"
@@ -56440,6 +57115,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTaskManager"
@@ -56492,6 +57168,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCpuDispatcher"
@@ -56505,6 +57182,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxTaskManager"
@@ -56545,6 +57223,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCpuDispatcher"
@@ -56601,6 +57280,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCpuDispatcher"
@@ -56627,6 +57307,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCpuDispatcher"
@@ -56669,6 +57350,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBaseTask"
@@ -56712,6 +57394,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBaseTask"
@@ -56725,6 +57408,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -56759,6 +57443,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBaseTask"
@@ -56798,6 +57483,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBaseTask"
@@ -56837,6 +57523,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBaseTask"
@@ -56882,6 +57569,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBaseTask"
@@ -56924,6 +57612,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBaseTask"
@@ -56937,6 +57626,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxTaskManager"
@@ -56964,6 +57654,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBaseTask"
@@ -57000,6 +57691,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBaseTask"
@@ -57041,6 +57733,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTask"
@@ -57080,6 +57773,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTask"
@@ -57125,6 +57819,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTask"
@@ -57171,6 +57866,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTask"
@@ -57211,6 +57907,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTask"
@@ -57250,6 +57947,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTask"
@@ -57291,6 +57989,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTask"
@@ -57334,6 +58033,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTask"
@@ -57376,6 +58076,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxLightCpuTask"
@@ -57403,6 +58104,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBaseTask"
@@ -57445,6 +58147,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxLightCpuTask"
@@ -57459,6 +58162,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBaseTask"
@@ -57498,6 +58202,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxLightCpuTask"
@@ -57511,6 +58216,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxBaseTask"
@@ -57548,6 +58254,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxLightCpuTask"
@@ -57587,6 +58294,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxLightCpuTask"
@@ -57629,6 +58337,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxLightCpuTask"
@@ -57670,6 +58379,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxLightCpuTask"
@@ -57711,6 +58421,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxGeometry"
@@ -57835,6 +58546,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBoxGeometry"
@@ -57861,6 +58573,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBVHRaycastCallback"
@@ -57891,6 +58604,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBVHRaycastCallback"
@@ -57934,6 +58648,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBVHOverlapCallback"
@@ -57964,6 +58679,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBVHOverlapCallback"
@@ -57996,6 +58712,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBVHTraversalCallback"
@@ -58026,6 +58743,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBVHTraversalCallback"
@@ -58071,6 +58789,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBVHTraversalCallback"
@@ -58091,6 +58810,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "UInt"
               }
@@ -58132,6 +58852,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBVH"
@@ -58225,6 +58946,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBVH"
@@ -58333,6 +59055,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBVH"
@@ -58432,6 +59155,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBVH"
@@ -58452,6 +59176,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPlane"
@@ -58521,6 +59246,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBVH"
@@ -58564,6 +59290,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBVH"
@@ -58577,6 +59304,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": true,
           "pointee": {
             "Record": {
               "name": "PxBounds3"
@@ -58617,6 +59345,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBVH"
@@ -58630,6 +59359,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxBounds3"
@@ -58677,6 +59407,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBVH"
@@ -58725,6 +59456,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBVH"
@@ -58788,6 +59520,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBVH"
@@ -58832,6 +59565,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBVH"
@@ -58877,6 +59611,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBVH"
@@ -58890,6 +59625,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -58966,6 +59702,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCapsuleGeometry"
@@ -59009,6 +59746,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConvexMesh"
@@ -59052,6 +59790,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConvexMesh"
@@ -59065,6 +59804,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": true,
           "pointee": {
             "Builtin": "Vec3"
           }
@@ -59101,6 +59841,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConvexMesh"
@@ -59114,6 +59855,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "UChar"
           }
@@ -59150,6 +59892,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConvexMesh"
@@ -59193,6 +59936,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConvexMesh"
@@ -59253,6 +59997,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConvexMesh"
@@ -59301,6 +60046,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConvexMesh"
@@ -59375,6 +60121,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConvexMesh"
@@ -59420,6 +60167,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConvexMesh"
@@ -59433,6 +60181,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Float"
           }
@@ -59458,6 +60207,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConvexMesh"
@@ -59471,6 +60221,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -59509,6 +60260,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConvexMesh"
@@ -59690,6 +60442,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMeshScale"
@@ -59731,6 +60484,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMeshScale"
@@ -59774,6 +60528,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMeshScale"
@@ -59815,6 +60570,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMeshScale"
@@ -59847,6 +60603,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMeshScale"
@@ -59890,6 +60647,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMeshScale"
@@ -59922,6 +60680,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMeshScale"
@@ -59959,6 +60718,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConvexMesh"
@@ -60029,6 +60789,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConvexMeshGeometry"
@@ -60106,6 +60867,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSphereGeometry"
@@ -60173,6 +60935,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPlaneGeometry"
@@ -60210,6 +60973,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTriangleMesh"
@@ -60280,6 +61044,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTriangleMeshGeometry"
@@ -60317,6 +61082,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxHeightField"
@@ -60392,6 +61158,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxHeightFieldGeometry"
@@ -60461,6 +61228,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxParticleSystemGeometry"
@@ -60528,6 +61296,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxHairSystemGeometry"
@@ -60565,6 +61334,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTetrahedronMesh"
@@ -60613,6 +61383,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTetrahedronMeshGeometry"
@@ -60686,6 +61457,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxLocationHit"
@@ -60896,6 +61668,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCustomGeometryCallbacks"
@@ -60941,6 +61714,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCustomGeometryCallbacks"
@@ -60999,6 +61773,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCustomGeometryCallbacks"
@@ -61082,6 +61857,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxGeomRaycastHit"
@@ -61102,6 +61878,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQueryThreadContext"
@@ -61145,6 +61922,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCustomGeometryCallbacks"
@@ -61211,6 +61989,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQueryThreadContext"
@@ -61254,6 +62033,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCustomGeometryCallbacks"
@@ -61365,6 +62145,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQueryThreadContext"
@@ -61406,6 +62187,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCustomGeometryCallbacks"
@@ -61471,6 +62253,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCustomGeometryCallbacks"
@@ -61521,6 +62304,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCustomGeometryCallbacks"
@@ -61626,6 +62410,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCustomGeometry"
@@ -61667,6 +62452,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCustomGeometry"
@@ -61701,6 +62487,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxGeometryHolder"
@@ -61737,6 +62524,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxGeometryHolder"
@@ -61776,6 +62564,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxGeometryHolder"
@@ -61815,6 +62604,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxGeometryHolder"
@@ -61854,6 +62644,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxGeometryHolder"
@@ -61893,6 +62684,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxGeometryHolder"
@@ -61932,6 +62724,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxGeometryHolder"
@@ -61971,6 +62764,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxGeometryHolder"
@@ -62010,6 +62804,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxGeometryHolder"
@@ -62049,6 +62844,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxGeometryHolder"
@@ -62088,6 +62884,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxGeometryHolder"
@@ -62127,6 +62924,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxGeometryHolder"
@@ -62166,6 +62964,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxGeometryHolder"
@@ -62205,6 +63004,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxGeometryHolder"
@@ -62244,6 +63044,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxGeometryHolder"
@@ -62283,6 +63084,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxGeometryHolder"
@@ -62322,6 +63124,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxGeometryHolder"
@@ -62361,6 +63164,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxGeometryHolder"
@@ -62400,6 +63204,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxGeometryHolder"
@@ -62439,6 +63244,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxGeometryHolder"
@@ -62478,6 +63284,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxGeometryHolder"
@@ -62517,6 +63324,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxGeometryHolder"
@@ -62556,6 +63364,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxGeometryHolder"
@@ -62595,6 +63404,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxGeometryHolder"
@@ -62634,6 +63444,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxGeometryHolder"
@@ -62673,6 +63484,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxGeometryHolder"
@@ -62842,6 +63654,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxGeomRaycastHit"
@@ -62871,6 +63684,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQueryThreadContext"
@@ -62985,6 +63799,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQueryThreadContext"
@@ -63144,6 +63959,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQueryThreadContext"
@@ -63358,6 +64174,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Vec3"
               }
@@ -63370,6 +64187,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "UInt"
               }
@@ -63536,6 +64354,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxHeightFieldSample"
@@ -63568,6 +64387,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxHeightFieldSample"
@@ -63598,6 +64418,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxHeightFieldSample"
@@ -63637,6 +64458,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxHeightField"
@@ -63681,6 +64503,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxHeightField"
@@ -63695,6 +64518,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -63751,6 +64575,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxHeightField"
@@ -63825,6 +64650,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxHeightField"
@@ -63868,6 +64694,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxHeightField"
@@ -63911,6 +64738,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxHeightField"
@@ -63958,6 +64786,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxHeightField"
@@ -64001,6 +64830,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxHeightField"
@@ -64044,6 +64874,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxHeightField"
@@ -64090,6 +64921,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxHeightField"
@@ -64147,6 +64979,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxHeightField"
@@ -64198,6 +65031,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxHeightField"
@@ -64247,6 +65081,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxHeightField"
@@ -64312,6 +65147,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxHeightField"
@@ -64344,6 +65180,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxHeightField"
@@ -64357,6 +65194,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -64415,6 +65253,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxHeightFieldDesc"
@@ -64456,6 +65295,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxHeightFieldDesc"
@@ -64546,6 +65386,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "UInt"
               }
@@ -64558,6 +65399,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "UInt"
               }
@@ -64664,6 +65506,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "UInt"
               }
@@ -64676,6 +65519,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "UInt"
               }
@@ -64771,6 +65615,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "UInt"
               }
@@ -64898,6 +65743,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "UInt"
               }
@@ -65041,6 +65887,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTriangle"
@@ -65077,6 +65924,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "UInt"
               }
@@ -65161,6 +66009,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSimpleTriangleMesh"
@@ -65200,6 +66049,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSimpleTriangleMesh"
@@ -65235,6 +66085,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxTriangle"
@@ -65299,6 +66150,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxTriangle"
@@ -65329,6 +66181,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTriangle"
@@ -65368,6 +66221,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTriangle"
@@ -65418,6 +66272,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTriangle"
@@ -65470,6 +66325,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTriangle"
@@ -65511,6 +66367,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTriangle"
@@ -65549,6 +66406,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxTrianglePadded"
@@ -65570,6 +66428,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTrianglePadded"
@@ -65611,6 +66470,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTriangleMesh"
@@ -65654,6 +66514,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTriangleMesh"
@@ -65667,6 +66528,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": true,
           "pointee": {
             "Builtin": "Vec3"
           }
@@ -65721,6 +66583,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTriangleMesh"
@@ -65734,6 +66597,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Vec3"
           }
@@ -65785,6 +66649,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTriangleMesh"
@@ -65830,6 +66695,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTriangleMesh"
@@ -65878,6 +66744,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTriangleMesh"
@@ -65891,6 +66758,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": true,
           "pointee": {
             "Builtin": "Void"
           }
@@ -65929,6 +66797,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTriangleMesh"
@@ -65981,6 +66850,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTriangleMesh"
@@ -65994,6 +66864,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "UInt"
           }
@@ -66028,6 +66899,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTriangleMesh"
@@ -66071,6 +66943,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTriangleMesh"
@@ -66120,6 +66993,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTriangleMesh"
@@ -66165,6 +67039,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTriangleMesh"
@@ -66178,6 +67053,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Float"
           }
@@ -66212,6 +67088,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTriangleMesh"
@@ -66290,6 +67167,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTriangleMesh"
@@ -66337,6 +67215,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTriangleMesh"
@@ -66387,6 +67266,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTriangleMesh"
@@ -66453,6 +67333,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxTetrahedron"
@@ -66528,6 +67409,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxTetrahedron"
@@ -66558,6 +67440,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTetrahedron"
@@ -66597,6 +67480,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSoftBodyAuxData"
@@ -66638,6 +67522,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTetrahedronMesh"
@@ -66681,6 +67566,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTetrahedronMesh"
@@ -66694,6 +67580,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": true,
           "pointee": {
             "Builtin": "Vec3"
           }
@@ -66730,6 +67617,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTetrahedronMesh"
@@ -66778,6 +67666,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTetrahedronMesh"
@@ -66791,6 +67680,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": true,
           "pointee": {
             "Builtin": "Void"
           }
@@ -66829,6 +67719,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTetrahedronMesh"
@@ -66881,6 +67772,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTetrahedronMesh"
@@ -66894,6 +67786,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "UInt"
           }
@@ -66930,6 +67823,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTetrahedronMesh"
@@ -66973,6 +67867,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTetrahedronMesh"
@@ -67012,6 +67907,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSoftBodyMesh"
@@ -67025,6 +67921,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxTetrahedronMesh"
@@ -67061,6 +67958,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSoftBodyMesh"
@@ -67074,6 +67972,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxTetrahedronMesh"
@@ -67110,6 +68009,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSoftBodyMesh"
@@ -67123,6 +68023,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxTetrahedronMesh"
@@ -67159,6 +68060,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSoftBodyMesh"
@@ -67172,6 +68074,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxTetrahedronMesh"
@@ -67208,6 +68111,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSoftBodyMesh"
@@ -67221,6 +68125,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxSoftBodyAuxData"
@@ -67257,6 +68162,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSoftBodyMesh"
@@ -67270,6 +68176,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxSoftBodyAuxData"
@@ -67306,6 +68213,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSoftBodyMesh"
@@ -67336,6 +68244,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCollisionMeshMappingData"
@@ -67366,6 +68275,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCollisionTetrahedronMeshData"
@@ -67379,6 +68289,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxTetrahedronMeshData"
@@ -67406,6 +68317,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCollisionTetrahedronMeshData"
@@ -67419,6 +68331,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxTetrahedronMeshData"
@@ -67446,6 +68359,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCollisionTetrahedronMeshData"
@@ -67459,6 +68373,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxSoftBodyCollisionData"
@@ -67486,6 +68401,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCollisionTetrahedronMeshData"
@@ -67499,6 +68415,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxSoftBodyCollisionData"
@@ -67526,6 +68443,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCollisionTetrahedronMeshData"
@@ -67556,6 +68474,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSimulationTetrahedronMeshData"
@@ -67569,6 +68488,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxTetrahedronMeshData"
@@ -67596,6 +68516,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSimulationTetrahedronMeshData"
@@ -67609,6 +68530,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxSoftBodySimulationData"
@@ -67636,6 +68558,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSimulationTetrahedronMeshData"
@@ -67679,6 +68602,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxActor"
@@ -67720,6 +68644,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxActor"
@@ -67767,6 +68692,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxActor"
@@ -67780,6 +68706,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxScene"
@@ -67822,6 +68749,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxActor"
@@ -67836,6 +68764,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -67875,6 +68804,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxActor"
@@ -67888,6 +68818,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -67927,6 +68858,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxActor"
@@ -67983,6 +68915,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxActor"
@@ -68040,6 +68973,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxActor"
@@ -68092,6 +69026,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxActor"
@@ -68149,6 +69084,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxActor"
@@ -68196,6 +69132,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxActor"
@@ -68242,6 +69179,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxActor"
@@ -68289,6 +69227,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxActor"
@@ -68332,6 +69271,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxActor"
@@ -68345,6 +69285,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxAggregate"
@@ -68469,6 +69410,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxAggregate"
@@ -68521,6 +69463,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxAggregate"
@@ -68548,6 +69491,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBVH"
@@ -68594,6 +69538,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxAggregate"
@@ -68656,6 +69601,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxAggregate"
@@ -68715,6 +69661,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxAggregate"
@@ -68773,6 +69720,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxAggregate"
@@ -68816,6 +69764,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxAggregate"
@@ -68861,6 +69810,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxAggregate"
@@ -68875,10 +69825,12 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": true,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": false,
+                  "is_array_like": true,
                   "pointee": {
                     "Record": {
                       "name": "PxActor"
@@ -68936,6 +69888,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxAggregate"
@@ -68949,6 +69902,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxScene"
@@ -68987,6 +69941,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxAggregate"
@@ -69019,6 +69974,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxAggregate"
@@ -69032,6 +69988,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -69121,6 +70078,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConstraintVisualizer"
@@ -69186,6 +70144,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConstraintVisualizer"
@@ -69263,6 +70222,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConstraintVisualizer"
@@ -69333,6 +70293,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConstraintVisualizer"
@@ -69403,6 +70364,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConstraintVisualizer"
@@ -69467,6 +70429,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConstraintVisualizer"
@@ -69536,6 +70499,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConstraintConnector"
@@ -69549,6 +70513,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Void"
           }
@@ -69591,6 +70556,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConstraintConnector"
@@ -69635,6 +70601,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConstraintConnector"
@@ -69686,6 +70653,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConstraintConnector"
@@ -69738,6 +70706,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConstraintConnector"
@@ -69751,6 +70720,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxBase"
@@ -69787,6 +70757,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConstraintConnector"
@@ -69800,6 +70771,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Void"
           }
@@ -69834,6 +70806,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConstraintConnector"
@@ -69848,6 +70821,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConstraint"
@@ -69881,6 +70855,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConstraintConnector"
@@ -69926,6 +70901,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSolverBodyData"
@@ -69974,6 +70950,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSolverConstraintPrepDesc"
@@ -70015,6 +70992,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConstraintAllocator"
@@ -70034,6 +71012,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "UChar"
           }
@@ -70071,6 +71050,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConstraintAllocator"
@@ -70090,6 +71070,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "UChar"
           }
@@ -70109,6 +71090,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConstraintAllocator"
@@ -70241,6 +71223,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTGSSolverBodyVel"
@@ -70295,6 +71278,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTGSSolverBodyData"
@@ -70343,6 +71327,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTGSSolverConstraintPrepDesc"
@@ -70384,6 +71369,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationAttachment"
@@ -70431,6 +71417,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationAttachment"
@@ -70474,6 +71461,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationAttachment"
@@ -70528,6 +71516,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationAttachment"
@@ -70571,6 +71560,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationAttachment"
@@ -70623,6 +71613,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationAttachment"
@@ -70664,6 +71655,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationAttachment"
@@ -70711,6 +71703,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationAttachment"
@@ -70754,6 +71747,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationAttachment"
@@ -70767,6 +71761,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxArticulationLink"
@@ -70805,6 +71800,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationAttachment"
@@ -70818,6 +71814,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxArticulationAttachment"
@@ -70856,6 +71853,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationAttachment"
@@ -70899,6 +71897,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationAttachment"
@@ -70912,6 +71911,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxArticulationSpatialTendon"
@@ -70951,6 +71951,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationAttachment"
@@ -70992,6 +71993,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationAttachment"
@@ -71005,6 +72007,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -71042,6 +72045,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationTendonJoint"
@@ -71103,6 +72107,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationTendonJoint"
@@ -71181,6 +72186,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationTendonJoint"
@@ -71194,6 +72200,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxArticulationLink"
@@ -71232,6 +72239,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationTendonJoint"
@@ -71245,6 +72253,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxArticulationTendonJoint"
@@ -71283,6 +72292,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationTendonJoint"
@@ -71296,6 +72306,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxArticulationFixedTendon"
@@ -71335,6 +72346,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationTendonJoint"
@@ -71376,6 +72388,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationTendonJoint"
@@ -71389,6 +72402,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -71423,6 +72437,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationTendon"
@@ -71470,6 +72485,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationTendon"
@@ -71511,6 +72527,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationTendon"
@@ -71558,6 +72575,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationTendon"
@@ -71601,6 +72619,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationTendon"
@@ -71650,6 +72669,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationTendon"
@@ -71694,6 +72714,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationTendon"
@@ -71747,6 +72768,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationTendon"
@@ -71790,6 +72812,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationTendon"
@@ -71803,6 +72826,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxArticulationReducedCoordinate"
@@ -71844,6 +72868,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationTendon"
@@ -71888,6 +72913,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationSpatialTendon"
@@ -71902,6 +72928,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationAttachment"
@@ -71928,6 +72955,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationLink"
@@ -71941,6 +72969,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxArticulationAttachment"
@@ -71979,6 +73008,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationSpatialTendon"
@@ -71993,10 +73023,12 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": true,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": false,
+                  "is_array_like": false,
                   "pointee": {
                     "Record": {
                       "name": "PxArticulationAttachment"
@@ -72054,6 +73086,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationSpatialTendon"
@@ -72097,6 +73130,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationSpatialTendon"
@@ -72110,6 +73144,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -72152,6 +73187,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationFixedTendon"
@@ -72166,6 +73202,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationTendonJoint"
@@ -72202,6 +73239,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationLink"
@@ -72215,6 +73253,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxArticulationTendonJoint"
@@ -72253,6 +73292,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationFixedTendon"
@@ -72267,10 +73307,12 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": true,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": false,
+                  "is_array_like": false,
                   "pointee": {
                     "Record": {
                       "name": "PxArticulationTendonJoint"
@@ -72328,6 +73370,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationFixedTendon"
@@ -72376,6 +73419,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationFixedTendon"
@@ -72423,6 +73467,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationFixedTendon"
@@ -72466,6 +73511,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationFixedTendon"
@@ -72520,6 +73566,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationFixedTendon"
@@ -72565,6 +73612,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationFixedTendon"
@@ -72578,6 +73626,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -72627,6 +73676,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationCache"
@@ -72669,6 +73719,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationSensor"
@@ -72713,6 +73764,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationSensor"
@@ -72760,6 +73812,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationSensor"
@@ -72808,6 +73861,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationSensor"
@@ -72862,6 +73916,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationSensor"
@@ -72875,6 +73930,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxArticulationLink"
@@ -72915,6 +73971,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationSensor"
@@ -72958,6 +74015,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationSensor"
@@ -72971,6 +74029,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxArticulationReducedCoordinate"
@@ -73009,6 +74068,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationSensor"
@@ -73056,6 +74116,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationSensor"
@@ -73113,6 +74174,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationSensor"
@@ -73126,6 +74188,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -73162,6 +74225,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -73175,6 +74239,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxScene"
@@ -73225,6 +74290,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -73276,6 +74342,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -73369,6 +74436,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -73414,6 +74482,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -73461,6 +74530,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -73511,6 +74581,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -73560,6 +74631,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -73611,6 +74683,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -73660,6 +74733,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -73707,6 +74781,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -73751,6 +74826,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -73799,6 +74875,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -73846,6 +74923,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -73896,6 +74974,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -73943,6 +75022,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -73989,6 +75069,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -74003,6 +75084,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationLink"
@@ -74029,6 +75111,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxArticulationLink"
@@ -74069,6 +75152,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -74110,6 +75194,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -74153,6 +75238,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -74167,10 +75253,12 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": true,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": false,
+                  "is_array_like": false,
                   "pointee": {
                     "Record": {
                       "name": "PxArticulationLink"
@@ -74228,6 +75316,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -74272,6 +75361,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -74286,6 +75376,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -74325,6 +75416,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -74338,6 +75430,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -74377,6 +75470,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -74428,6 +75522,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -74441,6 +75536,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxAggregate"
@@ -74479,6 +75575,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -74529,6 +75626,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -74586,6 +75684,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -74636,6 +75735,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -74684,6 +75784,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -74697,6 +75798,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxArticulationCache"
@@ -74739,6 +75841,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -74782,6 +75885,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -74841,6 +75945,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -74910,6 +76015,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -74976,6 +76082,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -74990,6 +76097,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Float"
               }
@@ -75002,6 +76110,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Float"
               }
@@ -75044,6 +76153,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -75058,6 +76168,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Float"
               }
@@ -75070,6 +76181,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Float"
               }
@@ -75114,6 +76226,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -75162,6 +76275,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -75224,6 +76338,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -75285,6 +76400,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -75347,6 +76463,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -75409,6 +76526,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -75466,6 +76584,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -75547,6 +76666,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -75606,6 +76726,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -75646,6 +76767,7 @@
             "Pointer": {
               "is_const": true,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Float"
               }
@@ -75698,6 +76820,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -75752,6 +76875,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -75766,6 +76890,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConstraint"
@@ -75807,6 +76932,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -75821,6 +76947,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConstraint"
@@ -75862,6 +76989,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -75905,6 +77033,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -75919,10 +77048,12 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": true,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": false,
+                  "is_array_like": false,
                   "pointee": {
                     "Record": {
                       "name": "PxConstraint"
@@ -75982,6 +77113,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -76029,6 +77161,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -76094,6 +77227,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -76145,6 +77279,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -76209,6 +77344,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -76257,6 +77393,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -76320,6 +77457,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -76369,6 +77507,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -76420,6 +77559,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -76466,6 +77606,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -76479,6 +77620,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxArticulationSpatialTendon"
@@ -76520,6 +77662,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -76533,6 +77676,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxArticulationFixedTendon"
@@ -76574,6 +77718,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -76588,6 +77733,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationLink"
@@ -76614,6 +77760,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxArticulationSensor"
@@ -76654,6 +77801,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -76668,10 +77816,12 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": true,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": false,
+                  "is_array_like": false,
                   "pointee": {
                     "Record": {
                       "name": "PxArticulationSpatialTendon"
@@ -76729,6 +77879,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -76774,6 +77925,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -76788,10 +77940,12 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": true,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": false,
+                  "is_array_like": false,
                   "pointee": {
                     "Record": {
                       "name": "PxArticulationFixedTendon"
@@ -76849,6 +78003,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -76894,6 +78049,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -76908,10 +78064,12 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": true,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": false,
+                  "is_array_like": false,
                   "pointee": {
                     "Record": {
                       "name": "PxArticulationSensor"
@@ -76969,6 +78127,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -77027,6 +78186,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationReducedCoordinate"
@@ -77077,6 +78237,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationJointReducedCoordinate"
@@ -77127,6 +78288,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationJointReducedCoordinate"
@@ -77181,6 +78343,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationJointReducedCoordinate"
@@ -77226,6 +78389,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationJointReducedCoordinate"
@@ -77276,6 +78440,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationJointReducedCoordinate"
@@ -77330,6 +78495,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationJointReducedCoordinate"
@@ -77376,6 +78542,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationJointReducedCoordinate"
@@ -77427,6 +78594,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationJointReducedCoordinate"
@@ -77475,6 +78643,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationJointReducedCoordinate"
@@ -77536,6 +78705,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationJointReducedCoordinate"
@@ -77599,6 +78769,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationJointReducedCoordinate"
@@ -77663,6 +78834,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationJointReducedCoordinate"
@@ -77720,6 +78892,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationJointReducedCoordinate"
@@ -77784,6 +78957,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationJointReducedCoordinate"
@@ -77847,6 +79021,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationJointReducedCoordinate"
@@ -77910,6 +79085,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationJointReducedCoordinate"
@@ -77965,6 +79141,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationJointReducedCoordinate"
@@ -78028,6 +79205,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationJointReducedCoordinate"
@@ -78084,6 +79262,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationJointReducedCoordinate"
@@ -78141,6 +79320,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationJointReducedCoordinate"
@@ -78202,6 +79382,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationJointReducedCoordinate"
@@ -78249,6 +79430,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationJointReducedCoordinate"
@@ -78295,6 +79477,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationJointReducedCoordinate"
@@ -78342,6 +79525,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationJointReducedCoordinate"
@@ -78395,6 +79579,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationJointReducedCoordinate"
@@ -78457,6 +79642,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationJointReducedCoordinate"
@@ -78514,6 +79700,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationJointReducedCoordinate"
@@ -78576,6 +79763,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationJointReducedCoordinate"
@@ -78629,6 +79817,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationJointReducedCoordinate"
@@ -78642,6 +79831,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -78681,6 +79871,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxShape"
@@ -78726,6 +79917,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxShape"
@@ -78782,6 +79974,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxShape"
@@ -78832,6 +80025,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxShape"
@@ -78845,6 +80039,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxRigidActor"
@@ -78897,6 +80092,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxShape"
@@ -78953,6 +80149,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxShape"
@@ -79003,6 +80200,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxShape"
@@ -79055,6 +80253,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxShape"
@@ -79101,6 +80300,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxShape"
@@ -79153,6 +80353,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxShape"
@@ -79201,6 +80402,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxShape"
@@ -79215,10 +80417,12 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": false,
+                  "is_array_like": false,
                   "pointee": {
                     "Record": {
                       "name": "PxMaterial"
@@ -79270,6 +80474,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxShape"
@@ -79317,6 +80522,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxShape"
@@ -79331,10 +80537,12 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": true,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": false,
+                  "is_array_like": false,
                   "pointee": {
                     "Record": {
                       "name": "PxMaterial"
@@ -79403,6 +80611,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxShape"
@@ -79422,6 +80631,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxBaseMaterial"
@@ -79471,6 +80681,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxShape"
@@ -79518,6 +80729,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxShape"
@@ -79571,6 +80783,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxShape"
@@ -79618,6 +80831,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxShape"
@@ -79666,6 +80880,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxShape"
@@ -79713,6 +80928,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxShape"
@@ -79762,6 +80978,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxShape"
@@ -79814,6 +81031,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxShape"
@@ -79863,6 +81081,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxShape"
@@ -79915,6 +81134,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxShape"
@@ -79964,6 +81184,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxShape"
@@ -80019,6 +81240,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxShape"
@@ -80069,6 +81291,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxShape"
@@ -80113,6 +81336,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxShape"
@@ -80160,6 +81384,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxShape"
@@ -80174,6 +81399,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -80213,6 +81439,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxShape"
@@ -80226,6 +81453,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -80251,6 +81479,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxShape"
@@ -80264,6 +81493,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -80310,6 +81540,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidActor"
@@ -80353,6 +81584,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidActor"
@@ -80401,6 +81633,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidActor"
@@ -80462,6 +81695,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidActor"
@@ -80536,6 +81770,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidActor"
@@ -80597,6 +81832,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidActor"
@@ -80659,6 +81895,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidActor"
@@ -80708,6 +81945,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidActor"
@@ -80722,10 +81960,12 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": true,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": false,
+                  "is_array_like": false,
                   "pointee": {
                     "Record": {
                       "name": "PxShape"
@@ -80785,6 +82025,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidActor"
@@ -80832,6 +82073,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidActor"
@@ -80846,10 +82088,12 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": true,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": false,
+                  "is_array_like": false,
                   "pointee": {
                     "Record": {
                       "name": "PxConstraint"
@@ -80946,6 +82190,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxNodeIndex"
@@ -80978,6 +82223,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxNodeIndex"
@@ -81010,6 +82256,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxNodeIndex"
@@ -81042,6 +82289,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxNodeIndex"
@@ -81074,6 +82322,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxNodeIndex"
@@ -81106,6 +82355,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxNodeIndex"
@@ -81148,6 +82398,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxNodeIndex"
@@ -81184,6 +82435,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxNodeIndex"
@@ -81233,6 +82485,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidBody"
@@ -81287,6 +82540,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidBody"
@@ -81347,6 +82601,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidBody"
@@ -81396,6 +82651,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidBody"
@@ -81439,6 +82695,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidBody"
@@ -81499,6 +82756,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidBody"
@@ -81555,6 +82813,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidBody"
@@ -81602,6 +82861,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidBody"
@@ -81648,6 +82908,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidBody"
@@ -81695,6 +82956,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidBody"
@@ -81743,6 +83005,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidBody"
@@ -81790,6 +83053,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidBody"
@@ -81836,6 +83100,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidBody"
@@ -81882,6 +83147,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidBody"
@@ -81934,6 +83200,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidBody"
@@ -81981,6 +83248,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidBody"
@@ -82036,6 +83304,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidBody"
@@ -82083,6 +83352,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidBody"
@@ -82146,6 +83416,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidBody"
@@ -82231,6 +83502,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidBody"
@@ -82309,6 +83581,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidBody"
@@ -82370,6 +83643,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidBody"
@@ -82425,6 +83699,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidBody"
@@ -82506,6 +83781,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidBody"
@@ -82552,6 +83828,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidBody"
@@ -82604,6 +83881,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidBody"
@@ -82663,6 +83941,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidBody"
@@ -82710,6 +83989,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidBody"
@@ -82752,6 +84032,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidBody"
@@ -82800,6 +84081,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidBody"
@@ -82843,6 +84125,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidBody"
@@ -82890,6 +84173,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidBody"
@@ -82934,6 +84218,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidBody"
@@ -82981,6 +84266,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidBody"
@@ -83024,6 +84310,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidBody"
@@ -83072,6 +84359,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationLink"
@@ -83113,6 +84401,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationLink"
@@ -83163,6 +84452,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationLink"
@@ -83176,6 +84466,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxArticulationJointReducedCoordinate"
@@ -83217,6 +84508,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationLink"
@@ -83260,6 +84552,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationLink"
@@ -83305,6 +84598,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationLink"
@@ -83348,6 +84642,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationLink"
@@ -83362,10 +84657,12 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": true,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": false,
+                  "is_array_like": false,
                   "pointee": {
                     "Record": {
                       "name": "PxArticulationLink"
@@ -83432,6 +84729,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationLink"
@@ -83479,6 +84777,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationLink"
@@ -83529,6 +84828,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationLink"
@@ -83578,6 +84878,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationLink"
@@ -83621,6 +84922,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxArticulationLink"
@@ -83634,6 +84936,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -83685,6 +84988,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConstraint"
@@ -83726,6 +85030,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConstraint"
@@ -83739,6 +85044,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxScene"
@@ -83775,6 +85081,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConstraint"
@@ -83792,6 +85099,7 @@
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": false,
+                  "is_array_like": false,
                   "pointee": {
                     "Record": {
                       "name": "PxRigidActor"
@@ -83811,6 +85119,7 @@
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": false,
+                  "is_array_like": false,
                   "pointee": {
                     "Record": {
                       "name": "PxRigidActor"
@@ -83852,6 +85161,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConstraint"
@@ -83866,6 +85176,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidActor"
@@ -83880,6 +85191,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidActor"
@@ -83919,6 +85231,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConstraint"
@@ -83960,6 +85273,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConstraint"
@@ -84006,6 +85320,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConstraint"
@@ -84054,6 +85369,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConstraint"
@@ -84112,6 +85428,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConstraint"
@@ -84179,6 +85496,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConstraint"
@@ -84222,6 +85540,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConstraint"
@@ -84273,6 +85592,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConstraint"
@@ -84339,6 +85659,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConstraint"
@@ -84386,6 +85707,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConstraint"
@@ -84431,6 +85753,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConstraint"
@@ -84455,6 +85778,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Void"
           }
@@ -84489,6 +85813,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConstraint"
@@ -84545,6 +85870,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConstraint"
@@ -84558,6 +85884,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -84588,6 +85915,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "UChar"
               }
@@ -84600,6 +85928,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "UChar"
               }
@@ -84612,6 +85941,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "UInt"
               }
@@ -84667,6 +85997,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactStreamIterator"
@@ -84710,6 +86041,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactStreamIterator"
@@ -84753,6 +86085,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactStreamIterator"
@@ -84794,6 +86127,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactStreamIterator"
@@ -84835,6 +86169,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactStreamIterator"
@@ -84876,6 +86211,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactStreamIterator"
@@ -84917,6 +86253,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactStreamIterator"
@@ -84965,6 +86302,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactStreamIterator"
@@ -85008,6 +86346,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactStreamIterator"
@@ -85051,6 +86390,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactStreamIterator"
@@ -85094,6 +86434,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactStreamIterator"
@@ -85137,6 +86478,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactStreamIterator"
@@ -85180,6 +86522,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactStreamIterator"
@@ -85228,6 +86571,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactStreamIterator"
@@ -85276,6 +86620,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactStreamIterator"
@@ -85319,6 +86664,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactStreamIterator"
@@ -85362,6 +86708,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactStreamIterator"
@@ -85405,6 +86752,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactStreamIterator"
@@ -85448,6 +86796,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactStreamIterator"
@@ -85491,6 +86840,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactStreamIterator"
@@ -85534,6 +86884,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactStreamIterator"
@@ -85577,6 +86928,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactStreamIterator"
@@ -85620,6 +86972,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactStreamIterator"
@@ -85663,6 +87016,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactStreamIterator"
@@ -85706,6 +87060,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactStreamIterator"
@@ -85755,6 +87110,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactSet"
@@ -85807,6 +87163,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactSet"
@@ -85865,6 +87222,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactSet"
@@ -85919,6 +87277,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactSet"
@@ -85977,6 +87336,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactSet"
@@ -86024,6 +87384,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactSet"
@@ -86077,6 +87438,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactSet"
@@ -86129,6 +87491,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactSet"
@@ -86189,6 +87552,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactSet"
@@ -86238,6 +87602,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactSet"
@@ -86287,6 +87652,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactSet"
@@ -86336,6 +87702,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactSet"
@@ -86389,6 +87756,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactSet"
@@ -86438,6 +87806,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactSet"
@@ -86491,6 +87860,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactSet"
@@ -86538,6 +87908,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactSet"
@@ -86591,6 +87962,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactSet"
@@ -86638,6 +88010,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactSet"
@@ -86691,6 +88064,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactSet"
@@ -86736,6 +88110,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactSet"
@@ -86782,6 +88157,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactSet"
@@ -86828,6 +88204,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactSet"
@@ -86874,6 +88251,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactSet"
@@ -86920,6 +88298,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactSet"
@@ -86966,6 +88345,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactSet"
@@ -87016,6 +88396,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactSet"
@@ -87066,6 +88447,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactSet"
@@ -87116,6 +88498,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactSet"
@@ -87166,6 +88549,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactModifyCallback"
@@ -87180,6 +88564,7 @@
             "Pointer": {
               "is_const": true,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactModifyPair"
@@ -87230,6 +88615,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCCDContactModifyCallback"
@@ -87244,6 +88630,7 @@
             "Pointer": {
               "is_const": true,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactModifyPair"
@@ -87298,6 +88685,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDeletionListener"
@@ -87312,6 +88700,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBase"
@@ -87326,6 +88715,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -87364,6 +88754,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBaseMaterial"
@@ -87378,6 +88769,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -87417,6 +88809,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxFEMMaterial"
@@ -87464,6 +88857,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxFEMMaterial"
@@ -87505,6 +88899,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxFEMMaterial"
@@ -87552,6 +88947,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxFEMMaterial"
@@ -87593,6 +88989,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxFEMMaterial"
@@ -87640,6 +89037,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxFEMMaterial"
@@ -87780,6 +89178,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxFilterData"
@@ -87933,6 +89332,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSimulationFilterCallback"
@@ -87967,6 +89367,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxActor"
@@ -87981,6 +89382,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxShape"
@@ -88009,6 +89411,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxActor"
@@ -88023,6 +89426,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxShape"
@@ -88084,6 +89488,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSimulationFilterCallback"
@@ -88177,6 +89582,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSimulationFilterCallback"
@@ -88257,6 +89663,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxLockedData"
@@ -88301,6 +89708,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxLockedData"
@@ -88334,6 +89742,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxLockedData"
@@ -88380,6 +89789,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMaterial"
@@ -88427,6 +89837,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMaterial"
@@ -88475,6 +89886,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMaterial"
@@ -88522,6 +89934,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMaterial"
@@ -88574,6 +89987,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMaterial"
@@ -88623,6 +90037,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMaterial"
@@ -88673,6 +90088,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMaterial"
@@ -88722,6 +90138,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMaterial"
@@ -88773,6 +90190,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMaterial"
@@ -88838,6 +90256,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMaterial"
@@ -88888,6 +90307,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMaterial"
@@ -88942,6 +90362,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMaterial"
@@ -88995,6 +90416,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMaterial"
@@ -89050,6 +90472,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMaterial"
@@ -89103,6 +90526,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMaterial"
@@ -89139,6 +90563,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMaterial"
@@ -89152,6 +90577,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -89210,6 +90636,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDiffuseParticleParams"
@@ -89249,6 +90676,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxParticleMaterial"
@@ -89296,6 +90724,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxParticleMaterial"
@@ -89337,6 +90766,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxParticleMaterial"
@@ -89384,6 +90814,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxParticleMaterial"
@@ -89425,6 +90856,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxParticleMaterial"
@@ -89472,6 +90904,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxParticleMaterial"
@@ -89513,6 +90946,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxParticleMaterial"
@@ -89560,6 +90994,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxParticleMaterial"
@@ -89602,6 +91037,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxParticleMaterial"
@@ -89649,6 +91085,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxParticleMaterial"
@@ -89703,6 +91140,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPhysics"
@@ -89744,6 +91182,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPhysics"
@@ -89801,6 +91240,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPhysics"
@@ -89832,6 +91272,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxAggregate"
@@ -89870,6 +91311,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPhysics"
@@ -89922,6 +91364,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPhysics"
@@ -89948,6 +91391,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxTriangleMesh"
@@ -89986,6 +91430,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPhysics"
@@ -90033,6 +91478,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPhysics"
@@ -90047,10 +91493,12 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": true,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": false,
+                  "is_array_like": false,
                   "pointee": {
                     "Record": {
                       "name": "PxTriangleMesh"
@@ -90110,6 +91558,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPhysics"
@@ -90136,6 +91585,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxTetrahedronMesh"
@@ -90174,6 +91624,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPhysics"
@@ -90200,6 +91651,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxSoftBodyMesh"
@@ -90238,6 +91690,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPhysics"
@@ -90285,6 +91738,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPhysics"
@@ -90299,10 +91753,12 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": true,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": false,
+                  "is_array_like": false,
                   "pointee": {
                     "Record": {
                       "name": "PxTetrahedronMesh"
@@ -90362,6 +91818,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPhysics"
@@ -90388,6 +91845,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxHeightField"
@@ -90426,6 +91884,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPhysics"
@@ -90473,6 +91932,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPhysics"
@@ -90487,10 +91947,12 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": true,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": false,
+                  "is_array_like": false,
                   "pointee": {
                     "Record": {
                       "name": "PxHeightField"
@@ -90550,6 +92012,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPhysics"
@@ -90576,6 +92039,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxConvexMesh"
@@ -90614,6 +92078,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPhysics"
@@ -90661,6 +92126,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPhysics"
@@ -90675,10 +92141,12 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": true,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": false,
+                  "is_array_like": false,
                   "pointee": {
                     "Record": {
                       "name": "PxConvexMesh"
@@ -90736,6 +92204,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPhysics"
@@ -90762,6 +92231,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxBVH"
@@ -90800,6 +92270,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPhysics"
@@ -90847,6 +92318,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPhysics"
@@ -90861,10 +92333,12 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": true,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": false,
+                  "is_array_like": false,
                   "pointee": {
                     "Record": {
                       "name": "PxBVH"
@@ -90925,6 +92399,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPhysics"
@@ -90951,6 +92426,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxScene"
@@ -90989,6 +92465,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPhysics"
@@ -91036,6 +92513,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPhysics"
@@ -91050,10 +92528,12 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": true,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": false,
+                  "is_array_like": false,
                   "pointee": {
                     "Record": {
                       "name": "PxScene"
@@ -91110,6 +92590,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPhysics"
@@ -91136,6 +92617,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxRigidStatic"
@@ -91173,6 +92655,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPhysics"
@@ -91199,6 +92682,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxRigidDynamic"
@@ -91245,6 +92729,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPhysics"
@@ -91259,10 +92744,12 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": false,
+                  "is_array_like": false,
                   "pointee": {
                     "Record": {
                       "name": "PxRigidActor"
@@ -91284,6 +92771,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxPruningStructure"
@@ -91326,6 +92814,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPhysics"
@@ -91380,6 +92869,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxShape"
@@ -91424,6 +92914,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPhysics"
@@ -91451,10 +92942,12 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": false,
+                  "is_array_like": false,
                   "pointee": {
                     "Record": {
                       "name": "PxMaterial"
@@ -91491,6 +92984,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxShape"
@@ -91529,6 +93023,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPhysics"
@@ -91576,6 +93071,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPhysics"
@@ -91590,10 +93086,12 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": true,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": false,
+                  "is_array_like": false,
                   "pointee": {
                     "Record": {
                       "name": "PxShape"
@@ -91654,6 +93152,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPhysics"
@@ -91668,6 +93167,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidActor"
@@ -91682,6 +93182,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidActor"
@@ -91727,6 +93228,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxConstraint"
@@ -91765,6 +93267,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPhysics"
@@ -91778,6 +93281,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxArticulationReducedCoordinate"
@@ -91816,6 +93320,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPhysics"
@@ -91847,6 +93352,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxMaterial"
@@ -91885,6 +93391,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPhysics"
@@ -91932,6 +93439,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPhysics"
@@ -91946,10 +93454,12 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": true,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": false,
+                  "is_array_like": false,
                   "pointee": {
                     "Record": {
                       "name": "PxMaterial"
@@ -92011,6 +93521,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPhysics"
@@ -92085,6 +93596,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPhysics"
@@ -92143,6 +93655,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPhysics"
@@ -92170,10 +93683,12 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": true,
+                  "is_array_like": false,
                   "pointee": {
                     "Record": {
                       "name": "PxBase"
@@ -92227,6 +93742,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPhysics"
@@ -92254,10 +93770,12 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": true,
+                  "is_array_like": false,
                   "pointee": {
                     "Record": {
                       "name": "PxBase"
@@ -92307,6 +93825,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPhysics"
@@ -92403,6 +93922,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPvd"
@@ -92417,6 +93937,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxOmniPvd"
@@ -92430,6 +93951,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxPhysics"
@@ -92491,6 +94013,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidActor"
@@ -92505,6 +94028,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxShape"
@@ -92568,6 +94092,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxShape"
@@ -92724,6 +94249,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQueryFilterCallback"
@@ -92751,6 +94277,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxShape"
@@ -92765,6 +94292,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidActor"
@@ -92826,6 +94354,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQueryFilterCallback"
@@ -92866,6 +94395,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxShape"
@@ -92880,6 +94410,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidActor"
@@ -92919,6 +94450,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQueryFilterCallback"
@@ -92976,6 +94508,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidDynamic"
@@ -93030,6 +94563,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidDynamic"
@@ -93119,6 +94653,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidDynamic"
@@ -93165,6 +94700,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidDynamic"
@@ -93212,6 +94748,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidDynamic"
@@ -93260,6 +94797,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidDynamic"
@@ -93309,6 +94847,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidDynamic"
@@ -93354,6 +94893,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidDynamic"
@@ -93403,6 +94943,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidDynamic"
@@ -93449,6 +94990,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidDynamic"
@@ -93502,6 +95044,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidDynamic"
@@ -93556,6 +95099,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidDynamic"
@@ -93617,6 +95161,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidDynamic"
@@ -93670,6 +95215,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidDynamic"
@@ -93740,6 +95286,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidDynamic"
@@ -93789,6 +95336,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidDynamic"
@@ -93839,6 +95387,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidDynamic"
@@ -93887,6 +95436,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidDynamic"
@@ -93937,6 +95487,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidDynamic"
@@ -93988,6 +95539,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidDynamic"
@@ -94064,6 +95616,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidDynamic"
@@ -94107,6 +95660,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidDynamic"
@@ -94143,6 +95697,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidDynamic"
@@ -94156,6 +95711,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -94181,6 +95737,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidStatic"
@@ -94194,6 +95751,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -94252,6 +95810,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSceneQueryDesc"
@@ -94293,6 +95852,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSceneQueryDesc"
@@ -94334,6 +95894,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSceneQuerySystemBase"
@@ -94381,6 +95942,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSceneQuerySystemBase"
@@ -94424,6 +95986,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSceneQuerySystemBase"
@@ -94469,6 +96032,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSceneQuerySystemBase"
@@ -94520,6 +96084,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSceneQuerySystemBase"
@@ -94568,6 +96133,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSceneQuerySystemBase"
@@ -94619,6 +96185,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSceneQuerySystemBase"
@@ -94665,6 +96232,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSceneQuerySystemBase"
@@ -94742,6 +96310,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQueryFilterCallback"
@@ -94756,6 +96325,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQueryCache"
@@ -94814,6 +96384,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSceneQuerySystemBase"
@@ -94906,6 +96477,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQueryFilterCallback"
@@ -94920,6 +96492,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQueryCache"
@@ -94985,6 +96558,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSceneQuerySystemBase"
@@ -95051,6 +96625,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQueryFilterCallback"
@@ -95065,6 +96640,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQueryCache"
@@ -95115,6 +96691,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSceneSQSystem"
@@ -95166,6 +96743,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSceneSQSystem"
@@ -95214,6 +96792,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSceneSQSystem"
@@ -95255,6 +96834,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSceneSQSystem"
@@ -95294,6 +96874,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSceneSQSystem"
@@ -95345,6 +96926,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSceneSQSystem"
@@ -95390,6 +96972,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSceneSQSystem"
@@ -95455,6 +97038,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSceneSQSystem"
@@ -95469,6 +97053,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBaseTask"
@@ -95519,6 +97104,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSceneSQSystem"
@@ -95569,6 +97155,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSceneSQSystem"
@@ -95616,6 +97203,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSceneQuerySystem"
@@ -95657,6 +97245,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSceneQuerySystem"
@@ -95699,6 +97288,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSceneQuerySystem"
@@ -95754,6 +97344,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSceneQuerySystem"
@@ -95795,6 +97386,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSceneQuerySystem"
@@ -95861,6 +97453,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "UInt"
               }
@@ -95906,6 +97499,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSceneQuerySystem"
@@ -95977,6 +97571,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSceneQuerySystem"
@@ -96057,6 +97652,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSceneQuerySystem"
@@ -96084,10 +97680,12 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": true,
+                  "is_array_like": false,
                   "pointee": {
                     "Record": {
                       "name": "PxShape"
@@ -96117,6 +97715,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTransform"
@@ -96158,6 +97757,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSceneQuerySystem"
@@ -96205,6 +97805,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSceneQuerySystem"
@@ -96265,6 +97866,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSceneQuerySystem"
@@ -96315,6 +97917,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSceneQuerySystem"
@@ -96372,6 +97975,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSceneQuerySystem"
@@ -96456,6 +98060,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSceneQuerySystem"
@@ -96476,6 +98081,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "UInt"
               }
@@ -96488,6 +98094,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "UInt"
               }
@@ -96500,6 +98107,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBounds3"
@@ -96514,6 +98122,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTransformPadded"
@@ -96584,6 +98193,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSceneQuerySystem"
@@ -96635,6 +98245,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSceneQuerySystem"
@@ -96654,6 +98265,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Void"
           }
@@ -96693,6 +98305,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSceneQuerySystem"
@@ -96707,6 +98320,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -96761,6 +98375,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBroadPhaseDesc"
@@ -96897,6 +98512,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "UInt"
               }
@@ -96915,6 +98531,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "UInt"
               }
@@ -96933,6 +98550,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "UInt"
               }
@@ -96951,6 +98569,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBounds3"
@@ -96965,6 +98584,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "UInt"
               }
@@ -96977,6 +98597,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Float"
               }
@@ -97041,6 +98662,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBroadPhaseRegions"
@@ -97084,6 +98706,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBroadPhaseRegions"
@@ -97098,6 +98721,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": true,
               "pointee": {
                 "Record": {
                   "name": "PxBroadPhaseRegionInfo"
@@ -97172,6 +98796,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBroadPhaseRegions"
@@ -97205,6 +98830,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBounds3"
@@ -97219,6 +98845,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Float"
               }
@@ -97267,6 +98894,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBroadPhaseRegions"
@@ -97305,6 +98933,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBroadPhaseRegions"
@@ -97337,6 +98966,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBroadPhaseRegions"
@@ -97350,6 +98980,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "UInt"
           }
@@ -97375,6 +99006,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBroadPhase"
@@ -97416,6 +99048,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBroadPhase"
@@ -97461,6 +99094,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBroadPhase"
@@ -97517,6 +99151,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBroadPhase"
@@ -97530,6 +99165,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxBroadPhaseRegions"
@@ -97572,6 +99208,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBroadPhase"
@@ -97585,6 +99222,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxAllocatorCallback"
@@ -97623,6 +99261,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBroadPhase"
@@ -97669,6 +99308,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBroadPhase"
@@ -97683,6 +99323,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -97732,6 +99373,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBroadPhase"
@@ -97759,6 +99401,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBaseTask"
@@ -97801,6 +99444,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBroadPhase"
@@ -97855,6 +99499,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBroadPhase"
@@ -97935,6 +99580,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxBroadPhase"
@@ -97962,6 +99608,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxAABBManager"
@@ -98003,6 +99650,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxAABBManager"
@@ -98055,6 +99703,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxAABBManager"
@@ -98068,6 +99717,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxBounds3"
@@ -98108,6 +99758,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxAABBManager"
@@ -98121,6 +99772,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Float"
           }
@@ -98157,6 +99809,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxAABBManager"
@@ -98170,6 +99823,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "UInt"
           }
@@ -98208,6 +99862,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxAABBManager"
@@ -98253,6 +99908,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxAABBManager"
@@ -98323,6 +99979,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxAABBManager"
@@ -98371,6 +100028,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxAABBManager"
@@ -98391,6 +100049,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBounds3"
@@ -98405,6 +100064,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Float"
               }
@@ -98448,6 +100108,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxAABBManager"
@@ -98462,6 +100123,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBaseTask"
@@ -98504,6 +100166,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxAABBManager"
@@ -98558,6 +100221,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxAABBManager"
@@ -98625,6 +100289,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxAABBManager"
@@ -98685,6 +100350,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSceneLimits"
@@ -98726,6 +100392,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSceneLimits"
@@ -98773,6 +100440,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxgDynamicsMemoryConfig"
@@ -98852,6 +100520,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSceneDesc"
@@ -98906,6 +100575,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSceneDesc"
@@ -98938,6 +100608,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSceneDesc"
@@ -98988,6 +100659,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSimulationStatistics"
@@ -99031,6 +100703,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSimulationStatistics"
@@ -99079,6 +100752,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSimulationStatistics"
@@ -99165,6 +100839,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPvdSceneClient"
@@ -99220,6 +100895,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPvdSceneClient"
@@ -99268,6 +100944,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPvdSceneClient"
@@ -99312,6 +100989,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPvdSceneClient"
@@ -99326,6 +101004,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -99396,6 +101075,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPvdSceneClient"
@@ -99410,6 +101090,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDebugPoint"
@@ -99455,6 +101136,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPvdSceneClient"
@@ -99469,6 +101151,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDebugLine"
@@ -99514,6 +101197,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPvdSceneClient"
@@ -99528,6 +101212,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDebugTriangle"
@@ -99573,6 +101258,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPvdSceneClient"
@@ -99638,6 +101324,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBroadPhaseCallback"
@@ -99679,6 +101366,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBroadPhaseCallback"
@@ -99746,6 +101434,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBroadPhaseCallback"
@@ -99804,6 +101493,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -99845,6 +101535,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -99902,6 +101593,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -99950,6 +101642,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -100004,6 +101697,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -100049,6 +101743,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -100099,6 +101794,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -100144,6 +101840,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -100202,6 +101899,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -100276,6 +101974,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -100303,6 +102002,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBVH"
@@ -100358,6 +102058,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -100372,10 +102073,12 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": false,
+                  "is_array_like": false,
                   "pointee": {
                     "Record": {
                       "name": "PxActor"
@@ -100442,6 +102145,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -100504,6 +102208,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -100571,6 +102276,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -100585,10 +102291,12 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": false,
+                  "is_array_like": false,
                   "pointee": {
                     "Record": {
                       "name": "PxActor"
@@ -100650,6 +102358,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -100708,6 +102417,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -100773,6 +102483,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -100829,6 +102540,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -100881,6 +102593,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -100904,10 +102617,12 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": true,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": false,
+                  "is_array_like": false,
                   "pointee": {
                     "Record": {
                       "name": "PxActor"
@@ -100970,6 +102685,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -100994,10 +102710,12 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxActor"
@@ -101038,6 +102756,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -101081,6 +102800,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -101095,10 +102815,12 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": true,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": false,
+                  "is_array_like": false,
                   "pointee": {
                     "Record": {
                       "name": "PxArticulationReducedCoordinate"
@@ -101156,6 +102878,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -101199,6 +102922,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -101213,10 +102937,12 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": true,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": false,
+                  "is_array_like": false,
                   "pointee": {
                     "Record": {
                       "name": "PxConstraint"
@@ -101274,6 +103000,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -101317,6 +103044,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -101331,10 +103059,12 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": true,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": false,
+                  "is_array_like": false,
                   "pointee": {
                     "Record": {
                       "name": "PxAggregate"
@@ -101439,6 +103169,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -101503,6 +103234,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -101558,6 +103290,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -101571,6 +103304,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxCpuDispatcher"
@@ -101611,6 +103345,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -101654,6 +103389,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -101668,6 +103404,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSimulationEventCallback"
@@ -101709,6 +103446,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -101722,6 +103460,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxSimulationEventCallback"
@@ -101760,6 +103499,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -101774,6 +103514,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactModifyCallback"
@@ -101815,6 +103556,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -101829,6 +103571,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCCDContactModifyCallback"
@@ -101870,6 +103613,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -101883,6 +103627,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxContactModifyCallback"
@@ -101921,6 +103666,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -101934,6 +103680,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxCCDContactModifyCallback"
@@ -101972,6 +103719,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -101986,6 +103734,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBroadPhaseCallback"
@@ -102027,6 +103776,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -102040,6 +103790,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxBroadPhaseCallback"
@@ -102084,6 +103835,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -102098,6 +103850,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -102145,6 +103898,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -102158,6 +103912,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Void"
           }
@@ -102194,6 +103949,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -102262,6 +104018,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -102326,6 +104083,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -102353,10 +104111,12 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": false,
+                  "is_array_like": false,
                   "pointee": {
                     "Record": {
                       "name": "PxShape"
@@ -102408,6 +104168,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -102455,6 +104216,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -102517,6 +104279,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -102537,6 +104300,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBaseTask"
@@ -102551,6 +104315,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -102606,6 +104371,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -102620,6 +104386,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBaseTask"
@@ -102665,6 +104432,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -102685,6 +104453,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBaseTask"
@@ -102699,6 +104468,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -102755,6 +104525,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -102803,6 +104574,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -102852,6 +104624,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -102872,6 +104645,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "UInt"
               }
@@ -102917,6 +104691,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -102934,6 +104709,7 @@
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": true,
+                  "is_array_like": false,
                   "pointee": {
                     "Record": {
                       "name": "PxContactPairHeader"
@@ -102997,6 +104773,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -103011,6 +104788,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBaseTask"
@@ -103054,6 +104832,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -103068,6 +104847,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "UInt"
               }
@@ -103105,6 +104885,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -103149,6 +104930,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -103201,6 +104983,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -103253,6 +105036,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -103296,6 +105080,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -103341,6 +105126,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -103384,6 +105170,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -103431,6 +105218,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -103474,6 +105262,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -103521,6 +105310,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -103564,6 +105354,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -103611,6 +105402,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -103654,6 +105446,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -103701,6 +105494,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -103744,6 +105538,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -103789,6 +105584,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -103832,6 +105628,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -103877,6 +105674,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -103918,6 +105716,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -103963,6 +105762,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -104014,6 +105814,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -104073,6 +105874,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -104126,6 +105928,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -104180,6 +105983,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -104229,6 +106033,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -104279,6 +106084,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -104333,6 +106139,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -104380,6 +106187,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -104436,6 +106244,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -104479,6 +106288,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -104493,6 +106303,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": true,
               "pointee": {
                 "Record": {
                   "name": "PxBroadPhaseRegionInfo"
@@ -104569,6 +106380,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -104638,6 +106450,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -104687,6 +106500,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -104700,6 +106514,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxTaskManager"
@@ -104748,6 +106563,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -104762,6 +106578,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -104807,6 +106624,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -104865,6 +106683,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -104879,6 +106698,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -104924,6 +106744,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -104971,6 +106792,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -105020,6 +106842,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -105065,6 +106888,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -105106,6 +106930,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -105149,6 +106974,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -105196,6 +107022,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -105239,6 +107066,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -105286,6 +107114,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -105329,6 +107158,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -105381,6 +107211,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -105433,6 +107264,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -105446,6 +107278,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxPvdSceneClient"
@@ -105482,6 +107315,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -105496,6 +107330,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -105508,6 +107343,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -105536,6 +107372,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -105573,6 +107410,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -105587,6 +107425,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -105599,6 +107438,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -105627,6 +107467,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -105639,6 +107480,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -105676,6 +107518,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -105690,10 +107533,12 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": false,
+                  "is_array_like": false,
                   "pointee": {
                     "Builtin": "Void"
                   }
@@ -105708,6 +107553,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -105720,6 +107566,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -105754,6 +107601,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -105791,6 +107639,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -105805,10 +107654,12 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": false,
+                  "is_array_like": false,
                   "pointee": {
                     "Builtin": "Void"
                   }
@@ -105823,6 +107674,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -105835,6 +107687,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -105869,6 +107722,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -105908,6 +107762,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -105922,6 +107777,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -105940,6 +107796,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -105952,6 +107809,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -105989,6 +107847,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -106003,6 +107862,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxGpuBodyData"
@@ -106017,6 +107877,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxGpuActorPair"
@@ -106037,6 +107898,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -106074,6 +107936,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -106088,6 +107951,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -106100,6 +107964,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxGpuActorPair"
@@ -106130,6 +107995,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -106142,6 +108008,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -106187,6 +108054,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -106201,6 +108069,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxIndexDataPair"
@@ -106221,6 +108090,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -106265,6 +108135,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -106279,6 +108150,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxIndexDataPair"
@@ -106299,6 +108171,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -106343,6 +108216,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -106357,6 +108231,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxIndexDataPair"
@@ -106377,6 +108252,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -106421,6 +108297,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -106435,6 +108312,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxIndexDataPair"
@@ -106455,6 +108333,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -106483,6 +108362,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -106531,6 +108411,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxScene"
@@ -106545,6 +108426,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "UInt"
               }
@@ -106557,6 +108439,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxGpuParticleBufferIndexPair"
@@ -106571,6 +108454,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Flags": {
                   "name": "PxParticleBufferFlags",
@@ -106592,6 +108476,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -106604,6 +108489,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -106650,6 +108536,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -106667,6 +108554,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxSceneReadLock"
@@ -106688,6 +108576,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSceneReadLock"
@@ -106736,6 +108625,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -106753,6 +108643,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxSceneWriteLock"
@@ -106774,6 +108665,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSceneWriteLock"
@@ -106869,6 +108761,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "UChar"
               }
@@ -106929,6 +108822,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactPairExtraDataIterator"
@@ -107002,6 +108896,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactPair"
@@ -107016,6 +108911,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": true,
               "pointee": {
                 "Record": {
                   "name": "PxContactPairPoint"
@@ -107066,6 +108962,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactPair"
@@ -107080,6 +108977,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactPair"
@@ -107094,6 +108992,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "UChar"
               }
@@ -107122,6 +109021,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactPair"
@@ -107135,6 +109035,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "UInt"
           }
@@ -107186,6 +109087,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConstraint"
@@ -107200,6 +109102,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -107251,6 +109154,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSimulationEventCallback"
@@ -107265,6 +109169,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConstraintInfo"
@@ -107321,6 +109226,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSimulationEventCallback"
@@ -107335,10 +109241,12 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": false,
+                  "is_array_like": false,
                   "pointee": {
                     "Record": {
                       "name": "PxActor"
@@ -107398,6 +109306,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSimulationEventCallback"
@@ -107412,10 +109321,12 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": false,
+                  "is_array_like": false,
                   "pointee": {
                     "Record": {
                       "name": "PxActor"
@@ -107470,6 +109381,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSimulationEventCallback"
@@ -107497,6 +109409,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactPair"
@@ -107547,6 +109460,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSimulationEventCallback"
@@ -107561,6 +109475,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTriggerPair"
@@ -107618,6 +109533,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSimulationEventCallback"
@@ -107632,10 +109548,12 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": true,
+                  "is_array_like": false,
                   "pointee": {
                     "Record": {
                       "name": "PxRigidBody"
@@ -107652,6 +109570,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTransform"
@@ -107682,6 +109601,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSimulationEventCallback"
@@ -107736,6 +109656,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPruningStructure"
@@ -107779,6 +109700,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPruningStructure"
@@ -107793,10 +109715,12 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": true,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": false,
+                  "is_array_like": false,
                   "pointee": {
                     "Record": {
                       "name": "PxRigidActor"
@@ -107856,6 +109780,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPruningStructure"
@@ -107902,6 +109827,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPruningStructure"
@@ -107915,6 +109841,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Void"
           }
@@ -107954,6 +109881,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPruningStructure"
@@ -107967,6 +109895,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Void"
           }
@@ -107992,6 +109921,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPruningStructure"
@@ -108005,6 +109935,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -108079,6 +110010,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxExtendedVec3"
@@ -108111,6 +110043,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxExtendedVec3"
@@ -108154,6 +110087,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxExtendedVec3"
@@ -108199,6 +110133,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxExtendedVec3"
@@ -108231,6 +110166,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxExtendedVec3"
@@ -108263,6 +110199,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxExtendedVec3"
@@ -108295,6 +110232,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxExtendedVec3"
@@ -108327,6 +110265,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxExtendedVec3"
@@ -108370,6 +110309,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxExtendedVec3"
@@ -108413,6 +110353,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxExtendedVec3"
@@ -108461,6 +110402,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxExtendedVec3"
@@ -108491,6 +110433,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxExtendedVec3"
@@ -108521,6 +110464,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxExtendedVec3"
@@ -108575,6 +110519,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxExtendedVec3"
@@ -108631,6 +110576,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxExtendedVec3"
@@ -108678,6 +110624,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxExtendedVec3"
@@ -108762,6 +110709,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxObstacle"
@@ -108837,6 +110785,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxObstacleContext"
@@ -108878,6 +110827,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxObstacleContext"
@@ -108928,6 +110878,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxObstacleContext"
@@ -108984,6 +110935,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxObstacleContext"
@@ -109033,6 +110985,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxObstacleContext"
@@ -109095,6 +111048,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxObstacleContext"
@@ -109138,6 +111092,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxObstacleContext"
@@ -109157,6 +111112,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxObstacle"
@@ -109195,6 +111151,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxObstacleContext"
@@ -109214,6 +111171,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxObstacle"
@@ -109252,6 +111210,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxUserControllerHitReport"
@@ -109304,6 +111263,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxUserControllerHitReport"
@@ -109356,6 +111316,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxUserControllerHitReport"
@@ -109393,6 +111354,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxControllerFilterCallback"
@@ -109434,6 +111396,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxControllerFilterCallback"
@@ -109488,6 +111451,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxFilterData"
@@ -109502,6 +111466,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQueryFilterCallback"
@@ -109516,6 +111481,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxControllerFilterCallback"
@@ -109561,6 +111527,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxControllerDesc"
@@ -109604,6 +111571,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxControllerDesc"
@@ -109649,6 +111617,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxController"
@@ -109694,6 +111663,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxController"
@@ -109735,6 +111705,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxController"
@@ -109785,6 +111756,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxObstacleContext"
@@ -109839,6 +111811,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxController"
@@ -109901,6 +111874,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxController"
@@ -109959,6 +111933,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxController"
@@ -110017,6 +111992,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxController"
@@ -110064,6 +112040,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxController"
@@ -110077,6 +112054,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxRigidDynamic"
@@ -110113,6 +112091,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxController"
@@ -110160,6 +112139,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxController"
@@ -110201,6 +112181,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxController"
@@ -110252,6 +112233,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxController"
@@ -110299,6 +112281,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxController"
@@ -110340,6 +112323,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxController"
@@ -110387,6 +112371,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxController"
@@ -110428,6 +112413,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxController"
@@ -110480,6 +112466,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxController"
@@ -110525,6 +112512,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxController"
@@ -110580,6 +112568,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxController"
@@ -110621,6 +112610,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxController"
@@ -110634,6 +112624,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxScene"
@@ -110672,6 +112663,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxController"
@@ -110685,6 +112677,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Void"
           }
@@ -110719,6 +112712,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxController"
@@ -110733,6 +112727,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -110770,6 +112765,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxController"
@@ -110822,6 +112818,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxController"
@@ -110879,6 +112876,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxController"
@@ -110918,6 +112916,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxBoxControllerDesc"
@@ -110939,6 +112938,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBoxControllerDesc"
@@ -110978,6 +112978,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBoxControllerDesc"
@@ -111019,6 +113020,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBoxControllerDesc"
@@ -111062,6 +113064,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBoxController"
@@ -111105,6 +113108,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBoxController"
@@ -111148,6 +113152,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBoxController"
@@ -111193,6 +113198,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBoxController"
@@ -111244,6 +113250,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBoxController"
@@ -111295,6 +113302,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBoxController"
@@ -111336,6 +113344,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxCapsuleControllerDesc"
@@ -111357,6 +113366,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCapsuleControllerDesc"
@@ -111396,6 +113406,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCapsuleControllerDesc"
@@ -111437,6 +113448,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCapsuleControllerDesc"
@@ -111480,6 +113492,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCapsuleController"
@@ -111525,6 +113538,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCapsuleController"
@@ -111574,6 +113588,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCapsuleController"
@@ -111619,6 +113634,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCapsuleController"
@@ -111668,6 +113684,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCapsuleController"
@@ -111713,6 +113730,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCapsuleController"
@@ -111771,6 +113789,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxControllerBehaviorCallback"
@@ -111850,6 +113869,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxControllerBehaviorCallback"
@@ -111914,6 +113934,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxControllerBehaviorCallback"
@@ -111975,6 +113996,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxControllerManager"
@@ -112016,6 +114038,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxControllerManager"
@@ -112066,6 +114089,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxControllerManager"
@@ -112109,6 +114133,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxControllerManager"
@@ -112128,6 +114153,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxController"
@@ -112166,6 +114192,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxControllerManager"
@@ -112192,6 +114219,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxController"
@@ -112228,6 +114256,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxControllerManager"
@@ -112269,6 +114298,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxControllerManager"
@@ -112317,6 +114347,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxControllerManager"
@@ -112367,6 +114398,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxControllerManager"
@@ -112410,6 +114442,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxControllerManager"
@@ -112429,6 +114462,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxObstacleContext"
@@ -112467,6 +114501,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxControllerManager"
@@ -112480,6 +114515,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxObstacleContext"
@@ -112527,6 +114563,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxControllerManager"
@@ -112547,6 +114584,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxControllerFilterCallback"
@@ -112593,6 +114631,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxControllerManager"
@@ -112658,6 +114697,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxControllerManager"
@@ -112707,6 +114747,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxControllerManager"
@@ -112762,6 +114803,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxControllerManager"
@@ -112814,6 +114856,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxControllerManager"
@@ -112891,6 +114934,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxControllerManager"
@@ -112968,6 +115012,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSDFDesc"
@@ -113033,6 +115078,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConvexMeshDesc"
@@ -113074,6 +115120,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxConvexMeshDesc"
@@ -113139,6 +115186,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTriangleMeshDesc"
@@ -113180,6 +115228,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTriangleMeshDesc"
@@ -113236,6 +115285,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTetrahedronMeshDesc"
@@ -113292,6 +115342,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSoftBodySimulationDataDesc"
@@ -113333,6 +115384,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBVH34MidphaseDesc"
@@ -113374,6 +115426,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBVH34MidphaseDesc"
@@ -113432,6 +115485,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMidphaseDesc"
@@ -113477,6 +115531,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMidphaseDesc"
@@ -113528,6 +115583,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMidphaseDesc"
@@ -113584,6 +115640,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBVHDesc"
@@ -113625,6 +115682,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBVHDesc"
@@ -113683,6 +115741,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxInsertionCallback"
@@ -113809,6 +115868,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxBVH"
@@ -113930,6 +115990,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxHeightField"
@@ -114016,6 +116077,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Enum": {
                   "name": "PxConvexMeshCookingResult",
@@ -114106,6 +116168,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Enum": {
                   "name": "PxConvexMeshCookingResult",
@@ -114121,6 +116184,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxConvexMesh"
@@ -114275,6 +116339,7 @@
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": false,
+                  "is_array_like": false,
                   "pointee": {
                     "Builtin": "Vec3"
                   }
@@ -114303,6 +116368,7 @@
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": false,
+                  "is_array_like": false,
                   "pointee": {
                     "Builtin": "UInt"
                   }
@@ -114331,6 +116397,7 @@
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": false,
+                  "is_array_like": false,
                   "pointee": {
                     "Record": {
                       "name": "PxHullPolygon"
@@ -114479,6 +116546,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Enum": {
                   "name": "PxTriangleMeshCookingResult",
@@ -114494,6 +116562,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxTriangleMesh"
@@ -114576,6 +116645,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Enum": {
                   "name": "PxTriangleMeshCookingResult",
@@ -114618,6 +116688,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxDefaultMemoryOutputStream"
@@ -114639,6 +116710,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDefaultMemoryOutputStream"
@@ -114669,6 +116741,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDefaultMemoryOutputStream"
@@ -114683,6 +116756,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -114719,6 +116793,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDefaultMemoryOutputStream"
@@ -114751,6 +116826,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDefaultMemoryOutputStream"
@@ -114764,6 +116840,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "UChar"
           }
@@ -114785,6 +116862,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "UChar"
               }
@@ -114802,6 +116880,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxDefaultMemoryInputData"
@@ -114829,6 +116908,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDefaultMemoryInputData"
@@ -114843,6 +116923,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -114879,6 +116960,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDefaultMemoryInputData"
@@ -114911,6 +116993,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDefaultMemoryInputData"
@@ -114947,6 +117030,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDefaultMemoryInputData"
@@ -114975,6 +117059,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -114986,6 +117071,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxDefaultFileOutputStream"
@@ -115007,6 +117093,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDefaultFileOutputStream"
@@ -115037,6 +117124,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDefaultFileOutputStream"
@@ -115051,6 +117139,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -115087,6 +117176,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDefaultFileOutputStream"
@@ -115115,6 +117205,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -115126,6 +117217,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxDefaultFileInputData"
@@ -115147,6 +117239,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDefaultFileInputData"
@@ -115177,6 +117270,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDefaultFileInputData"
@@ -115191,6 +117285,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -115227,6 +117322,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDefaultFileInputData"
@@ -115263,6 +117359,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDefaultFileInputData"
@@ -115295,6 +117392,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDefaultFileInputData"
@@ -115327,6 +117425,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDefaultFileInputData"
@@ -115363,6 +117462,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Void"
           }
@@ -115387,6 +117487,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -115415,6 +117516,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDefaultAllocator"
@@ -115435,6 +117537,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -115447,6 +117550,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -115464,6 +117568,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Void"
           }
@@ -115489,6 +117594,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDefaultAllocator"
@@ -115503,6 +117609,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -115525,6 +117632,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDefaultAllocator"
@@ -115566,6 +117674,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxJoint"
@@ -115580,6 +117689,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidActor"
@@ -115594,6 +117704,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidActor"
@@ -115633,6 +117744,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxJoint"
@@ -115650,6 +117762,7 @@
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": false,
+                  "is_array_like": false,
                   "pointee": {
                     "Record": {
                       "name": "PxRigidActor"
@@ -115669,6 +117782,7 @@
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": false,
+                  "is_array_like": false,
                   "pointee": {
                     "Record": {
                       "name": "PxRigidActor"
@@ -115712,6 +117826,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxJoint"
@@ -115776,6 +117891,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxJoint"
@@ -115831,6 +117947,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxJoint"
@@ -115877,6 +117994,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxJoint"
@@ -115920,6 +118038,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxJoint"
@@ -115965,6 +118084,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxJoint"
@@ -116016,6 +118136,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxJoint"
@@ -116077,6 +118198,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxJoint"
@@ -116125,6 +118247,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxJoint"
@@ -116182,6 +118305,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxJoint"
@@ -116226,6 +118350,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxJoint"
@@ -116273,6 +118398,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxJoint"
@@ -116314,6 +118440,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxJoint"
@@ -116361,6 +118488,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxJoint"
@@ -116402,6 +118530,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxJoint"
@@ -116449,6 +118578,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxJoint"
@@ -116490,6 +118620,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxJoint"
@@ -116537,6 +118668,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxJoint"
@@ -116582,6 +118714,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxJoint"
@@ -116595,6 +118728,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxConstraint"
@@ -116634,6 +118768,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxJoint"
@@ -116648,6 +118783,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -116687,6 +118823,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxJoint"
@@ -116700,6 +118837,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -116736,6 +118874,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxJoint"
@@ -116777,6 +118916,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxJoint"
@@ -116790,6 +118930,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxScene"
@@ -116915,6 +119056,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Vec3"
               }
@@ -116927,6 +119069,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Vec3"
               }
@@ -116976,6 +119119,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidActor"
@@ -117003,6 +119147,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidActor"
@@ -117029,6 +119174,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxDistanceJoint"
@@ -117065,6 +119211,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDistanceJoint"
@@ -117113,6 +119260,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDistanceJoint"
@@ -117160,6 +119308,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDistanceJoint"
@@ -117208,6 +119357,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDistanceJoint"
@@ -117255,6 +119405,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDistanceJoint"
@@ -117296,6 +119447,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDistanceJoint"
@@ -117351,6 +119503,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDistanceJoint"
@@ -117399,6 +119552,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDistanceJoint"
@@ -117446,6 +119600,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDistanceJoint"
@@ -117494,6 +119649,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDistanceJoint"
@@ -117541,6 +119697,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDistanceJoint"
@@ -117596,6 +119753,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDistanceJoint"
@@ -117643,6 +119801,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDistanceJoint"
@@ -117687,6 +119846,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDistanceJoint"
@@ -117735,6 +119895,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDistanceJoint"
@@ -117792,6 +119953,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDistanceJoint"
@@ -117836,6 +119998,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDistanceJoint"
@@ -117849,6 +120012,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -117895,6 +120059,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidActor"
@@ -117922,6 +120087,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidActor"
@@ -117948,6 +120114,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxContactJoint"
@@ -118059,6 +120226,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactJoint"
@@ -118109,6 +120277,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactJoint"
@@ -118159,6 +120328,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactJoint"
@@ -118204,6 +120374,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactJoint"
@@ -118245,6 +120416,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactJoint"
@@ -118286,6 +120458,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactJoint"
@@ -118318,6 +120491,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactJoint"
@@ -118350,6 +120524,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactJoint"
@@ -118386,6 +120561,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactJoint"
@@ -118418,6 +120594,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactJoint"
@@ -118463,6 +120640,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactJoint"
@@ -118476,6 +120654,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -118501,6 +120680,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactJoint"
@@ -118515,6 +120695,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxJacobianRow"
@@ -118545,6 +120726,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxContactJoint"
@@ -118598,6 +120780,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidActor"
@@ -118625,6 +120808,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidActor"
@@ -118651,6 +120835,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxFixedJoint"
@@ -118687,6 +120872,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxFixedJoint"
@@ -118700,6 +120886,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -118719,6 +120906,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxJointLimitParameters"
@@ -118757,6 +120945,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxJointLimitParameters"
@@ -118789,6 +120978,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxJointLimitParameters"
@@ -118926,6 +121116,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxJointLinearLimit"
@@ -118952,6 +121143,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxJointLinearLimit"
@@ -119099,6 +121291,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxJointLinearLimitPair"
@@ -119125,6 +121318,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxJointLinearLimitPair"
@@ -119263,6 +121457,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxJointAngularLimitPair"
@@ -119289,6 +121484,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxJointAngularLimitPair"
@@ -119423,6 +121619,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxJointLimitCone"
@@ -119449,6 +121646,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxJointLimitCone"
@@ -119607,6 +121805,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxJointLimitPyramid"
@@ -119633,6 +121832,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxJointLimitPyramid"
@@ -119684,6 +121884,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidActor"
@@ -119711,6 +121912,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidActor"
@@ -119737,6 +121939,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxPrismaticJoint"
@@ -119773,6 +121976,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPrismaticJoint"
@@ -119814,6 +122018,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPrismaticJoint"
@@ -119858,6 +122063,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPrismaticJoint"
@@ -119910,6 +122116,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPrismaticJoint"
@@ -119956,6 +122163,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPrismaticJoint"
@@ -120004,6 +122212,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPrismaticJoint"
@@ -120061,6 +122270,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPrismaticJoint"
@@ -120105,6 +122315,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPrismaticJoint"
@@ -120118,6 +122329,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -120164,6 +122376,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidActor"
@@ -120191,6 +122404,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidActor"
@@ -120217,6 +122431,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxRevoluteJoint"
@@ -120253,6 +122468,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRevoluteJoint"
@@ -120294,6 +122510,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRevoluteJoint"
@@ -120339,6 +122556,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRevoluteJoint"
@@ -120393,6 +122611,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRevoluteJoint"
@@ -120449,6 +122668,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRevoluteJoint"
@@ -120502,6 +122722,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRevoluteJoint"
@@ -120550,6 +122771,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRevoluteJoint"
@@ -120597,6 +122819,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRevoluteJoint"
@@ -120646,6 +122869,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRevoluteJoint"
@@ -120693,6 +122917,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRevoluteJoint"
@@ -120737,6 +122962,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRevoluteJoint"
@@ -120785,6 +123011,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRevoluteJoint"
@@ -120842,6 +123069,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRevoluteJoint"
@@ -120886,6 +123114,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRevoluteJoint"
@@ -120899,6 +123128,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -120945,6 +123175,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidActor"
@@ -120972,6 +123203,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidActor"
@@ -120998,6 +123230,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxSphericalJoint"
@@ -121039,6 +123272,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSphericalJoint"
@@ -121082,6 +123316,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSphericalJoint"
@@ -121134,6 +123369,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSphericalJoint"
@@ -121175,6 +123411,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSphericalJoint"
@@ -121219,6 +123456,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSphericalJoint"
@@ -121267,6 +123505,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSphericalJoint"
@@ -121324,6 +123563,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSphericalJoint"
@@ -121368,6 +123608,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSphericalJoint"
@@ -121381,6 +123622,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -121427,6 +123669,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidActor"
@@ -121454,6 +123697,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidActor"
@@ -121480,6 +123724,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxD6Joint"
@@ -121589,6 +123834,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxD6JointDrive"
@@ -121636,6 +123882,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxD6Joint"
@@ -121697,6 +123944,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxD6Joint"
@@ -121752,6 +124000,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxD6Joint"
@@ -121793,6 +124042,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxD6Joint"
@@ -121834,6 +124084,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxD6Joint"
@@ -121879,6 +124130,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxD6Joint"
@@ -121933,6 +124185,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxD6Joint"
@@ -121983,6 +124236,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxD6Joint"
@@ -122047,6 +124301,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxD6Joint"
@@ -122104,6 +124359,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxD6Joint"
@@ -122158,6 +124414,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxD6Joint"
@@ -122205,6 +124462,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxD6Joint"
@@ -122259,6 +124517,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxD6Joint"
@@ -122308,6 +124567,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxD6Joint"
@@ -122362,6 +124622,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxD6Joint"
@@ -122408,6 +124669,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxD6Joint"
@@ -122470,6 +124732,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxD6Joint"
@@ -122528,6 +124791,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxD6Joint"
@@ -122586,6 +124850,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxD6Joint"
@@ -122631,6 +124896,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxD6Joint"
@@ -122698,6 +124964,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxD6Joint"
@@ -122772,6 +125039,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxD6Joint"
@@ -122819,6 +125087,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxD6Joint"
@@ -122875,6 +125144,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxD6Joint"
@@ -122922,6 +125192,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxD6Joint"
@@ -122963,6 +125234,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxD6Joint"
@@ -122976,6 +125248,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -123022,6 +125295,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidActor"
@@ -123049,6 +125323,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidActor"
@@ -123075,6 +125350,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxGearJoint"
@@ -123123,6 +125399,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxGearJoint"
@@ -123137,6 +125414,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBase"
@@ -123151,6 +125429,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBase"
@@ -123198,6 +125477,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxGearJoint"
@@ -123245,6 +125525,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxGearJoint"
@@ -123277,6 +125558,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxGearJoint"
@@ -123290,6 +125572,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -123338,6 +125621,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidActor"
@@ -123365,6 +125649,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRigidActor"
@@ -123391,6 +125676,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxRackAndPinionJoint"
@@ -123447,6 +125733,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRackAndPinionJoint"
@@ -123461,6 +125748,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBase"
@@ -123475,6 +125763,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBase"
@@ -123520,6 +125809,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRackAndPinionJoint"
@@ -123567,6 +125857,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRackAndPinionJoint"
@@ -123616,6 +125907,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRackAndPinionJoint"
@@ -123666,6 +125958,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRackAndPinionJoint"
@@ -123679,6 +125972,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -123698,6 +125992,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxGroupsMask"
@@ -123719,6 +126014,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxGroupsMask"
@@ -123814,6 +126110,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -124409,6 +126706,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxDefaultErrorCallback"
@@ -124430,6 +126728,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDefaultErrorCallback"
@@ -124460,6 +126759,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDefaultErrorCallback"
@@ -124484,6 +126784,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -124496,6 +126797,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -124591,10 +126893,12 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": false,
+                  "is_array_like": false,
                   "pointee": {
                     "Record": {
                       "name": "PxMaterial"
@@ -124625,6 +126929,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxShape"
@@ -124734,6 +127039,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxShape"
@@ -124794,6 +127100,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxBounds3"
@@ -124862,6 +127169,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxBVH"
@@ -125015,6 +127323,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMassProperties"
@@ -125294,6 +127603,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMassProperties"
@@ -125308,6 +127618,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTransform"
@@ -125391,6 +127702,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Float"
               }
@@ -125409,6 +127721,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Vec3"
               }
@@ -125477,6 +127790,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Vec3"
               }
@@ -125544,6 +127858,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Float"
               }
@@ -125562,6 +127877,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Vec3"
               }
@@ -125633,6 +127949,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Vec3"
               }
@@ -125680,10 +127997,12 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Pointer": {
                   "is_const": false,
                   "is_pointee_const": true,
+                  "is_array_like": false,
                   "pointee": {
                     "Record": {
                       "name": "PxShape"
@@ -126666,6 +128985,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQueryFilterCallback"
@@ -126680,6 +129000,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQueryCache"
@@ -126787,6 +129108,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSweepHit"
@@ -126801,6 +129123,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "UInt"
               }
@@ -126867,6 +129190,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQueryFilterCallback"
@@ -126881,6 +129205,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQueryCache"
@@ -127056,6 +129381,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRaycastHit"
@@ -127348,6 +129674,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxMeshOverlapUtil"
@@ -127369,6 +129696,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMeshOverlapUtil"
@@ -127410,6 +129738,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMeshOverlapUtil"
@@ -127505,6 +129834,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMeshOverlapUtil"
@@ -127600,6 +129930,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMeshOverlapUtil"
@@ -127613,6 +129944,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "UInt"
           }
@@ -127649,6 +129981,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxMeshOverlapUtil"
@@ -127782,6 +130115,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "UInt"
               }
@@ -127913,6 +130247,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "UInt"
               }
@@ -128051,6 +130386,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCollection"
@@ -128136,6 +130472,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCollection"
@@ -128269,6 +130606,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCollection"
@@ -128283,6 +130621,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxStringTable"
@@ -128297,6 +130636,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxXmlMiscParameter"
@@ -128310,6 +130650,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxCollection"
@@ -128354,6 +130695,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -128379,6 +130721,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCollection"
@@ -128392,6 +130735,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxCollection"
@@ -128473,6 +130817,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCooking"
@@ -128487,6 +130832,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCollection"
@@ -128501,6 +130847,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxXmlMiscParameter"
@@ -128593,6 +130940,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCollection"
@@ -128654,6 +131002,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxSerializationRegistry"
@@ -128692,6 +131041,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDefaultCpuDispatcher"
@@ -128733,6 +131083,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDefaultCpuDispatcher"
@@ -128780,6 +131131,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxDefaultCpuDispatcher"
@@ -128834,6 +131186,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "UInt"
               }
@@ -128861,6 +131214,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxDefaultCpuDispatcher"
@@ -128916,6 +131270,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Vec3"
               }
@@ -128928,6 +131283,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "UInt"
               }
@@ -128940,6 +131296,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "UShort"
               }
@@ -128952,6 +131309,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Vec3"
               }
@@ -129069,6 +131427,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxRigidDynamic"
@@ -129151,6 +131510,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxRigidDynamic"
@@ -129264,6 +131624,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxRigidDynamic"
@@ -129351,6 +131712,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxRigidDynamic"
@@ -129452,6 +131814,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxRigidStatic"
@@ -129527,6 +131890,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxRigidStatic"
@@ -129611,6 +131975,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxShape"
@@ -129700,6 +132065,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxRigidStatic"
@@ -129801,6 +132167,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxRigidDynamic"
@@ -129876,6 +132243,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxRigidStatic"
@@ -130012,6 +132380,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBounds3"
@@ -130151,6 +132520,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQueryFilterCallback"
@@ -130165,6 +132535,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQueryCache"
@@ -130288,6 +132659,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQueryFilterCallback"
@@ -130302,6 +132674,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQueryCache"
@@ -130401,6 +132774,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRaycastHit"
@@ -130445,6 +132819,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQueryFilterCallback"
@@ -130459,6 +132834,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQueryCache"
@@ -130597,6 +132973,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQueryFilterCallback"
@@ -130611,6 +132988,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQueryCache"
@@ -130755,6 +133133,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQueryFilterCallback"
@@ -130769,6 +133148,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQueryCache"
@@ -130889,6 +133269,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSweepHit"
@@ -130933,6 +133314,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQueryFilterCallback"
@@ -130947,6 +133329,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQueryCache"
@@ -131039,6 +133422,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxOverlapHit"
@@ -131072,6 +133456,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQueryFilterCallback"
@@ -131184,6 +133569,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQueryFilterCallback"
@@ -131216,6 +133602,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBatchQueryExt"
@@ -131265,6 +133652,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBatchQueryExt"
@@ -131335,6 +133723,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQueryCache"
@@ -131348,6 +133737,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxRaycastBuffer"
@@ -131395,6 +133785,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBatchQueryExt"
@@ -131480,6 +133871,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQueryCache"
@@ -131499,6 +133891,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxSweepBuffer"
@@ -131547,6 +133940,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBatchQueryExt"
@@ -131606,6 +134000,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQueryCache"
@@ -131619,6 +134014,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxOverlapBuffer"
@@ -131646,6 +134042,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxBatchQueryExt"
@@ -131700,6 +134097,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQueryFilterCallback"
@@ -131749,6 +134147,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxBatchQueryExt"
@@ -131800,6 +134199,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQueryFilterCallback"
@@ -131814,6 +134214,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRaycastBuffer"
@@ -131834,6 +134235,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRaycastHit"
@@ -131854,6 +134256,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSweepBuffer"
@@ -131874,6 +134277,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxSweepHit"
@@ -131894,6 +134298,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxOverlapBuffer"
@@ -131914,6 +134319,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxOverlapHit"
@@ -131933,6 +134339,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxBatchQueryExt"
@@ -131996,6 +134403,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxSceneQuerySystem"
@@ -132043,6 +134451,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCustomSceneQuerySystem"
@@ -132130,6 +134539,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCustomSceneQuerySystem"
@@ -132171,6 +134581,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCustomSceneQuerySystem"
@@ -132218,6 +134629,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCustomSceneQuerySystem"
@@ -132242,6 +134654,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCustomSceneQuerySystemAdapter"
@@ -132287,6 +134700,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCustomSceneQuerySystemAdapter"
@@ -132358,6 +134772,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCustomSceneQuerySystemAdapter"
@@ -132378,6 +134793,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQueryThreadContext"
@@ -132405,6 +134821,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxQueryFilterCallback"
@@ -132484,6 +134901,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxCustomSceneQuerySystem"
@@ -132602,6 +135020,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPoissonSampler"
@@ -132649,6 +135068,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPoissonSampler"
@@ -132711,6 +135131,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPoissonSampler"
@@ -132767,6 +135188,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPoissonSampler"
@@ -132857,6 +135279,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxPoissonSampler"
@@ -132895,6 +135318,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTriangleMeshPoissonSampler"
@@ -132932,6 +135356,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTriangleMeshPoissonSampler"
@@ -132972,6 +135397,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "UInt"
               }
@@ -132990,6 +135416,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Vec3"
               }
@@ -133019,6 +135446,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxTriangleMeshPoissonSampler"
@@ -133057,6 +135485,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTetrahedronMesh"
@@ -133128,6 +135557,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxTetrahedronMesh"
@@ -133207,6 +135637,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPvd"
@@ -133262,6 +135693,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -133274,6 +135706,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Void"
               }
@@ -133312,6 +135745,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRepXObject"
@@ -133353,6 +135787,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCooking"
@@ -133367,6 +135802,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxStringTable"
@@ -133410,6 +135846,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRepXSerializer"
@@ -133423,6 +135860,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": true,
+          "is_array_like": false,
           "pointee": {
             "Builtin": "Char"
           }
@@ -133457,6 +135895,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRepXSerializer"
@@ -133484,6 +135923,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCollection"
@@ -133564,6 +136004,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxRepXSerializer"
@@ -133617,6 +136058,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxCollection"
@@ -133660,6 +136102,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPvd"
@@ -133724,6 +136167,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPvd"
@@ -133763,6 +136207,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPvd"
@@ -133811,6 +136256,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPvd"
@@ -133824,6 +136270,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxPvdTransport"
@@ -133860,6 +136307,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPvd"
@@ -133904,6 +136352,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPvd"
@@ -133954,6 +136403,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxPvd"
@@ -133991,6 +136441,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPvdTransport"
@@ -134033,6 +136484,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPvdTransport"
@@ -134072,6 +136524,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPvdTransport"
@@ -134114,6 +136567,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPvdTransport"
@@ -134128,6 +136582,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "UChar"
               }
@@ -134164,6 +136619,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPvdTransport"
@@ -134203,6 +136659,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPvdTransport"
@@ -134242,6 +136699,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPvdTransport"
@@ -134281,6 +136739,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPvdTransport"
@@ -134313,6 +136772,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": false,
+              "is_array_like": false,
               "pointee": {
                 "Record": {
                   "name": "PxPvdTransport"
@@ -134351,6 +136811,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -134374,6 +136835,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxPvdTransport"
@@ -134409,6 +136871,7 @@
             "Pointer": {
               "is_const": false,
               "is_pointee_const": true,
+              "is_array_like": false,
               "pointee": {
                 "Builtin": "Char"
               }
@@ -134420,6 +136883,7 @@
         "Pointer": {
           "is_const": false,
           "is_pointee_const": false,
+          "is_array_like": false,
           "pointee": {
             "Record": {
               "name": "PxPvdTransport"

--- a/functions.odin
+++ b/functions.odin
@@ -1437,7 +1437,7 @@ foreign libphysx {
     render_buffer_get_nb_points :: proc(self_: ^RenderBuffer) -> _c.uint32_t ---
 
     @(link_name = "PxRenderBuffer_getPoints")
-    render_buffer_get_points :: proc(self_: ^RenderBuffer) -> ^DebugPoint ---
+    render_buffer_get_points :: proc(self_: ^RenderBuffer) -> [^]DebugPoint ---
 
     @(link_name = "PxRenderBuffer_addPoint_mut")
     render_buffer_add_point_mut :: proc(self_: ^RenderBuffer, #by_ptr point: DebugPoint) ---
@@ -1446,22 +1446,22 @@ foreign libphysx {
     render_buffer_get_nb_lines :: proc(self_: ^RenderBuffer) -> _c.uint32_t ---
 
     @(link_name = "PxRenderBuffer_getLines")
-    render_buffer_get_lines :: proc(self_: ^RenderBuffer) -> ^DebugLine ---
+    render_buffer_get_lines :: proc(self_: ^RenderBuffer) -> [^]DebugLine ---
 
     @(link_name = "PxRenderBuffer_addLine_mut")
     render_buffer_add_line_mut :: proc(self_: ^RenderBuffer, #by_ptr line: DebugLine) ---
 
     @(link_name = "PxRenderBuffer_reserveLines_mut")
-    render_buffer_reserve_lines_mut :: proc(self_: ^RenderBuffer, nbLines: _c.uint32_t) -> ^DebugLine ---
+    render_buffer_reserve_lines_mut :: proc(self_: ^RenderBuffer, nbLines: _c.uint32_t) -> [^]DebugLine ---
 
     @(link_name = "PxRenderBuffer_reservePoints_mut")
-    render_buffer_reserve_points_mut :: proc(self_: ^RenderBuffer, nbLines: _c.uint32_t) -> ^DebugPoint ---
+    render_buffer_reserve_points_mut :: proc(self_: ^RenderBuffer, nbLines: _c.uint32_t) -> [^]DebugPoint ---
 
     @(link_name = "PxRenderBuffer_getNbTriangles")
     render_buffer_get_nb_triangles :: proc(self_: ^RenderBuffer) -> _c.uint32_t ---
 
     @(link_name = "PxRenderBuffer_getTriangles")
-    render_buffer_get_triangles :: proc(self_: ^RenderBuffer) -> ^DebugTriangle ---
+    render_buffer_get_triangles :: proc(self_: ^RenderBuffer) -> [^]DebugTriangle ---
 
     @(link_name = "PxRenderBuffer_addTriangle_mut")
     render_buffer_add_triangle_mut :: proc(self_: ^RenderBuffer, #by_ptr triangle: DebugTriangle) ---
@@ -1654,7 +1654,7 @@ foreign libphysx {
     ///
     /// number of members PxBase objects that have been written to the userBuffer
     @(link_name = "PxCollection_getObjects")
-    collection_get_objects :: proc(self_: ^Collection, userBuffer: ^^Base, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
+    collection_get_objects :: proc(self_: ^Collection, userBuffer: [^]^Base, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
 
     /// Looks for a PxBase object given a PxSerialObjectId value.
     ///
@@ -1674,7 +1674,7 @@ foreign libphysx {
     ///
     /// number of members PxSerialObjectId values that have been written to the userBuffer
     @(link_name = "PxCollection_getIds")
-    collection_get_ids :: proc(self_: ^Collection, userBuffer: ^_c.uint64_t, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
+    collection_get_ids :: proc(self_: ^Collection, userBuffer: [^]_c.uint64_t, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
 
     /// Gets the PxSerialObjectId name of a PxBase object within the collection.
     ///
@@ -2125,7 +2125,7 @@ foreign libphysx {
     ///
     /// These are the user-defined bounds passed to the BVH builder, not the internal bounds around each BVH node.
     @(link_name = "PxBVH_getBounds")
-    b_v_h_get_bounds :: proc(self_: ^BVH) -> ^Bounds3 ---
+    b_v_h_get_bounds :: proc(self_: ^BVH) -> [^]Bounds3 ---
 
     /// Retrieve the bounds in the BVH.
     ///
@@ -2205,7 +2205,7 @@ foreign libphysx {
     ///
     /// Array of vertices.
     @(link_name = "PxConvexMesh_getVertices")
-    convex_mesh_get_vertices :: proc(self_: ^ConvexMesh) -> ^Vec3 ---
+    convex_mesh_get_vertices :: proc(self_: ^ConvexMesh) -> [^]Vec3 ---
 
     /// Returns the index buffer.
     ///
@@ -2939,7 +2939,7 @@ foreign libphysx {
     ///
     /// array of vertices
     @(link_name = "PxTriangleMesh_getVertices")
-    triangle_mesh_get_vertices :: proc(self_: ^TriangleMesh) -> ^Vec3 ---
+    triangle_mesh_get_vertices :: proc(self_: ^TriangleMesh) -> [^]Vec3 ---
 
     /// Returns all mesh vertices for modification.
     ///
@@ -3106,7 +3106,7 @@ foreign libphysx {
     ///
     /// array of vertices
     @(link_name = "PxTetrahedronMesh_getVertices")
-    tetrahedron_mesh_get_vertices :: proc(self_: ^TetrahedronMesh) -> ^Vec3 ---
+    tetrahedron_mesh_get_vertices :: proc(self_: ^TetrahedronMesh) -> [^]Vec3 ---
 
     /// Returns the number of tetrahedrons.
     ///
@@ -3409,7 +3409,7 @@ foreign libphysx {
     ///
     /// Number of actor pointers written to the buffer.
     @(link_name = "PxAggregate_getActors")
-    aggregate_get_actors :: proc(self_: ^Aggregate, userBuffer: ^^Actor, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
+    aggregate_get_actors :: proc(self_: ^Aggregate, userBuffer: [^][^]Actor, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
 
     /// Retrieves the scene which this aggregate belongs to.
     ///
@@ -3755,7 +3755,7 @@ foreign libphysx {
     ///
     /// The number of attachments that were filled into the user buffer.
     @(link_name = "PxArticulationSpatialTendon_getAttachments")
-    articulation_spatial_tendon_get_attachments :: proc(self_: ^ArticulationSpatialTendon, userBuffer: ^^ArticulationAttachment, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
+    articulation_spatial_tendon_get_attachments :: proc(self_: ^ArticulationSpatialTendon, userBuffer: [^]^ArticulationAttachment, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
 
     /// Returns the number of attachments in the tendon.
     ///
@@ -3785,7 +3785,7 @@ foreign libphysx {
     ///
     /// The number of tendon joints filled into the user buffer.
     @(link_name = "PxArticulationFixedTendon_getTendonJoints")
-    articulation_fixed_tendon_get_tendon_joints :: proc(self_: ^ArticulationFixedTendon, userBuffer: ^^ArticulationTendonJoint, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
+    articulation_fixed_tendon_get_tendon_joints :: proc(self_: ^ArticulationFixedTendon, userBuffer: [^]^ArticulationTendonJoint, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
 
     /// Returns the number of tendon joints in the tendon.
     ///
@@ -4112,7 +4112,7 @@ foreign libphysx {
     ///
     /// The number of links written into the buffer.
     @(link_name = "PxArticulationReducedCoordinate_getLinks")
-    articulation_reduced_coordinate_get_links :: proc(self_: ^ArticulationReducedCoordinate, userBuffer: ^^ArticulationLink, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
+    articulation_reduced_coordinate_get_links :: proc(self_: ^ArticulationReducedCoordinate, userBuffer: [^]^ArticulationLink, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
 
     /// Returns the number of shapes in the articulation.
     ///
@@ -4381,7 +4381,7 @@ foreign libphysx {
     ///
     /// The number of constraints written into the buffer.
     @(link_name = "PxArticulationReducedCoordinate_getLoopJoints")
-    articulation_reduced_coordinate_get_loop_joints :: proc(self_: ^ArticulationReducedCoordinate, userBuffer: ^^Constraint, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
+    articulation_reduced_coordinate_get_loop_joints :: proc(self_: ^ArticulationReducedCoordinate, userBuffer: [^]^Constraint, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
 
     /// Returns the required size of the coefficient matrix in the articulation.
     ///
@@ -4509,7 +4509,7 @@ foreign libphysx {
     ///
     /// The number of tendons written into the buffer.
     @(link_name = "PxArticulationReducedCoordinate_getSpatialTendons")
-    articulation_reduced_coordinate_get_spatial_tendons :: proc(self_: ^ArticulationReducedCoordinate, userBuffer: ^^ArticulationSpatialTendon, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
+    articulation_reduced_coordinate_get_spatial_tendons :: proc(self_: ^ArticulationReducedCoordinate, userBuffer: [^]^ArticulationSpatialTendon, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
 
     /// Returns the number of spatial tendons in the articulation.
     ///
@@ -4523,7 +4523,7 @@ foreign libphysx {
     ///
     /// The number of tendons written into the buffer.
     @(link_name = "PxArticulationReducedCoordinate_getFixedTendons")
-    articulation_reduced_coordinate_get_fixed_tendons :: proc(self_: ^ArticulationReducedCoordinate, userBuffer: ^^ArticulationFixedTendon, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
+    articulation_reduced_coordinate_get_fixed_tendons :: proc(self_: ^ArticulationReducedCoordinate, userBuffer: [^]^ArticulationFixedTendon, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
 
     /// Returns the number of fixed tendons in the articulation.
     ///
@@ -4537,7 +4537,7 @@ foreign libphysx {
     ///
     /// The number of sensors written into the buffer.
     @(link_name = "PxArticulationReducedCoordinate_getSensors")
-    articulation_reduced_coordinate_get_sensors :: proc(self_: ^ArticulationReducedCoordinate, userBuffer: ^^ArticulationSensor, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
+    articulation_reduced_coordinate_get_sensors :: proc(self_: ^ArticulationReducedCoordinate, userBuffer: [^]^ArticulationSensor, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
 
     /// Returns the number of sensors in the articulation.
     ///
@@ -4910,7 +4910,7 @@ foreign libphysx {
     ///
     /// Number of material pointers written to the buffer.
     @(link_name = "PxShape_getMaterials")
-    shape_get_materials :: proc(self_: ^Shape, userBuffer: ^^Material, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
+    shape_get_materials :: proc(self_: ^Shape, userBuffer: [^]^Material, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
 
     /// Retrieve material from given triangle index.
     ///
@@ -5188,7 +5188,7 @@ foreign libphysx {
     ///
     /// Number of shape pointers written to the buffer.
     @(link_name = "PxRigidActor_getShapes")
-    rigid_actor_get_shapes :: proc(self_: ^RigidActor, userBuffer: ^^Shape, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
+    rigid_actor_get_shapes :: proc(self_: ^RigidActor, userBuffer: [^]^Shape, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
 
     /// Returns the number of constraint shaders attached to the actor.
     ///
@@ -5206,7 +5206,7 @@ foreign libphysx {
     ///
     /// Number of constraint shader pointers written to the buffer.
     @(link_name = "PxRigidActor_getConstraints")
-    rigid_actor_get_constraints :: proc(self_: ^RigidActor, userBuffer: ^^Constraint, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
+    rigid_actor_get_constraints :: proc(self_: ^RigidActor, userBuffer: [^]^Constraint, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
 
     @(link_name = "PxNodeIndex_new")
     node_index_new :: proc(id: _c.uint32_t, articLinkId: _c.uint32_t) -> NodeIndex ---
@@ -5661,7 +5661,7 @@ foreign libphysx {
     ///
     /// The number of articulation links written to the buffer.
     @(link_name = "PxArticulationLink_getChildren")
-    articulation_link_get_children :: proc(self_: ^ArticulationLink, userBuffer: ^^ArticulationLink, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
+    articulation_link_get_children :: proc(self_: ^ArticulationLink, userBuffer: [^]^ArticulationLink, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
 
     /// Set the constraint-force-mixing scale term.
     ///
@@ -6575,7 +6575,7 @@ foreign libphysx {
     ///
     /// The number of triangle mesh pointers written to userBuffer, this should be less or equal to bufferSize.
     @(link_name = "PxPhysics_getTriangleMeshes")
-    physics_get_triangle_meshes :: proc(self_: ^Physics, userBuffer: ^^TriangleMesh, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
+    physics_get_triangle_meshes :: proc(self_: ^Physics, userBuffer: [^]^TriangleMesh, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
 
     /// Creates a tetrahedron mesh object.
     ///
@@ -6605,7 +6605,7 @@ foreign libphysx {
     ///
     /// The number of tetrahedron mesh pointers written to userBuffer, this should be less or equal to bufferSize.
     @(link_name = "PxPhysics_getTetrahedronMeshes")
-    physics_get_tetrahedron_meshes :: proc(self_: ^Physics, userBuffer: ^^TetrahedronMesh, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
+    physics_get_tetrahedron_meshes :: proc(self_: ^Physics, userBuffer: [^]^TetrahedronMesh, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
 
     /// Creates a heightfield object from previously cooked stream.
     ///
@@ -6629,7 +6629,7 @@ foreign libphysx {
     ///
     /// The number of heightfield pointers written to userBuffer, this should be less or equal to bufferSize.
     @(link_name = "PxPhysics_getHeightFields")
-    physics_get_height_fields :: proc(self_: ^Physics, userBuffer: ^^HeightField, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
+    physics_get_height_fields :: proc(self_: ^Physics, userBuffer: [^]^HeightField, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
 
     /// Creates a convex mesh object.
     ///
@@ -6653,7 +6653,7 @@ foreign libphysx {
     ///
     /// The number of convex mesh pointers written to userBuffer, this should be less or equal to bufferSize.
     @(link_name = "PxPhysics_getConvexMeshes")
-    physics_get_convex_meshes :: proc(self_: ^Physics, userBuffer: ^^ConvexMesh, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
+    physics_get_convex_meshes :: proc(self_: ^Physics, userBuffer: [^]^ConvexMesh, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
 
     /// Creates a bounding volume hierarchy.
     ///
@@ -6675,7 +6675,7 @@ foreign libphysx {
     ///
     /// The number of BVH pointers written to userBuffer, this should be less or equal to bufferSize.
     @(link_name = "PxPhysics_getBVHs")
-    physics_get_b_v_hs :: proc(self_: ^Physics, userBuffer: ^^BVH, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
+    physics_get_b_v_hs :: proc(self_: ^Physics, userBuffer: [^]^BVH, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
 
     /// Creates a scene.
     ///
@@ -6700,7 +6700,7 @@ foreign libphysx {
     ///
     /// The number of scene pointers written to userBuffer, this should be less or equal to bufferSize.
     @(link_name = "PxPhysics_getScenes")
-    physics_get_scenes :: proc(self_: ^Physics, userBuffer: ^^Scene, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
+    physics_get_scenes :: proc(self_: ^Physics, userBuffer: [^]^Scene, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
 
     /// Creates a static rigid actor with the specified pose and all other fields initialized
     /// to their default values.
@@ -6762,7 +6762,7 @@ foreign libphysx {
     ///
     /// The number of shape pointers written to userBuffer, this should be less or equal to bufferSize.
     @(link_name = "PxPhysics_getShapes")
-    physics_get_shapes :: proc(self_: ^Physics, userBuffer: ^^Shape, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
+    physics_get_shapes :: proc(self_: ^Physics, userBuffer: [^]^Shape, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
 
     /// Creates a constraint shader.
     ///
@@ -6799,7 +6799,7 @@ foreign libphysx {
     ///
     /// The number of material pointers written to userBuffer, this should be less or equal to bufferSize.
     @(link_name = "PxPhysics_getMaterials")
-    physics_get_materials :: proc(self_: ^Physics, userBuffer: ^^Material, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
+    physics_get_materials :: proc(self_: ^Physics, userBuffer: [^]^Material, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
 
     /// Register a deletion listener. Listeners will be called whenever an object is deleted.
     ///
@@ -7533,7 +7533,7 @@ foreign libphysx {
     ///
     /// Number of written out regions.
     @(link_name = "PxBroadPhaseRegions_getRegions")
-    broad_phase_regions_get_regions :: proc(self_: ^BroadPhaseRegions, userBuffer: ^BroadPhaseRegionInfo, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
+    broad_phase_regions_get_regions :: proc(self_: ^BroadPhaseRegions, userBuffer: [^]BroadPhaseRegionInfo, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
 
     /// Adds a new broad-phase region.
     ///
@@ -8047,7 +8047,7 @@ foreign libphysx {
     ///
     /// Number of actors written to the buffer.
     @(link_name = "PxScene_getActors")
-    scene_get_actors :: proc(self_: ^Scene, types: ActorTypeFlags_Set, userBuffer: ^^Actor, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
+    scene_get_actors :: proc(self_: ^Scene, types: ActorTypeFlags_Set, userBuffer: [^]^Actor, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
 
     /// Queries the PxScene for a list of the PxActors whose transforms have been
     /// updated during the previous simulation step. Only includes actors of type PxRigidDynamic and PxArticulationLink.
@@ -8070,7 +8070,7 @@ foreign libphysx {
     ///
     /// Number of articulations written to the buffer.
     @(link_name = "PxScene_getArticulations")
-    scene_get_articulations :: proc(self_: ^Scene, userBuffer: ^^ArticulationReducedCoordinate, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
+    scene_get_articulations :: proc(self_: ^Scene, userBuffer: [^]^ArticulationReducedCoordinate, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
 
     /// Returns the number of constraint shaders in the scene.
     ///
@@ -8082,7 +8082,7 @@ foreign libphysx {
     ///
     /// Number of constraint shaders written to the buffer.
     @(link_name = "PxScene_getConstraints")
-    scene_get_constraints :: proc(self_: ^Scene, userBuffer: ^^Constraint, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
+    scene_get_constraints :: proc(self_: ^Scene, userBuffer: [^]^Constraint, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
 
     /// Returns the number of aggregates in the scene.
     ///
@@ -8094,7 +8094,7 @@ foreign libphysx {
     ///
     /// Number of aggregates written to the buffer.
     @(link_name = "PxScene_getAggregates")
-    scene_get_aggregates :: proc(self_: ^Scene, userBuffer: ^^Aggregate, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
+    scene_get_aggregates :: proc(self_: ^Scene, userBuffer: [^]^Aggregate, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
 
     /// Specifies the dominance behavior of contacts between two actors with two certain dominance groups.
     ///
@@ -8560,7 +8560,7 @@ foreign libphysx {
     ///
     /// Number of written out regions
     @(link_name = "PxScene_getBroadPhaseRegions")
-    scene_get_broad_phase_regions :: proc(self_: ^Scene, userBuffer: ^BroadPhaseRegionInfo, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
+    scene_get_broad_phase_regions :: proc(self_: ^Scene, userBuffer: [^]BroadPhaseRegionInfo, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
 
     /// Adds a new broad-phase region.
     ///
@@ -8886,7 +8886,7 @@ foreign libphysx {
     ///
     /// Number of contact points written to the buffer.
     @(link_name = "PxContactPair_extractContacts")
-    contact_pair_extract_contacts :: proc(self_: ^ContactPair, userBuffer: ^ContactPairPoint, bufferSize: _c.uint32_t) -> _c.uint32_t ---
+    contact_pair_extract_contacts :: proc(self_: ^ContactPair, userBuffer: [^]ContactPairPoint, bufferSize: _c.uint32_t) -> _c.uint32_t ---
 
     /// Helper method to clone the contact pair and copy the contact data stream into a user buffer.
     ///
@@ -8998,7 +8998,7 @@ foreign libphysx {
     ///
     /// Number of rigid actor pointers written to the buffer.
     @(link_name = "PxPruningStructure_getRigidActors")
-    pruning_structure_get_rigid_actors :: proc(self_: ^PruningStructure, userBuffer: ^^RigidActor, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
+    pruning_structure_get_rigid_actors :: proc(self_: ^PruningStructure, userBuffer: [^]^RigidActor, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
 
     /// Returns the number of rigid actors in the pruning structure.
     ///

--- a/functions.odin
+++ b/functions.odin
@@ -23,7 +23,7 @@ foreign libphysx {
     ///
     /// The allocated block of memory.
     @(link_name = "PxAllocatorCallback_allocate_mut")
-    allocator_callback_allocate_mut :: proc(self_: ^AllocatorCallback, size: _c.size_t, typeName: ^_c.char, filename: ^_c.char, line: _c.int32_t) -> rawptr ---
+    allocator_callback_allocate_mut :: proc(self_: ^AllocatorCallback, size: _c.size_t, typeName: [^]_c.char, filename: [^]_c.char, line: _c.int32_t) -> rawptr ---
 
     /// Frees memory previously allocated by allocate().
     ///
@@ -140,19 +140,19 @@ foreign libphysx {
     inc_foundation_ref_count :: proc() ---
 
     @(link_name = "PxAllocator_new")
-    allocator_new :: proc(anon_param0: ^_c.char) -> Allocator ---
+    allocator_new :: proc(anon_param0: [^]_c.char) -> Allocator ---
 
     @(link_name = "PxAllocator_allocate_mut")
-    allocator_allocate_mut :: proc(self_: ^Allocator, size: _c.size_t, file: ^_c.char, line: _c.int32_t) -> rawptr ---
+    allocator_allocate_mut :: proc(self_: ^Allocator, size: _c.size_t, file: [^]_c.char, line: _c.int32_t) -> rawptr ---
 
     @(link_name = "PxAllocator_deallocate_mut")
     allocator_deallocate_mut :: proc(self_: ^Allocator, ptr: rawptr) ---
 
     @(link_name = "PxRawAllocator_new")
-    raw_allocator_new :: proc(anon_param0: ^_c.char) -> RawAllocator ---
+    raw_allocator_new :: proc(anon_param0: [^]_c.char) -> RawAllocator ---
 
     @(link_name = "PxRawAllocator_allocate_mut")
-    raw_allocator_allocate_mut :: proc(self_: ^RawAllocator, size: _c.size_t, anon_param1: ^_c.char, anon_param2: _c.int32_t) -> rawptr ---
+    raw_allocator_allocate_mut :: proc(self_: ^RawAllocator, size: _c.size_t, anon_param1: [^]_c.char, anon_param2: _c.int32_t) -> rawptr ---
 
     @(link_name = "PxRawAllocator_deallocate_mut")
     raw_allocator_deallocate_mut :: proc(self_: ^RawAllocator, ptr: rawptr) ---
@@ -161,7 +161,7 @@ foreign libphysx {
     virtual_allocator_callback_delete :: proc(self_: ^VirtualAllocatorCallback) ---
 
     @(link_name = "PxVirtualAllocatorCallback_allocate_mut")
-    virtual_allocator_callback_allocate_mut :: proc(self_: ^VirtualAllocatorCallback, size: _c.size_t, group: _c.int32_t, file: ^_c.char, line: _c.int32_t) -> rawptr ---
+    virtual_allocator_callback_allocate_mut :: proc(self_: ^VirtualAllocatorCallback, size: _c.size_t, group: _c.int32_t, file: [^]_c.char, line: _c.int32_t) -> rawptr ---
 
     @(link_name = "PxVirtualAllocatorCallback_deallocate_mut")
     virtual_allocator_callback_deallocate_mut :: proc(self_: ^VirtualAllocatorCallback, ptr: rawptr) ---
@@ -170,7 +170,7 @@ foreign libphysx {
     virtual_allocator_new :: proc(callback: ^VirtualAllocatorCallback, group: _c.int32_t) -> VirtualAllocator ---
 
     @(link_name = "PxVirtualAllocator_allocate_mut")
-    virtual_allocator_allocate_mut :: proc(self_: ^VirtualAllocator, size: _c.size_t, file: ^_c.char, line: _c.int32_t) -> rawptr ---
+    virtual_allocator_allocate_mut :: proc(self_: ^VirtualAllocator, size: _c.size_t, file: [^]_c.char, line: _c.int32_t) -> rawptr ---
 
     @(link_name = "PxVirtualAllocator_deallocate_mut")
     virtual_allocator_deallocate_mut :: proc(self_: ^VirtualAllocator, ptr: rawptr) ---
@@ -179,10 +179,10 @@ foreign libphysx {
     temp_allocator_chunk_new :: proc() -> TempAllocatorChunk ---
 
     @(link_name = "PxTempAllocator_new")
-    temp_allocator_new :: proc(anon_param0: ^_c.char) -> TempAllocator ---
+    temp_allocator_new :: proc(anon_param0: [^]_c.char) -> TempAllocator ---
 
     @(link_name = "PxTempAllocator_allocate_mut")
-    temp_allocator_allocate_mut :: proc(self_: ^TempAllocator, size: _c.size_t, file: ^_c.char, line: _c.int32_t) -> rawptr ---
+    temp_allocator_allocate_mut :: proc(self_: ^TempAllocator, size: _c.size_t, file: [^]_c.char, line: _c.int32_t) -> rawptr ---
 
     @(link_name = "PxTempAllocator_deallocate_mut")
     temp_allocator_deallocate_mut :: proc(self_: ^TempAllocator, ptr: rawptr) ---
@@ -559,7 +559,7 @@ foreign libphysx {
 
     /// Construct from float[9]
     @(link_name = "PxMat33_new_5")
-    mat33_new_5 :: proc(values: ^_c.float) -> Mat33 ---
+    mat33_new_5 :: proc(values: [^]_c.float) -> Mat33 ---
 
     /// Construct from a quaternion
     @(link_name = "PxMat33_new_6")
@@ -747,11 +747,11 @@ foreign libphysx {
 
     /// Reports an error code.
     @(link_name = "PxErrorCallback_reportError_mut")
-    error_callback_report_error_mut :: proc(self_: ^ErrorCallback, code: ErrorCode, message: ^_c.char, file: ^_c.char, line: _c.int32_t) ---
+    error_callback_report_error_mut :: proc(self_: ^ErrorCallback, code: ErrorCode, message: [^]_c.char, file: [^]_c.char, line: _c.int32_t) ---
 
     /// callback when memory is allocated.
     @(link_name = "PxAllocationListener_onAllocation_mut")
-    allocation_listener_on_allocation_mut :: proc(self_: ^AllocationListener, size: _c.size_t, typeName: ^_c.char, filename: ^_c.char, line: _c.int32_t, allocatedMemory: rawptr) ---
+    allocation_listener_on_allocation_mut :: proc(self_: ^AllocationListener, size: _c.size_t, typeName: [^]_c.char, filename: [^]_c.char, line: _c.int32_t, allocatedMemory: rawptr) ---
 
     /// callback when memory is deallocated.
     @(link_name = "PxAllocationListener_onDeallocation_mut")
@@ -776,7 +776,7 @@ foreign libphysx {
     ///
     /// The allocated block of memory.
     @(link_name = "PxBroadcastingAllocator_allocate_mut")
-    broadcasting_allocator_allocate_mut :: proc(self_: ^BroadcastingAllocator, size: _c.size_t, typeName: ^_c.char, filename: ^_c.char, line: _c.int32_t) -> rawptr ---
+    broadcasting_allocator_allocate_mut :: proc(self_: ^BroadcastingAllocator, size: _c.size_t, typeName: [^]_c.char, filename: [^]_c.char, line: _c.int32_t) -> rawptr ---
 
     /// Frees memory previously allocated by allocate().
     ///
@@ -796,7 +796,7 @@ foreign libphysx {
 
     /// Reports an error code.
     @(link_name = "PxBroadcastingErrorCallback_reportError_mut")
-    broadcasting_error_callback_report_error_mut :: proc(self_: ^BroadcastingErrorCallback, code: ErrorCode, message: ^_c.char, file: ^_c.char, line: _c.int32_t) ---
+    broadcasting_error_callback_report_error_mut :: proc(self_: ^BroadcastingErrorCallback, code: ErrorCode, message: [^]_c.char, file: [^]_c.char, line: _c.int32_t) ---
 
     /// Enables floating point exceptions for the scalar and SIMD unit
     @(link_name = "phys_PxEnableFPExceptions")
@@ -867,7 +867,7 @@ foreign libphysx {
 
     /// Initializes from an array of scalar parameters.
     @(link_name = "PxVec4_new_5")
-    vec4_new_5 :: proc(v: ^_c.float) -> Vec4 ---
+    vec4_new_5 :: proc(v: [^]_c.float) -> Vec4 ---
 
     /// tests for exact zero vector
     @(link_name = "PxVec4_isZero")
@@ -1218,16 +1218,16 @@ foreign libphysx {
     ///
     /// Returns implementation-specific profiler data for this event
     @(link_name = "PxProfilerCallback_zoneStart_mut")
-    profiler_callback_zone_start_mut :: proc(self_: ^ProfilerCallback, eventName: ^_c.char, detached: _c.bool, contextId: _c.uint64_t) -> rawptr ---
+    profiler_callback_zone_start_mut :: proc(self_: ^ProfilerCallback, eventName: [^]_c.char, detached: _c.bool, contextId: _c.uint64_t) -> rawptr ---
 
     /// Mark the end of a nested profile block
     ///
     /// eventName plus contextId can be used to uniquely match up start and end of a zone.
     @(link_name = "PxProfilerCallback_zoneEnd_mut")
-    profiler_callback_zone_end_mut :: proc(self_: ^ProfilerCallback, profilerData: rawptr, eventName: ^_c.char, detached: _c.bool, contextId: _c.uint64_t) ---
+    profiler_callback_zone_end_mut :: proc(self_: ^ProfilerCallback, profilerData: rawptr, eventName: [^]_c.char, detached: _c.bool, contextId: _c.uint64_t) ---
 
     @(link_name = "PxProfileScoped_new_alloc")
-    profile_scoped_new_alloc :: proc(callback: ^ProfilerCallback, eventName: ^_c.char, detached: _c.bool, contextId: _c.uint64_t) -> ^ProfileScoped ---
+    profile_scoped_new_alloc :: proc(callback: ^ProfilerCallback, eventName: [^]_c.char, detached: _c.bool, contextId: _c.uint64_t) -> ^ProfileScoped ---
 
     @(link_name = "PxProfileScoped_delete")
     profile_scoped_delete :: proc(self_: ^ProfileScoped) ---
@@ -1428,7 +1428,7 @@ foreign libphysx {
     debug_text_new :: proc() -> DebugText ---
 
     @(link_name = "PxDebugText_new_1")
-    debug_text_new_1 :: proc(#by_ptr pos: Vec3, #by_ptr sz: _c.float, #by_ptr clr: _c.uint32_t, str: ^_c.char) -> DebugText ---
+    debug_text_new_1 :: proc(#by_ptr pos: Vec3, #by_ptr sz: _c.float, #by_ptr clr: _c.uint32_t, str: [^]_c.char) -> DebugText ---
 
     @(link_name = "PxRenderBuffer_delete")
     render_buffer_delete :: proc(self_: ^RenderBuffer) ---
@@ -1520,7 +1520,7 @@ foreign libphysx {
     ///
     /// This function is assumed to be called within the implementation of PxSerializer::exportExtraData.
     @(link_name = "PxSerializationContext_writeName_mut")
-    serialization_context_write_name_mut :: proc(self_: ^SerializationContext, name: ^_c.char) ---
+    serialization_context_write_name_mut :: proc(self_: ^SerializationContext, name: [^]_c.char) ---
 
     /// Retrieves a pointer to a deserialized PxBase object given a corresponding deserialized reference value
     ///
@@ -1541,7 +1541,7 @@ foreign libphysx {
     ///
     /// This function is assumed to be called within the implementation of PxSerializer::createObject.
     @(link_name = "PxDeserializationContext_readName_mut")
-    deserialization_context_read_name_mut :: proc(self_: ^DeserializationContext, name: ^^_c.char) ---
+    deserialization_context_read_name_mut :: proc(self_: ^DeserializationContext, name: ^[^]_c.char) ---
 
     /// Function to align the extra data stream to a power of 2 alignment
     ///
@@ -1579,7 +1579,7 @@ foreign libphysx {
     ///
     /// Registered PxRepXSerializer object corresponding to type name
     @(link_name = "PxSerializationRegistry_getRepXSerializer")
-    serialization_registry_get_rep_x_serializer :: proc(self_: ^SerializationRegistry, typeName: ^_c.char) -> ^RepXSerializer ---
+    serialization_registry_get_rep_x_serializer :: proc(self_: ^SerializationRegistry, typeName: [^]_c.char) -> ^RepXSerializer ---
 
     /// Releases PxSerializationRegistry instance.
     ///
@@ -1709,7 +1709,7 @@ foreign libphysx {
     ///
     /// Class name of most derived type of this object.
     @(link_name = "PxBase_getConcreteTypeName")
-    base_get_concrete_type_name :: proc(self_: ^Base) -> ^_c.char ---
+    base_get_concrete_type_name :: proc(self_: ^Base) -> [^]_c.char ---
 
     /// Returns concrete type of object.
     ///
@@ -1772,7 +1772,7 @@ foreign libphysx {
     ///
     /// *Always* a valid null terminated string.  "" is returned if "" or null is passed in.
     @(link_name = "PxStringTable_allocateStr_mut")
-    string_table_allocate_str_mut :: proc(self_: ^StringTable, inSrc: ^_c.char) -> ^_c.char ---
+    string_table_allocate_str_mut :: proc(self_: ^StringTable, inSrc: [^]_c.char) -> [^]_c.char ---
 
     /// Release the string table and all the strings associated with it.
     @(link_name = "PxStringTable_release_mut")
@@ -1782,7 +1782,7 @@ foreign libphysx {
     ///
     /// Class name of most derived type of this object.
     @(link_name = "PxSerializer_getConcreteTypeName")
-    serializer_get_concrete_type_name :: proc(self_: ^Serializer) -> ^_c.char ---
+    serializer_get_concrete_type_name :: proc(self_: ^Serializer) -> [^]_c.char ---
 
     /// Adds required objects to the collection.
     ///
@@ -1866,13 +1866,13 @@ foreign libphysx {
     ///
     /// The ID of the task with that name, or eNOT_PRESENT if not found
     @(link_name = "PxTaskManager_getNamedTask_mut")
-    task_manager_get_named_task_mut :: proc(self_: ^TaskManager, name: ^_c.char) -> _c.uint32_t ---
+    task_manager_get_named_task_mut :: proc(self_: ^TaskManager, name: [^]_c.char) -> _c.uint32_t ---
 
     /// Submit a task with a unique name.
     ///
     /// The ID of the task with that name, or eNOT_PRESENT if not found
     @(link_name = "PxTaskManager_submitNamedTask_mut")
-    task_manager_submit_named_task_mut :: proc(self_: ^TaskManager, task: ^Task, name: ^_c.char, type: TaskType) -> _c.uint32_t ---
+    task_manager_submit_named_task_mut :: proc(self_: ^TaskManager, task: ^Task, name: [^]_c.char, type: TaskType) -> _c.uint32_t ---
 
     /// Submit an unnamed task.
     ///
@@ -1926,7 +1926,7 @@ foreign libphysx {
     ///
     /// The name of this task
     @(link_name = "PxBaseTask_getName")
-    base_task_get_name :: proc(self_: ^BaseTask) -> ^_c.char ---
+    base_task_get_name :: proc(self_: ^BaseTask) -> [^]_c.char ---
 
     /// Implemented by derived implementation classes
     @(link_name = "PxBaseTask_addReference_mut")
@@ -2180,7 +2180,7 @@ foreign libphysx {
     b_v_h_traverse :: proc(self_: ^BVH, cb: ^BVHTraversalCallback) -> _c.bool ---
 
     @(link_name = "PxBVH_getConcreteTypeName")
-    b_v_h_get_concrete_type_name :: proc(self_: ^BVH) -> ^_c.char ---
+    b_v_h_get_concrete_type_name :: proc(self_: ^BVH) -> [^]_c.char ---
 
     /// Constructor, initializes to a capsule with passed radius and half height.
     @(link_name = "PxCapsuleGeometry_new")
@@ -2255,7 +2255,7 @@ foreign libphysx {
     convex_mesh_get_s_d_f :: proc(self_: ^ConvexMesh) -> ^_c.float ---
 
     @(link_name = "PxConvexMesh_getConcreteTypeName")
-    convex_mesh_get_concrete_type_name :: proc(self_: ^ConvexMesh) -> ^_c.char ---
+    convex_mesh_get_concrete_type_name :: proc(self_: ^ConvexMesh) -> [^]_c.char ---
 
     /// This method decides whether a convex mesh is gpu compatible. If the total number of vertices are more than 64 or any number of vertices in a polygon is more than 32, or
     /// convex hull data was not cooked with GPU data enabled during cooking or was loaded from a serialized collection, the convex hull is incompatible with GPU collision detection. Otherwise
@@ -2784,7 +2784,7 @@ foreign libphysx {
     height_field_get_timestamp :: proc(self_: ^HeightField) -> _c.uint32_t ---
 
     @(link_name = "PxHeightField_getConcreteTypeName")
-    height_field_get_concrete_type_name :: proc(self_: ^HeightField) -> ^_c.char ---
+    height_field_get_concrete_type_name :: proc(self_: ^HeightField) -> [^]_c.char ---
 
     /// Constructor sets to default.
     @(link_name = "PxHeightFieldDesc_new")
@@ -3238,13 +3238,13 @@ foreign libphysx {
     /// Default:
     /// NULL
     @(link_name = "PxActor_setName_mut")
-    actor_set_name_mut :: proc(self_: ^Actor, name: ^_c.char) ---
+    actor_set_name_mut :: proc(self_: ^Actor, name: [^]_c.char) ---
 
     /// Retrieves the name string set with setName().
     ///
     /// Name string associated with object.
     @(link_name = "PxActor_getName")
-    actor_get_name :: proc(self_: ^Actor) -> ^_c.char ---
+    actor_get_name :: proc(self_: ^Actor) -> [^]_c.char ---
 
     /// Retrieves the axis aligned bounding box enclosing the actor.
     ///
@@ -3424,7 +3424,7 @@ foreign libphysx {
     aggregate_get_self_collision :: proc(self_: ^Aggregate) -> _c.bool ---
 
     @(link_name = "PxAggregate_getConcreteTypeName")
-    aggregate_get_concrete_type_name :: proc(self_: ^Aggregate) -> ^_c.char ---
+    aggregate_get_concrete_type_name :: proc(self_: ^Aggregate) -> [^]_c.char ---
 
     @(link_name = "PxConstraintInvMassScale_new")
     constraint_inv_mass_scale_new :: proc() -> ConstraintInvMassScale ---
@@ -3636,7 +3636,7 @@ foreign libphysx {
     ///
     /// The string name.
     @(link_name = "PxArticulationAttachment_getConcreteTypeName")
-    articulation_attachment_get_concrete_type_name :: proc(self_: ^ArticulationAttachment) -> ^_c.char ---
+    articulation_attachment_get_concrete_type_name :: proc(self_: ^ArticulationAttachment) -> [^]_c.char ---
 
     /// Sets the tendon joint coefficient.
     ///
@@ -3678,7 +3678,7 @@ foreign libphysx {
     ///
     /// The string name.
     @(link_name = "PxArticulationTendonJoint_getConcreteTypeName")
-    articulation_tendon_joint_get_concrete_type_name :: proc(self_: ^ArticulationTendonJoint) -> ^_c.char ---
+    articulation_tendon_joint_get_concrete_type_name :: proc(self_: ^ArticulationTendonJoint) -> [^]_c.char ---
 
     /// Sets the spring stiffness term acting on the tendon length.
     @(link_name = "PxArticulationTendon_setStiffness_mut")
@@ -3767,7 +3767,7 @@ foreign libphysx {
     ///
     /// The string name.
     @(link_name = "PxArticulationSpatialTendon_getConcreteTypeName")
-    articulation_spatial_tendon_get_concrete_type_name :: proc(self_: ^ArticulationSpatialTendon) -> ^_c.char ---
+    articulation_spatial_tendon_get_concrete_type_name :: proc(self_: ^ArticulationSpatialTendon) -> [^]_c.char ---
 
     /// Creates an articulation tendon joint and adds it to the list of children in the parent tendon joint.
     ///
@@ -3826,7 +3826,7 @@ foreign libphysx {
     ///
     /// The string name.
     @(link_name = "PxArticulationFixedTendon_getConcreteTypeName")
-    articulation_fixed_tendon_get_concrete_type_name :: proc(self_: ^ArticulationFixedTendon) -> ^_c.char ---
+    articulation_fixed_tendon_get_concrete_type_name :: proc(self_: ^ArticulationFixedTendon) -> [^]_c.char ---
 
     @(link_name = "PxArticulationCache_new")
     articulation_cache_new :: proc() -> ArticulationCache ---
@@ -3905,7 +3905,7 @@ foreign libphysx {
     ///
     /// The string name.
     @(link_name = "PxArticulationSensor_getConcreteTypeName")
-    articulation_sensor_get_concrete_type_name :: proc(self_: ^ArticulationSensor) -> ^_c.char ---
+    articulation_sensor_get_concrete_type_name :: proc(self_: ^ArticulationSensor) -> [^]_c.char ---
 
     /// Returns the scene which this articulation belongs to.
     ///
@@ -4125,13 +4125,13 @@ foreign libphysx {
     /// This is for debugging and is not used by the SDK. The string is not copied by the SDK,
     /// only the pointer is stored.
     @(link_name = "PxArticulationReducedCoordinate_setName_mut")
-    articulation_reduced_coordinate_set_name_mut :: proc(self_: ^ArticulationReducedCoordinate, name: ^_c.char) ---
+    articulation_reduced_coordinate_set_name_mut :: proc(self_: ^ArticulationReducedCoordinate, name: [^]_c.char) ---
 
     /// Returns the name string set with setName().
     ///
     /// Name string associated with the articulation.
     @(link_name = "PxArticulationReducedCoordinate_getName")
-    articulation_reduced_coordinate_get_name :: proc(self_: ^ArticulationReducedCoordinate) -> ^_c.char ---
+    articulation_reduced_coordinate_get_name :: proc(self_: ^ArticulationReducedCoordinate) -> [^]_c.char ---
 
     /// Returns the axis-aligned bounding box enclosing the articulation.
     ///
@@ -4796,7 +4796,7 @@ foreign libphysx {
     ///
     /// The string name.
     @(link_name = "PxArticulationJointReducedCoordinate_getConcreteTypeName")
-    articulation_joint_reduced_coordinate_get_concrete_type_name :: proc(self_: ^ArticulationJointReducedCoordinate) -> ^_c.char ---
+    articulation_joint_reduced_coordinate_get_concrete_type_name :: proc(self_: ^ArticulationJointReducedCoordinate) -> [^]_c.char ---
 
     /// Decrements the reference count of a shape and releases it if the new reference count is zero.
     ///
@@ -5071,16 +5071,16 @@ foreign libphysx {
     /// Default:
     /// NULL
     @(link_name = "PxShape_setName_mut")
-    shape_set_name_mut :: proc(self_: ^Shape, name: ^_c.char) ---
+    shape_set_name_mut :: proc(self_: ^Shape, name: [^]_c.char) ---
 
     /// retrieves the name string set with setName().
     ///
     /// The name associated with the shape.
     @(link_name = "PxShape_getName")
-    shape_get_name :: proc(self_: ^Shape) -> ^_c.char ---
+    shape_get_name :: proc(self_: ^Shape) -> [^]_c.char ---
 
     @(link_name = "PxShape_getConcreteTypeName")
-    shape_get_concrete_type_name :: proc(self_: ^Shape) -> ^_c.char ---
+    shape_get_concrete_type_name :: proc(self_: ^Shape) -> [^]_c.char ---
 
     /// Deletes the rigid actor object.
     ///
@@ -5713,7 +5713,7 @@ foreign libphysx {
     ///
     /// The string name.
     @(link_name = "PxArticulationLink_getConcreteTypeName")
-    articulation_link_get_concrete_type_name :: proc(self_: ^ArticulationLink) -> ^_c.char ---
+    articulation_link_get_concrete_type_name :: proc(self_: ^ArticulationLink) -> [^]_c.char ---
 
     @(link_name = "PxConeLimitedConstraint_new")
     cone_limited_constraint_new :: proc() -> ConeLimitedConstraint ---
@@ -5813,7 +5813,7 @@ foreign libphysx {
     constraint_set_constraint_functions_mut :: proc(self_: ^Constraint, connector: ^ConstraintConnector, #by_ptr shaders: ConstraintShaderTable) ---
 
     @(link_name = "PxConstraint_getConcreteTypeName")
-    constraint_get_concrete_type_name :: proc(self_: ^Constraint) -> ^_c.char ---
+    constraint_get_concrete_type_name :: proc(self_: ^Constraint) -> [^]_c.char ---
 
     /// Constructor
     @(link_name = "PxContactStreamIterator_new")
@@ -6179,7 +6179,7 @@ foreign libphysx {
     deletion_listener_on_release_mut :: proc(self_: ^DeletionListener, observed: ^Base, userData: rawptr, deletionEvent: DeletionEventFlag) ---
 
     @(link_name = "PxBaseMaterial_isKindOf")
-    base_material_is_kind_of :: proc(self_: ^BaseMaterial, name: ^_c.char) -> _c.bool ---
+    base_material_is_kind_of :: proc(self_: ^BaseMaterial, name: [^]_c.char) -> _c.bool ---
 
     /// Sets young's modulus which defines the body's stiffness
     @(link_name = "PxFEMMaterial_setYoungsModulus_mut")
@@ -6450,7 +6450,7 @@ foreign libphysx {
     material_get_restitution_combine_mode :: proc(self_: ^Material) -> CombineMode ---
 
     @(link_name = "PxMaterial_getConcreteTypeName")
-    material_get_concrete_type_name :: proc(self_: ^Material) -> ^_c.char ---
+    material_get_concrete_type_name :: proc(self_: ^Material) -> [^]_c.char ---
 
     /// Construct parameters with default values.
     @(link_name = "PxDiffuseParticleParams_new")
@@ -6724,7 +6724,7 @@ foreign libphysx {
     ///
     /// Pruning structure created from given actors, or NULL if any of the actors did not comply with the above requirements.
     @(link_name = "PxPhysics_createPruningStructure_mut")
-    physics_create_pruning_structure_mut :: proc(self_: ^Physics, actors: ^^RigidActor, nbActors: _c.uint32_t) -> ^PruningStructure ---
+    physics_create_pruning_structure_mut :: proc(self_: ^Physics, actors: [^]^RigidActor, nbActors: _c.uint32_t) -> ^PruningStructure ---
 
     /// Creates a shape which may be attached to multiple actors
     ///
@@ -7172,10 +7172,10 @@ foreign libphysx {
     rigid_dynamic_set_contact_report_threshold_mut :: proc(self_: ^RigidDynamic, threshold: _c.float) ---
 
     @(link_name = "PxRigidDynamic_getConcreteTypeName")
-    rigid_dynamic_get_concrete_type_name :: proc(self_: ^RigidDynamic) -> ^_c.char ---
+    rigid_dynamic_get_concrete_type_name :: proc(self_: ^RigidDynamic) -> [^]_c.char ---
 
     @(link_name = "PxRigidStatic_getConcreteTypeName")
-    rigid_static_get_concrete_type_name :: proc(self_: ^RigidStatic) -> ^_c.char ---
+    rigid_static_get_concrete_type_name :: proc(self_: ^RigidStatic) -> [^]_c.char ---
 
     /// constructor sets to default.
     @(link_name = "PxSceneQueryDesc_new")
@@ -7822,7 +7822,7 @@ foreign libphysx {
 
     /// update camera on PVD application's render window
     @(link_name = "PxPvdSceneClient_updateCamera_mut")
-    pvd_scene_client_update_camera_mut :: proc(self_: ^PvdSceneClient, name: ^_c.char, #by_ptr origin: Vec3, #by_ptr up: Vec3, #by_ptr target: Vec3) ---
+    pvd_scene_client_update_camera_mut :: proc(self_: ^PvdSceneClient, name: [^]_c.char, #by_ptr origin: Vec3, #by_ptr up: Vec3, #by_ptr target: Vec3) ---
 
     /// draw points on PVD application's render window
     @(link_name = "PxPvdSceneClient_drawPoints_mut")
@@ -7958,7 +7958,7 @@ foreign libphysx {
     ///
     /// True if success
     @(link_name = "PxScene_addActors_mut")
-    scene_add_actors_mut :: proc(self_: ^Scene, actors: ^^Actor, nbActors: _c.uint32_t) -> _c.bool ---
+    scene_add_actors_mut :: proc(self_: ^Scene, actors: [^]^Actor, nbActors: _c.uint32_t) -> _c.bool ---
 
     /// Adds a pruning structure together with its actors to this scene. Only supports actors of type PxRigidStatic and PxRigidDynamic.
     ///
@@ -8004,7 +8004,7 @@ foreign libphysx {
     ///
     /// If the actor is a PxRigidActor then all assigned PxConstraint objects will get removed from the scene automatically.
     @(link_name = "PxScene_removeActors_mut")
-    scene_remove_actors_mut :: proc(self_: ^Scene, actors: ^^Actor, nbActors: _c.uint32_t, wakeOnLostTouch: _c.bool) ---
+    scene_remove_actors_mut :: proc(self_: ^Scene, actors: [^]^Actor, nbActors: _c.uint32_t, wakeOnLostTouch: _c.bool) ---
 
     /// Adds an aggregate to this scene.
     ///
@@ -8622,7 +8622,7 @@ foreign libphysx {
     ///
     /// Recursive locking is supported but each lockRead() call must be paired with an unlockRead().
     @(link_name = "PxScene_lockRead_mut")
-    scene_lock_read_mut :: proc(self_: ^Scene, file: ^_c.char, line: _c.uint32_t) ---
+    scene_lock_read_mut :: proc(self_: ^Scene, file: [^]_c.char, line: _c.uint32_t) ---
 
     /// Unlock the scene from reading.
     ///
@@ -8651,7 +8651,7 @@ foreign libphysx {
     /// If a thread has already locked the scene for writing then it may call
     /// lockRead().
     @(link_name = "PxScene_lockWrite_mut")
-    scene_lock_write_mut :: proc(self_: ^Scene, file: ^_c.char, line: _c.uint32_t) ---
+    scene_lock_write_mut :: proc(self_: ^Scene, file: [^]_c.char, line: _c.uint32_t) ---
 
     /// Unlock the scene from writing.
     ///
@@ -8831,14 +8831,14 @@ foreign libphysx {
 
     /// Constructor
     @(link_name = "PxSceneReadLock_new_alloc")
-    scene_read_lock_new_alloc :: proc(scene: ^Scene, file: ^_c.char, line: _c.uint32_t) -> ^SceneReadLock ---
+    scene_read_lock_new_alloc :: proc(scene: ^Scene, file: [^]_c.char, line: _c.uint32_t) -> ^SceneReadLock ---
 
     @(link_name = "PxSceneReadLock_delete")
     scene_read_lock_delete :: proc(self_: ^SceneReadLock) ---
 
     /// Constructor
     @(link_name = "PxSceneWriteLock_new_alloc")
-    scene_write_lock_new_alloc :: proc(scene: ^Scene, file: ^_c.char, line: _c.uint32_t) -> ^SceneWriteLock ---
+    scene_write_lock_new_alloc :: proc(scene: ^Scene, file: [^]_c.char, line: _c.uint32_t) -> ^SceneWriteLock ---
 
     @(link_name = "PxSceneWriteLock_delete")
     scene_write_lock_delete :: proc(self_: ^SceneWriteLock) ---
@@ -8928,7 +8928,7 @@ foreign libphysx {
     /// If an actor gets newly added to a scene with properties such that it is awake and the sleep state does not get changed by
     /// the user or simulation, then an onWake() event will get sent at the next simulate/fetchResults() step.
     @(link_name = "PxSimulationEventCallback_onWake_mut")
-    simulation_event_callback_on_wake_mut :: proc(self_: ^SimulationEventCallback, actors: ^^Actor, count: _c.uint32_t) ---
+    simulation_event_callback_on_wake_mut :: proc(self_: ^SimulationEventCallback, actors: [^]^Actor, count: _c.uint32_t) ---
 
     /// This is called with the actors which have just been put to sleep.
     ///
@@ -8944,7 +8944,7 @@ foreign libphysx {
     /// If an actor gets newly added to a scene with properties such that it is asleep and the sleep state does not get changed by
     /// the user or simulation, then an onSleep() event will get sent at the next simulate/fetchResults() step.
     @(link_name = "PxSimulationEventCallback_onSleep_mut")
-    simulation_event_callback_on_sleep_mut :: proc(self_: ^SimulationEventCallback, actors: ^^Actor, count: _c.uint32_t) ---
+    simulation_event_callback_on_sleep_mut :: proc(self_: ^SimulationEventCallback, actors: [^]^Actor, count: _c.uint32_t) ---
 
     /// This is called when certain contact events occur.
     ///
@@ -9027,7 +9027,7 @@ foreign libphysx {
     pruning_structure_get_dynamic_merge_data :: proc(self_: ^PruningStructure) -> rawptr ---
 
     @(link_name = "PxPruningStructure_getConcreteTypeName")
-    pruning_structure_get_concrete_type_name :: proc(self_: ^PruningStructure) -> ^_c.char ---
+    pruning_structure_get_concrete_type_name :: proc(self_: ^PruningStructure) -> [^]_c.char ---
 
     @(link_name = "PxExtendedVec3_new")
     extended_vec3_new :: proc() -> ExtendedVec3 ---
@@ -9913,7 +9913,7 @@ foreign libphysx {
     default_memory_input_data_tell :: proc(self_: ^DefaultMemoryInputData) -> _c.uint32_t ---
 
     @(link_name = "PxDefaultFileOutputStream_new_alloc")
-    default_file_output_stream_new_alloc :: proc(name: ^_c.char) -> ^DefaultFileOutputStream ---
+    default_file_output_stream_new_alloc :: proc(name: [^]_c.char) -> ^DefaultFileOutputStream ---
 
     @(link_name = "PxDefaultFileOutputStream_delete")
     default_file_output_stream_delete :: proc(self_: ^DefaultFileOutputStream) ---
@@ -9925,7 +9925,7 @@ foreign libphysx {
     default_file_output_stream_is_valid_mut :: proc(self_: ^DefaultFileOutputStream) -> _c.bool ---
 
     @(link_name = "PxDefaultFileInputData_new_alloc")
-    default_file_input_data_new_alloc :: proc(name: ^_c.char) -> ^DefaultFileInputData ---
+    default_file_input_data_new_alloc :: proc(name: [^]_c.char) -> ^DefaultFileInputData ---
 
     @(link_name = "PxDefaultFileInputData_delete")
     default_file_input_data_delete :: proc(self_: ^DefaultFileInputData) ---
@@ -9952,7 +9952,7 @@ foreign libphysx {
     platform_aligned_free :: proc(ptr: rawptr) ---
 
     @(link_name = "PxDefaultAllocator_allocate_mut")
-    default_allocator_allocate_mut :: proc(self_: ^DefaultAllocator, size: _c.size_t, anon_param1: ^_c.char, anon_param2: ^_c.char, anon_param3: _c.int32_t) -> rawptr ---
+    default_allocator_allocate_mut :: proc(self_: ^DefaultAllocator, size: _c.size_t, anon_param1: [^]_c.char, anon_param2: [^]_c.char, anon_param3: _c.int32_t) -> rawptr ---
 
     @(link_name = "PxDefaultAllocator_deallocate_mut")
     default_allocator_deallocate_mut :: proc(self_: ^DefaultAllocator, ptr: rawptr) ---
@@ -10080,13 +10080,13 @@ foreign libphysx {
     /// This is for debugging and is not used by the SDK. The string is not copied by the SDK,
     /// only the pointer is stored.
     @(link_name = "PxJoint_setName_mut")
-    joint_set_name_mut :: proc(self_: ^Joint, name: ^_c.char) ---
+    joint_set_name_mut :: proc(self_: ^Joint, name: [^]_c.char) ---
 
     /// Retrieves the name string set with setName().
     ///
     /// Name string associated with object.
     @(link_name = "PxJoint_getName")
-    joint_get_name :: proc(self_: ^Joint) -> ^_c.char ---
+    joint_get_name :: proc(self_: ^Joint) -> [^]_c.char ---
 
     /// Deletes the joint.
     ///
@@ -10259,7 +10259,7 @@ foreign libphysx {
 
     /// Returns string name of PxDistanceJoint, used for serialization
     @(link_name = "PxDistanceJoint_getConcreteTypeName")
-    distance_joint_get_concrete_type_name :: proc(self_: ^DistanceJoint) -> ^_c.char ---
+    distance_joint_get_concrete_type_name :: proc(self_: ^DistanceJoint) -> [^]_c.char ---
 
     /// Create a distance Joint.
     @(link_name = "phys_PxContactJointCreate")
@@ -10309,7 +10309,7 @@ foreign libphysx {
 
     /// Returns string name of PxContactJoint, used for serialization
     @(link_name = "PxContactJoint_getConcreteTypeName")
-    contact_joint_get_concrete_type_name :: proc(self_: ^ContactJoint) -> ^_c.char ---
+    contact_joint_get_concrete_type_name :: proc(self_: ^ContactJoint) -> [^]_c.char ---
 
     @(link_name = "PxContactJoint_computeJacobians")
     contact_joint_compute_jacobians :: proc(self_: ^ContactJoint, jacobian: ^JacobianRow) ---
@@ -10323,7 +10323,7 @@ foreign libphysx {
 
     /// Returns string name of PxFixedJoint, used for serialization
     @(link_name = "PxFixedJoint_getConcreteTypeName")
-    fixed_joint_get_concrete_type_name :: proc(self_: ^FixedJoint) -> ^_c.char ---
+    fixed_joint_get_concrete_type_name :: proc(self_: ^FixedJoint) -> [^]_c.char ---
 
     @(link_name = "PxJointLimitParameters_new_alloc")
     joint_limit_parameters_new_alloc :: proc() -> ^JointLimitParameters ---
@@ -10468,7 +10468,7 @@ foreign libphysx {
 
     /// Returns string name of PxPrismaticJoint, used for serialization
     @(link_name = "PxPrismaticJoint_getConcreteTypeName")
-    prismatic_joint_get_concrete_type_name :: proc(self_: ^PrismaticJoint) -> ^_c.char ---
+    prismatic_joint_get_concrete_type_name :: proc(self_: ^PrismaticJoint) -> [^]_c.char ---
 
     /// Create a revolute joint.
     @(link_name = "phys_PxRevoluteJointCreate")
@@ -10573,7 +10573,7 @@ foreign libphysx {
 
     /// Returns string name of PxRevoluteJoint, used for serialization
     @(link_name = "PxRevoluteJoint_getConcreteTypeName")
-    revolute_joint_get_concrete_type_name :: proc(self_: ^RevoluteJoint) -> ^_c.char ---
+    revolute_joint_get_concrete_type_name :: proc(self_: ^RevoluteJoint) -> [^]_c.char ---
 
     /// Create a spherical joint.
     @(link_name = "phys_PxSphericalJointCreate")
@@ -10619,7 +10619,7 @@ foreign libphysx {
 
     /// Returns string name of PxSphericalJoint, used for serialization
     @(link_name = "PxSphericalJoint_getConcreteTypeName")
-    spherical_joint_get_concrete_type_name :: proc(self_: ^SphericalJoint) -> ^_c.char ---
+    spherical_joint_get_concrete_type_name :: proc(self_: ^SphericalJoint) -> [^]_c.char ---
 
     /// Create a D6 joint.
     @(link_name = "phys_PxD6JointCreate")
@@ -10824,7 +10824,7 @@ foreign libphysx {
 
     /// Returns string name of PxD6Joint, used for serialization
     @(link_name = "PxD6Joint_getConcreteTypeName")
-    d6_joint_get_concrete_type_name :: proc(self_: ^D6Joint) -> ^_c.char ---
+    d6_joint_get_concrete_type_name :: proc(self_: ^D6Joint) -> [^]_c.char ---
 
     /// Create a gear Joint.
     @(link_name = "phys_PxGearJointCreate")
@@ -10863,7 +10863,7 @@ foreign libphysx {
     gear_joint_get_gear_ratio :: proc(self_: ^GearJoint) -> _c.float ---
 
     @(link_name = "PxGearJoint_getConcreteTypeName")
-    gear_joint_get_concrete_type_name :: proc(self_: ^GearJoint) -> ^_c.char ---
+    gear_joint_get_concrete_type_name :: proc(self_: ^GearJoint) -> [^]_c.char ---
 
     /// Create a rack
     /// &
@@ -10922,7 +10922,7 @@ foreign libphysx {
     rack_and_pinion_joint_set_data_mut :: proc(self_: ^RackAndPinionJoint, nbRackTeeth: _c.uint32_t, nbPinionTeeth: _c.uint32_t, rackLength: _c.float) -> _c.bool ---
 
     @(link_name = "PxRackAndPinionJoint_getConcreteTypeName")
-    rack_and_pinion_joint_get_concrete_type_name :: proc(self_: ^RackAndPinionJoint) -> ^_c.char ---
+    rack_and_pinion_joint_get_concrete_type_name :: proc(self_: ^RackAndPinionJoint) -> [^]_c.char ---
 
     @(link_name = "PxGroupsMask_new_alloc")
     groups_mask_new_alloc :: proc() -> ^GroupsMask ---
@@ -11020,7 +11020,7 @@ foreign libphysx {
     default_error_callback_delete :: proc(self_: ^DefaultErrorCallback) ---
 
     @(link_name = "PxDefaultErrorCallback_reportError_mut")
-    default_error_callback_report_error_mut :: proc(self_: ^DefaultErrorCallback, code: ErrorCode, message: ^_c.char, file: ^_c.char, line: _c.int32_t) ---
+    default_error_callback_report_error_mut :: proc(self_: ^DefaultErrorCallback, code: ErrorCode, message: [^]_c.char, file: [^]_c.char, line: _c.int32_t) ---
 
     /// Creates a new shape with default properties and a list of materials and adds it to the list of shapes of this actor.
     ///
@@ -12077,7 +12077,7 @@ foreign libphysx {
     close_extensions :: proc() ---
 
     @(link_name = "PxRepXObject_new")
-    rep_x_object_new :: proc(inTypeName: ^_c.char, inSerializable: rawptr, inId: _c.uint64_t) -> RepXObject ---
+    rep_x_object_new :: proc(inTypeName: [^]_c.char, inSerializable: rawptr, inId: _c.uint64_t) -> RepXObject ---
 
     @(link_name = "PxRepXObject_isValid")
     rep_x_object_is_valid :: proc(self_: ^RepXObject) -> _c.bool ---
@@ -12087,7 +12087,7 @@ foreign libphysx {
 
     /// The type this Serializer is meant to operate on.
     @(link_name = "PxRepXSerializer_getTypeName_mut")
-    rep_x_serializer_get_type_name_mut :: proc(self_: ^RepXSerializer) -> ^_c.char ---
+    rep_x_serializer_get_type_name_mut :: proc(self_: ^RepXSerializer) -> [^]_c.char ---
 
     /// Convert from a RepX object to a key-value pair hierarchy
     @(link_name = "PxRepXSerializer_objectToFile_mut")
@@ -12167,10 +12167,10 @@ foreign libphysx {
 
     /// Create a default socket transport.
     @(link_name = "phys_PxDefaultPvdSocketTransportCreate")
-    default_pvd_socket_transport_create :: proc(host: ^_c.char, port: _c.int32_t, timeoutInMilliseconds: _c.uint32_t) -> ^PvdTransport ---
+    default_pvd_socket_transport_create :: proc(host: [^]_c.char, port: _c.int32_t, timeoutInMilliseconds: _c.uint32_t) -> ^PvdTransport ---
 
     /// Create a default file transport.
     @(link_name = "phys_PxDefaultPvdFileTransportCreate")
-    default_pvd_file_transport_create :: proc(name: ^_c.char) -> ^PvdTransport ---
+    default_pvd_file_transport_create :: proc(name: [^]_c.char) -> ^PvdTransport ---
 
 }

--- a/functions.odin
+++ b/functions.odin
@@ -23,7 +23,7 @@ foreign libphysx {
     ///
     /// The allocated block of memory.
     @(link_name = "PxAllocatorCallback_allocate_mut")
-    allocator_callback_allocate_mut :: proc(self_: ^AllocatorCallback, size: _c.size_t, typeName: [^]_c.char, filename: [^]_c.char, line: _c.int32_t) -> rawptr ---
+    allocator_callback_allocate_mut :: proc(self_: ^AllocatorCallback, size: _c.size_t, typeName: cstring, filename: cstring, line: _c.int32_t) -> rawptr ---
 
     /// Frees memory previously allocated by allocate().
     ///
@@ -140,19 +140,19 @@ foreign libphysx {
     inc_foundation_ref_count :: proc() ---
 
     @(link_name = "PxAllocator_new")
-    allocator_new :: proc(anon_param0: [^]_c.char) -> Allocator ---
+    allocator_new :: proc(anon_param0: cstring) -> Allocator ---
 
     @(link_name = "PxAllocator_allocate_mut")
-    allocator_allocate_mut :: proc(self_: ^Allocator, size: _c.size_t, file: [^]_c.char, line: _c.int32_t) -> rawptr ---
+    allocator_allocate_mut :: proc(self_: ^Allocator, size: _c.size_t, file: cstring, line: _c.int32_t) -> rawptr ---
 
     @(link_name = "PxAllocator_deallocate_mut")
     allocator_deallocate_mut :: proc(self_: ^Allocator, ptr: rawptr) ---
 
     @(link_name = "PxRawAllocator_new")
-    raw_allocator_new :: proc(anon_param0: [^]_c.char) -> RawAllocator ---
+    raw_allocator_new :: proc(anon_param0: cstring) -> RawAllocator ---
 
     @(link_name = "PxRawAllocator_allocate_mut")
-    raw_allocator_allocate_mut :: proc(self_: ^RawAllocator, size: _c.size_t, anon_param1: [^]_c.char, anon_param2: _c.int32_t) -> rawptr ---
+    raw_allocator_allocate_mut :: proc(self_: ^RawAllocator, size: _c.size_t, anon_param1: cstring, anon_param2: _c.int32_t) -> rawptr ---
 
     @(link_name = "PxRawAllocator_deallocate_mut")
     raw_allocator_deallocate_mut :: proc(self_: ^RawAllocator, ptr: rawptr) ---
@@ -161,7 +161,7 @@ foreign libphysx {
     virtual_allocator_callback_delete :: proc(self_: ^VirtualAllocatorCallback) ---
 
     @(link_name = "PxVirtualAllocatorCallback_allocate_mut")
-    virtual_allocator_callback_allocate_mut :: proc(self_: ^VirtualAllocatorCallback, size: _c.size_t, group: _c.int32_t, file: [^]_c.char, line: _c.int32_t) -> rawptr ---
+    virtual_allocator_callback_allocate_mut :: proc(self_: ^VirtualAllocatorCallback, size: _c.size_t, group: _c.int32_t, file: cstring, line: _c.int32_t) -> rawptr ---
 
     @(link_name = "PxVirtualAllocatorCallback_deallocate_mut")
     virtual_allocator_callback_deallocate_mut :: proc(self_: ^VirtualAllocatorCallback, ptr: rawptr) ---
@@ -170,7 +170,7 @@ foreign libphysx {
     virtual_allocator_new :: proc(callback: ^VirtualAllocatorCallback, group: _c.int32_t) -> VirtualAllocator ---
 
     @(link_name = "PxVirtualAllocator_allocate_mut")
-    virtual_allocator_allocate_mut :: proc(self_: ^VirtualAllocator, size: _c.size_t, file: [^]_c.char, line: _c.int32_t) -> rawptr ---
+    virtual_allocator_allocate_mut :: proc(self_: ^VirtualAllocator, size: _c.size_t, file: cstring, line: _c.int32_t) -> rawptr ---
 
     @(link_name = "PxVirtualAllocator_deallocate_mut")
     virtual_allocator_deallocate_mut :: proc(self_: ^VirtualAllocator, ptr: rawptr) ---
@@ -179,10 +179,10 @@ foreign libphysx {
     temp_allocator_chunk_new :: proc() -> TempAllocatorChunk ---
 
     @(link_name = "PxTempAllocator_new")
-    temp_allocator_new :: proc(anon_param0: [^]_c.char) -> TempAllocator ---
+    temp_allocator_new :: proc(anon_param0: cstring) -> TempAllocator ---
 
     @(link_name = "PxTempAllocator_allocate_mut")
-    temp_allocator_allocate_mut :: proc(self_: ^TempAllocator, size: _c.size_t, file: [^]_c.char, line: _c.int32_t) -> rawptr ---
+    temp_allocator_allocate_mut :: proc(self_: ^TempAllocator, size: _c.size_t, file: cstring, line: _c.int32_t) -> rawptr ---
 
     @(link_name = "PxTempAllocator_deallocate_mut")
     temp_allocator_deallocate_mut :: proc(self_: ^TempAllocator, ptr: rawptr) ---
@@ -559,7 +559,7 @@ foreign libphysx {
 
     /// Construct from float[9]
     @(link_name = "PxMat33_new_5")
-    mat33_new_5 :: proc(values: [^]_c.float) -> Mat33 ---
+    mat33_new_5 :: proc(values: ^_c.float) -> Mat33 ---
 
     /// Construct from a quaternion
     @(link_name = "PxMat33_new_6")
@@ -747,11 +747,11 @@ foreign libphysx {
 
     /// Reports an error code.
     @(link_name = "PxErrorCallback_reportError_mut")
-    error_callback_report_error_mut :: proc(self_: ^ErrorCallback, code: ErrorCode, message: [^]_c.char, file: [^]_c.char, line: _c.int32_t) ---
+    error_callback_report_error_mut :: proc(self_: ^ErrorCallback, code: ErrorCode, message: cstring, file: cstring, line: _c.int32_t) ---
 
     /// callback when memory is allocated.
     @(link_name = "PxAllocationListener_onAllocation_mut")
-    allocation_listener_on_allocation_mut :: proc(self_: ^AllocationListener, size: _c.size_t, typeName: [^]_c.char, filename: [^]_c.char, line: _c.int32_t, allocatedMemory: rawptr) ---
+    allocation_listener_on_allocation_mut :: proc(self_: ^AllocationListener, size: _c.size_t, typeName: cstring, filename: cstring, line: _c.int32_t, allocatedMemory: rawptr) ---
 
     /// callback when memory is deallocated.
     @(link_name = "PxAllocationListener_onDeallocation_mut")
@@ -776,7 +776,7 @@ foreign libphysx {
     ///
     /// The allocated block of memory.
     @(link_name = "PxBroadcastingAllocator_allocate_mut")
-    broadcasting_allocator_allocate_mut :: proc(self_: ^BroadcastingAllocator, size: _c.size_t, typeName: [^]_c.char, filename: [^]_c.char, line: _c.int32_t) -> rawptr ---
+    broadcasting_allocator_allocate_mut :: proc(self_: ^BroadcastingAllocator, size: _c.size_t, typeName: cstring, filename: cstring, line: _c.int32_t) -> rawptr ---
 
     /// Frees memory previously allocated by allocate().
     ///
@@ -796,7 +796,7 @@ foreign libphysx {
 
     /// Reports an error code.
     @(link_name = "PxBroadcastingErrorCallback_reportError_mut")
-    broadcasting_error_callback_report_error_mut :: proc(self_: ^BroadcastingErrorCallback, code: ErrorCode, message: [^]_c.char, file: [^]_c.char, line: _c.int32_t) ---
+    broadcasting_error_callback_report_error_mut :: proc(self_: ^BroadcastingErrorCallback, code: ErrorCode, message: cstring, file: cstring, line: _c.int32_t) ---
 
     /// Enables floating point exceptions for the scalar and SIMD unit
     @(link_name = "phys_PxEnableFPExceptions")
@@ -867,7 +867,7 @@ foreign libphysx {
 
     /// Initializes from an array of scalar parameters.
     @(link_name = "PxVec4_new_5")
-    vec4_new_5 :: proc(v: [^]_c.float) -> Vec4 ---
+    vec4_new_5 :: proc(v: ^_c.float) -> Vec4 ---
 
     /// tests for exact zero vector
     @(link_name = "PxVec4_isZero")
@@ -1218,16 +1218,16 @@ foreign libphysx {
     ///
     /// Returns implementation-specific profiler data for this event
     @(link_name = "PxProfilerCallback_zoneStart_mut")
-    profiler_callback_zone_start_mut :: proc(self_: ^ProfilerCallback, eventName: [^]_c.char, detached: _c.bool, contextId: _c.uint64_t) -> rawptr ---
+    profiler_callback_zone_start_mut :: proc(self_: ^ProfilerCallback, eventName: cstring, detached: _c.bool, contextId: _c.uint64_t) -> rawptr ---
 
     /// Mark the end of a nested profile block
     ///
     /// eventName plus contextId can be used to uniquely match up start and end of a zone.
     @(link_name = "PxProfilerCallback_zoneEnd_mut")
-    profiler_callback_zone_end_mut :: proc(self_: ^ProfilerCallback, profilerData: rawptr, eventName: [^]_c.char, detached: _c.bool, contextId: _c.uint64_t) ---
+    profiler_callback_zone_end_mut :: proc(self_: ^ProfilerCallback, profilerData: rawptr, eventName: cstring, detached: _c.bool, contextId: _c.uint64_t) ---
 
     @(link_name = "PxProfileScoped_new_alloc")
-    profile_scoped_new_alloc :: proc(callback: ^ProfilerCallback, eventName: [^]_c.char, detached: _c.bool, contextId: _c.uint64_t) -> ^ProfileScoped ---
+    profile_scoped_new_alloc :: proc(callback: ^ProfilerCallback, eventName: cstring, detached: _c.bool, contextId: _c.uint64_t) -> ^ProfileScoped ---
 
     @(link_name = "PxProfileScoped_delete")
     profile_scoped_delete :: proc(self_: ^ProfileScoped) ---
@@ -1428,7 +1428,7 @@ foreign libphysx {
     debug_text_new :: proc() -> DebugText ---
 
     @(link_name = "PxDebugText_new_1")
-    debug_text_new_1 :: proc(#by_ptr pos: Vec3, #by_ptr sz: _c.float, #by_ptr clr: _c.uint32_t, str: [^]_c.char) -> DebugText ---
+    debug_text_new_1 :: proc(#by_ptr pos: Vec3, #by_ptr sz: _c.float, #by_ptr clr: _c.uint32_t, str: cstring) -> DebugText ---
 
     @(link_name = "PxRenderBuffer_delete")
     render_buffer_delete :: proc(self_: ^RenderBuffer) ---
@@ -1452,10 +1452,10 @@ foreign libphysx {
     render_buffer_add_line_mut :: proc(self_: ^RenderBuffer, #by_ptr line: DebugLine) ---
 
     @(link_name = "PxRenderBuffer_reserveLines_mut")
-    render_buffer_reserve_lines_mut :: proc(self_: ^RenderBuffer, nbLines: _c.uint32_t) -> [^]DebugLine ---
+    render_buffer_reserve_lines_mut :: proc(self_: ^RenderBuffer, nbLines: _c.uint32_t) -> ^DebugLine ---
 
     @(link_name = "PxRenderBuffer_reservePoints_mut")
-    render_buffer_reserve_points_mut :: proc(self_: ^RenderBuffer, nbLines: _c.uint32_t) -> [^]DebugPoint ---
+    render_buffer_reserve_points_mut :: proc(self_: ^RenderBuffer, nbLines: _c.uint32_t) -> ^DebugPoint ---
 
     @(link_name = "PxRenderBuffer_getNbTriangles")
     render_buffer_get_nb_triangles :: proc(self_: ^RenderBuffer) -> _c.uint32_t ---
@@ -1520,7 +1520,7 @@ foreign libphysx {
     ///
     /// This function is assumed to be called within the implementation of PxSerializer::exportExtraData.
     @(link_name = "PxSerializationContext_writeName_mut")
-    serialization_context_write_name_mut :: proc(self_: ^SerializationContext, name: [^]_c.char) ---
+    serialization_context_write_name_mut :: proc(self_: ^SerializationContext, name: cstring) ---
 
     /// Retrieves a pointer to a deserialized PxBase object given a corresponding deserialized reference value
     ///
@@ -1541,7 +1541,7 @@ foreign libphysx {
     ///
     /// This function is assumed to be called within the implementation of PxSerializer::createObject.
     @(link_name = "PxDeserializationContext_readName_mut")
-    deserialization_context_read_name_mut :: proc(self_: ^DeserializationContext, name: ^[^]_c.char) ---
+    deserialization_context_read_name_mut :: proc(self_: ^DeserializationContext, name: ^cstring) ---
 
     /// Function to align the extra data stream to a power of 2 alignment
     ///
@@ -1579,7 +1579,7 @@ foreign libphysx {
     ///
     /// Registered PxRepXSerializer object corresponding to type name
     @(link_name = "PxSerializationRegistry_getRepXSerializer")
-    serialization_registry_get_rep_x_serializer :: proc(self_: ^SerializationRegistry, typeName: [^]_c.char) -> ^RepXSerializer ---
+    serialization_registry_get_rep_x_serializer :: proc(self_: ^SerializationRegistry, typeName: cstring) -> ^RepXSerializer ---
 
     /// Releases PxSerializationRegistry instance.
     ///
@@ -1674,7 +1674,7 @@ foreign libphysx {
     ///
     /// number of members PxSerialObjectId values that have been written to the userBuffer
     @(link_name = "PxCollection_getIds")
-    collection_get_ids :: proc(self_: ^Collection, userBuffer: [^]_c.uint64_t, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
+    collection_get_ids :: proc(self_: ^Collection, userBuffer: ^_c.uint64_t, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
 
     /// Gets the PxSerialObjectId name of a PxBase object within the collection.
     ///
@@ -1709,7 +1709,7 @@ foreign libphysx {
     ///
     /// Class name of most derived type of this object.
     @(link_name = "PxBase_getConcreteTypeName")
-    base_get_concrete_type_name :: proc(self_: ^Base) -> [^]_c.char ---
+    base_get_concrete_type_name :: proc(self_: ^Base) -> cstring ---
 
     /// Returns concrete type of object.
     ///
@@ -1772,7 +1772,7 @@ foreign libphysx {
     ///
     /// *Always* a valid null terminated string.  "" is returned if "" or null is passed in.
     @(link_name = "PxStringTable_allocateStr_mut")
-    string_table_allocate_str_mut :: proc(self_: ^StringTable, inSrc: [^]_c.char) -> [^]_c.char ---
+    string_table_allocate_str_mut :: proc(self_: ^StringTable, inSrc: cstring) -> cstring ---
 
     /// Release the string table and all the strings associated with it.
     @(link_name = "PxStringTable_release_mut")
@@ -1782,7 +1782,7 @@ foreign libphysx {
     ///
     /// Class name of most derived type of this object.
     @(link_name = "PxSerializer_getConcreteTypeName")
-    serializer_get_concrete_type_name :: proc(self_: ^Serializer) -> [^]_c.char ---
+    serializer_get_concrete_type_name :: proc(self_: ^Serializer) -> cstring ---
 
     /// Adds required objects to the collection.
     ///
@@ -1866,13 +1866,13 @@ foreign libphysx {
     ///
     /// The ID of the task with that name, or eNOT_PRESENT if not found
     @(link_name = "PxTaskManager_getNamedTask_mut")
-    task_manager_get_named_task_mut :: proc(self_: ^TaskManager, name: [^]_c.char) -> _c.uint32_t ---
+    task_manager_get_named_task_mut :: proc(self_: ^TaskManager, name: cstring) -> _c.uint32_t ---
 
     /// Submit a task with a unique name.
     ///
     /// The ID of the task with that name, or eNOT_PRESENT if not found
     @(link_name = "PxTaskManager_submitNamedTask_mut")
-    task_manager_submit_named_task_mut :: proc(self_: ^TaskManager, task: ^Task, name: [^]_c.char, type: TaskType) -> _c.uint32_t ---
+    task_manager_submit_named_task_mut :: proc(self_: ^TaskManager, task: ^Task, name: cstring, type: TaskType) -> _c.uint32_t ---
 
     /// Submit an unnamed task.
     ///
@@ -1926,7 +1926,7 @@ foreign libphysx {
     ///
     /// The name of this task
     @(link_name = "PxBaseTask_getName")
-    base_task_get_name :: proc(self_: ^BaseTask) -> [^]_c.char ---
+    base_task_get_name :: proc(self_: ^BaseTask) -> cstring ---
 
     /// Implemented by derived implementation classes
     @(link_name = "PxBaseTask_addReference_mut")
@@ -2180,7 +2180,7 @@ foreign libphysx {
     b_v_h_traverse :: proc(self_: ^BVH, cb: ^BVHTraversalCallback) -> _c.bool ---
 
     @(link_name = "PxBVH_getConcreteTypeName")
-    b_v_h_get_concrete_type_name :: proc(self_: ^BVH) -> [^]_c.char ---
+    b_v_h_get_concrete_type_name :: proc(self_: ^BVH) -> cstring ---
 
     /// Constructor, initializes to a capsule with passed radius and half height.
     @(link_name = "PxCapsuleGeometry_new")
@@ -2255,7 +2255,7 @@ foreign libphysx {
     convex_mesh_get_s_d_f :: proc(self_: ^ConvexMesh) -> ^_c.float ---
 
     @(link_name = "PxConvexMesh_getConcreteTypeName")
-    convex_mesh_get_concrete_type_name :: proc(self_: ^ConvexMesh) -> [^]_c.char ---
+    convex_mesh_get_concrete_type_name :: proc(self_: ^ConvexMesh) -> cstring ---
 
     /// This method decides whether a convex mesh is gpu compatible. If the total number of vertices are more than 64 or any number of vertices in a polygon is more than 32, or
     /// convex hull data was not cooked with GPU data enabled during cooking or was loaded from a serialized collection, the convex hull is incompatible with GPU collision detection. Otherwise
@@ -2784,7 +2784,7 @@ foreign libphysx {
     height_field_get_timestamp :: proc(self_: ^HeightField) -> _c.uint32_t ---
 
     @(link_name = "PxHeightField_getConcreteTypeName")
-    height_field_get_concrete_type_name :: proc(self_: ^HeightField) -> [^]_c.char ---
+    height_field_get_concrete_type_name :: proc(self_: ^HeightField) -> cstring ---
 
     /// Constructor sets to default.
     @(link_name = "PxHeightFieldDesc_new")
@@ -3238,13 +3238,13 @@ foreign libphysx {
     /// Default:
     /// NULL
     @(link_name = "PxActor_setName_mut")
-    actor_set_name_mut :: proc(self_: ^Actor, name: [^]_c.char) ---
+    actor_set_name_mut :: proc(self_: ^Actor, name: cstring) ---
 
     /// Retrieves the name string set with setName().
     ///
     /// Name string associated with object.
     @(link_name = "PxActor_getName")
-    actor_get_name :: proc(self_: ^Actor) -> [^]_c.char ---
+    actor_get_name :: proc(self_: ^Actor) -> cstring ---
 
     /// Retrieves the axis aligned bounding box enclosing the actor.
     ///
@@ -3409,7 +3409,7 @@ foreign libphysx {
     ///
     /// Number of actor pointers written to the buffer.
     @(link_name = "PxAggregate_getActors")
-    aggregate_get_actors :: proc(self_: ^Aggregate, userBuffer: [^][^]Actor, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
+    aggregate_get_actors :: proc(self_: ^Aggregate, userBuffer: [^]^Actor, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
 
     /// Retrieves the scene which this aggregate belongs to.
     ///
@@ -3424,7 +3424,7 @@ foreign libphysx {
     aggregate_get_self_collision :: proc(self_: ^Aggregate) -> _c.bool ---
 
     @(link_name = "PxAggregate_getConcreteTypeName")
-    aggregate_get_concrete_type_name :: proc(self_: ^Aggregate) -> [^]_c.char ---
+    aggregate_get_concrete_type_name :: proc(self_: ^Aggregate) -> cstring ---
 
     @(link_name = "PxConstraintInvMassScale_new")
     constraint_inv_mass_scale_new :: proc() -> ConstraintInvMassScale ---
@@ -3636,7 +3636,7 @@ foreign libphysx {
     ///
     /// The string name.
     @(link_name = "PxArticulationAttachment_getConcreteTypeName")
-    articulation_attachment_get_concrete_type_name :: proc(self_: ^ArticulationAttachment) -> [^]_c.char ---
+    articulation_attachment_get_concrete_type_name :: proc(self_: ^ArticulationAttachment) -> cstring ---
 
     /// Sets the tendon joint coefficient.
     ///
@@ -3678,7 +3678,7 @@ foreign libphysx {
     ///
     /// The string name.
     @(link_name = "PxArticulationTendonJoint_getConcreteTypeName")
-    articulation_tendon_joint_get_concrete_type_name :: proc(self_: ^ArticulationTendonJoint) -> [^]_c.char ---
+    articulation_tendon_joint_get_concrete_type_name :: proc(self_: ^ArticulationTendonJoint) -> cstring ---
 
     /// Sets the spring stiffness term acting on the tendon length.
     @(link_name = "PxArticulationTendon_setStiffness_mut")
@@ -3767,7 +3767,7 @@ foreign libphysx {
     ///
     /// The string name.
     @(link_name = "PxArticulationSpatialTendon_getConcreteTypeName")
-    articulation_spatial_tendon_get_concrete_type_name :: proc(self_: ^ArticulationSpatialTendon) -> [^]_c.char ---
+    articulation_spatial_tendon_get_concrete_type_name :: proc(self_: ^ArticulationSpatialTendon) -> cstring ---
 
     /// Creates an articulation tendon joint and adds it to the list of children in the parent tendon joint.
     ///
@@ -3826,7 +3826,7 @@ foreign libphysx {
     ///
     /// The string name.
     @(link_name = "PxArticulationFixedTendon_getConcreteTypeName")
-    articulation_fixed_tendon_get_concrete_type_name :: proc(self_: ^ArticulationFixedTendon) -> [^]_c.char ---
+    articulation_fixed_tendon_get_concrete_type_name :: proc(self_: ^ArticulationFixedTendon) -> cstring ---
 
     @(link_name = "PxArticulationCache_new")
     articulation_cache_new :: proc() -> ArticulationCache ---
@@ -3905,7 +3905,7 @@ foreign libphysx {
     ///
     /// The string name.
     @(link_name = "PxArticulationSensor_getConcreteTypeName")
-    articulation_sensor_get_concrete_type_name :: proc(self_: ^ArticulationSensor) -> [^]_c.char ---
+    articulation_sensor_get_concrete_type_name :: proc(self_: ^ArticulationSensor) -> cstring ---
 
     /// Returns the scene which this articulation belongs to.
     ///
@@ -4125,13 +4125,13 @@ foreign libphysx {
     /// This is for debugging and is not used by the SDK. The string is not copied by the SDK,
     /// only the pointer is stored.
     @(link_name = "PxArticulationReducedCoordinate_setName_mut")
-    articulation_reduced_coordinate_set_name_mut :: proc(self_: ^ArticulationReducedCoordinate, name: [^]_c.char) ---
+    articulation_reduced_coordinate_set_name_mut :: proc(self_: ^ArticulationReducedCoordinate, name: cstring) ---
 
     /// Returns the name string set with setName().
     ///
     /// Name string associated with the articulation.
     @(link_name = "PxArticulationReducedCoordinate_getName")
-    articulation_reduced_coordinate_get_name :: proc(self_: ^ArticulationReducedCoordinate) -> [^]_c.char ---
+    articulation_reduced_coordinate_get_name :: proc(self_: ^ArticulationReducedCoordinate) -> cstring ---
 
     /// Returns the axis-aligned bounding box enclosing the articulation.
     ///
@@ -4796,7 +4796,7 @@ foreign libphysx {
     ///
     /// The string name.
     @(link_name = "PxArticulationJointReducedCoordinate_getConcreteTypeName")
-    articulation_joint_reduced_coordinate_get_concrete_type_name :: proc(self_: ^ArticulationJointReducedCoordinate) -> [^]_c.char ---
+    articulation_joint_reduced_coordinate_get_concrete_type_name :: proc(self_: ^ArticulationJointReducedCoordinate) -> cstring ---
 
     /// Decrements the reference count of a shape and releases it if the new reference count is zero.
     ///
@@ -4892,7 +4892,7 @@ foreign libphysx {
     /// NOT
     /// wake the associated actor up automatically.
     @(link_name = "PxShape_setMaterials_mut")
-    shape_set_materials_mut :: proc(self_: ^Shape, materials: ^^Material, materialCount: _c.uint16_t) ---
+    shape_set_materials_mut :: proc(self_: ^Shape, materials: [^]^Material, materialCount: _c.uint16_t) ---
 
     /// Returns the number of materials assigned to the shape.
     ///
@@ -5071,16 +5071,16 @@ foreign libphysx {
     /// Default:
     /// NULL
     @(link_name = "PxShape_setName_mut")
-    shape_set_name_mut :: proc(self_: ^Shape, name: [^]_c.char) ---
+    shape_set_name_mut :: proc(self_: ^Shape, name: cstring) ---
 
     /// retrieves the name string set with setName().
     ///
     /// The name associated with the shape.
     @(link_name = "PxShape_getName")
-    shape_get_name :: proc(self_: ^Shape) -> [^]_c.char ---
+    shape_get_name :: proc(self_: ^Shape) -> cstring ---
 
     @(link_name = "PxShape_getConcreteTypeName")
-    shape_get_concrete_type_name :: proc(self_: ^Shape) -> [^]_c.char ---
+    shape_get_concrete_type_name :: proc(self_: ^Shape) -> cstring ---
 
     /// Deletes the rigid actor object.
     ///
@@ -5713,7 +5713,7 @@ foreign libphysx {
     ///
     /// The string name.
     @(link_name = "PxArticulationLink_getConcreteTypeName")
-    articulation_link_get_concrete_type_name :: proc(self_: ^ArticulationLink) -> [^]_c.char ---
+    articulation_link_get_concrete_type_name :: proc(self_: ^ArticulationLink) -> cstring ---
 
     @(link_name = "PxConeLimitedConstraint_new")
     cone_limited_constraint_new :: proc() -> ConeLimitedConstraint ---
@@ -5813,7 +5813,7 @@ foreign libphysx {
     constraint_set_constraint_functions_mut :: proc(self_: ^Constraint, connector: ^ConstraintConnector, #by_ptr shaders: ConstraintShaderTable) ---
 
     @(link_name = "PxConstraint_getConcreteTypeName")
-    constraint_get_concrete_type_name :: proc(self_: ^Constraint) -> [^]_c.char ---
+    constraint_get_concrete_type_name :: proc(self_: ^Constraint) -> cstring ---
 
     /// Constructor
     @(link_name = "PxContactStreamIterator_new")
@@ -6179,7 +6179,7 @@ foreign libphysx {
     deletion_listener_on_release_mut :: proc(self_: ^DeletionListener, observed: ^Base, userData: rawptr, deletionEvent: DeletionEventFlag) ---
 
     @(link_name = "PxBaseMaterial_isKindOf")
-    base_material_is_kind_of :: proc(self_: ^BaseMaterial, name: [^]_c.char) -> _c.bool ---
+    base_material_is_kind_of :: proc(self_: ^BaseMaterial, name: cstring) -> _c.bool ---
 
     /// Sets young's modulus which defines the body's stiffness
     @(link_name = "PxFEMMaterial_setYoungsModulus_mut")
@@ -6450,7 +6450,7 @@ foreign libphysx {
     material_get_restitution_combine_mode :: proc(self_: ^Material) -> CombineMode ---
 
     @(link_name = "PxMaterial_getConcreteTypeName")
-    material_get_concrete_type_name :: proc(self_: ^Material) -> [^]_c.char ---
+    material_get_concrete_type_name :: proc(self_: ^Material) -> cstring ---
 
     /// Construct parameters with default values.
     @(link_name = "PxDiffuseParticleParams_new")
@@ -6746,7 +6746,7 @@ foreign libphysx {
     ///
     /// Shapes created from *SDF* triangle-mesh geometries do not support more than one material.
     @(link_name = "PxPhysics_createShape_mut_1")
-    physics_create_shape_mut_1 :: proc(self_: ^Physics, geometry: ^Geometry, materials: ^^Material, materialCount: _c.uint16_t, isExclusive: _c.bool, shapeFlags: ShapeFlags_Set) -> ^Shape ---
+    physics_create_shape_mut_1 :: proc(self_: ^Physics, geometry: ^Geometry, materials: [^]^Material, materialCount: _c.uint16_t, isExclusive: _c.bool, shapeFlags: ShapeFlags_Set) -> ^Shape ---
 
     /// Return the number of shapes that currently exist.
     ///
@@ -6825,7 +6825,7 @@ foreign libphysx {
     ///
     /// The deletion listener has to be registered through [`registerDeletionListener`]() and configured to support restricted object sets prior to this method being used.
     @(link_name = "PxPhysics_registerDeletionListenerObjects_mut")
-    physics_register_deletion_listener_objects_mut :: proc(self_: ^Physics, observer: ^DeletionListener, observables: ^^Base, observableCount: _c.uint32_t) ---
+    physics_register_deletion_listener_objects_mut :: proc(self_: ^Physics, observer: ^DeletionListener, observables: [^]^Base, observableCount: _c.uint32_t) ---
 
     /// Unregister specific objects for deletion events.
     ///
@@ -6835,7 +6835,7 @@ foreign libphysx {
     ///
     /// The deletion listener has to be registered through [`registerDeletionListener`]() and configured to support restricted object sets prior to this method being used.
     @(link_name = "PxPhysics_unregisterDeletionListenerObjects_mut")
-    physics_unregister_deletion_listener_objects_mut :: proc(self_: ^Physics, observer: ^DeletionListener, observables: ^^Base, observableCount: _c.uint32_t) ---
+    physics_unregister_deletion_listener_objects_mut :: proc(self_: ^Physics, observer: ^DeletionListener, observables: [^]^Base, observableCount: _c.uint32_t) ---
 
     /// Gets PxPhysics object insertion interface.
     ///
@@ -7172,10 +7172,10 @@ foreign libphysx {
     rigid_dynamic_set_contact_report_threshold_mut :: proc(self_: ^RigidDynamic, threshold: _c.float) ---
 
     @(link_name = "PxRigidDynamic_getConcreteTypeName")
-    rigid_dynamic_get_concrete_type_name :: proc(self_: ^RigidDynamic) -> [^]_c.char ---
+    rigid_dynamic_get_concrete_type_name :: proc(self_: ^RigidDynamic) -> cstring ---
 
     @(link_name = "PxRigidStatic_getConcreteTypeName")
-    rigid_static_get_concrete_type_name :: proc(self_: ^RigidStatic) -> [^]_c.char ---
+    rigid_static_get_concrete_type_name :: proc(self_: ^RigidStatic) -> cstring ---
 
     /// constructor sets to default.
     @(link_name = "PxSceneQueryDesc_new")
@@ -7398,7 +7398,7 @@ foreign libphysx {
     ///
     /// SQ compound handle
     @(link_name = "PxSceneQuerySystem_addSQCompound_mut")
-    scene_query_system_add_s_q_compound_mut :: proc(self_: ^SceneQuerySystem, actor: ^RigidActor, shapes: ^^Shape, #by_ptr bvh: BVH, transforms: ^Transform) -> _c.uint32_t ---
+    scene_query_system_add_s_q_compound_mut :: proc(self_: ^SceneQuerySystem, actor: ^RigidActor, shapes: [^]^Shape, #by_ptr bvh: BVH, transforms: ^Transform) -> _c.uint32_t ---
 
     /// Removes a compound from the SQ system.
     @(link_name = "PxSceneQuerySystem_removeSQCompound_mut")
@@ -7533,7 +7533,7 @@ foreign libphysx {
     ///
     /// Number of written out regions.
     @(link_name = "PxBroadPhaseRegions_getRegions")
-    broad_phase_regions_get_regions :: proc(self_: ^BroadPhaseRegions, userBuffer: [^]BroadPhaseRegionInfo, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
+    broad_phase_regions_get_regions :: proc(self_: ^BroadPhaseRegions, userBuffer: ^BroadPhaseRegionInfo, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
 
     /// Adds a new broad-phase region.
     ///
@@ -7577,7 +7577,7 @@ foreign libphysx {
     broad_phase_regions_get_nb_out_of_bounds_objects :: proc(self_: ^BroadPhaseRegions) -> _c.uint32_t ---
 
     @(link_name = "PxBroadPhaseRegions_getOutOfBoundsObjects")
-    broad_phase_regions_get_out_of_bounds_objects :: proc(self_: ^BroadPhaseRegions) -> ^_c.uint32_t ---
+    broad_phase_regions_get_out_of_bounds_objects :: proc(self_: ^BroadPhaseRegions) -> [^]_c.uint32_t ---
 
     @(link_name = "PxBroadPhase_release_mut")
     broad_phase_release_mut :: proc(self_: ^BroadPhase) ---
@@ -7671,7 +7671,7 @@ foreign libphysx {
     ///
     /// The managed object bounds.
     @(link_name = "PxAABBManager_getBounds")
-    a_a_b_b_manager_get_bounds :: proc(self_: ^AABBManager) -> ^Bounds3 ---
+    a_a_b_b_manager_get_bounds :: proc(self_: ^AABBManager) -> [^]Bounds3 ---
 
     /// Retrieves the managed distances.
     ///
@@ -7679,13 +7679,13 @@ foreign libphysx {
     ///
     /// The managed object distances.
     @(link_name = "PxAABBManager_getDistances")
-    a_a_b_b_manager_get_distances :: proc(self_: ^AABBManager) -> ^_c.float ---
+    a_a_b_b_manager_get_distances :: proc(self_: ^AABBManager) -> [^]_c.float ---
 
     /// Retrieves the managed filter groups.
     ///
     /// The managed object groups.
     @(link_name = "PxAABBManager_getGroups")
-    a_a_b_b_manager_get_groups :: proc(self_: ^AABBManager) -> ^_c.uint32_t ---
+    a_a_b_b_manager_get_groups :: proc(self_: ^AABBManager) -> [^]_c.uint32_t ---
 
     /// Retrieves the managed buffers' capacity.
     ///
@@ -7822,7 +7822,7 @@ foreign libphysx {
 
     /// update camera on PVD application's render window
     @(link_name = "PxPvdSceneClient_updateCamera_mut")
-    pvd_scene_client_update_camera_mut :: proc(self_: ^PvdSceneClient, name: [^]_c.char, #by_ptr origin: Vec3, #by_ptr up: Vec3, #by_ptr target: Vec3) ---
+    pvd_scene_client_update_camera_mut :: proc(self_: ^PvdSceneClient, name: cstring, #by_ptr origin: Vec3, #by_ptr up: Vec3, #by_ptr target: Vec3) ---
 
     /// draw points on PVD application's render window
     @(link_name = "PxPvdSceneClient_drawPoints_mut")
@@ -8058,7 +8058,7 @@ foreign libphysx {
     ///
     /// A pointer to the list of active PxActors generated during the last call to fetchResults().
     @(link_name = "PxScene_getActiveActors_mut")
-    scene_get_active_actors_mut :: proc(self_: ^Scene, nbActorsOut: ^_c.uint32_t) -> ^^Actor ---
+    scene_get_active_actors_mut :: proc(self_: ^Scene, nbActorsOut: ^_c.uint32_t) -> [^]^Actor ---
 
     /// Returns the number of articulations in the scene.
     ///
@@ -8282,7 +8282,7 @@ foreign libphysx {
     /// Sleeping:
     /// Does wake up the actor.
     @(link_name = "PxScene_resetFiltering_mut_1")
-    scene_reset_filtering_mut_1 :: proc(self_: ^Scene, actor: ^RigidActor, shapes: ^^Shape, shapeCount: _c.uint32_t) -> _c.bool ---
+    scene_reset_filtering_mut_1 :: proc(self_: ^Scene, actor: ^RigidActor, shapes: [^]^Shape, shapeCount: _c.uint32_t) -> _c.bool ---
 
     /// Gets the pair filtering mode for kinematic-kinematic pairs.
     ///
@@ -8560,7 +8560,7 @@ foreign libphysx {
     ///
     /// Number of written out regions
     @(link_name = "PxScene_getBroadPhaseRegions")
-    scene_get_broad_phase_regions :: proc(self_: ^Scene, userBuffer: [^]BroadPhaseRegionInfo, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
+    scene_get_broad_phase_regions :: proc(self_: ^Scene, userBuffer: ^BroadPhaseRegionInfo, bufferSize: _c.uint32_t, startIndex: _c.uint32_t) -> _c.uint32_t ---
 
     /// Adds a new broad-phase region.
     ///
@@ -8622,7 +8622,7 @@ foreign libphysx {
     ///
     /// Recursive locking is supported but each lockRead() call must be paired with an unlockRead().
     @(link_name = "PxScene_lockRead_mut")
-    scene_lock_read_mut :: proc(self_: ^Scene, file: [^]_c.char, line: _c.uint32_t) ---
+    scene_lock_read_mut :: proc(self_: ^Scene, file: cstring, line: _c.uint32_t) ---
 
     /// Unlock the scene from reading.
     ///
@@ -8651,7 +8651,7 @@ foreign libphysx {
     /// If a thread has already locked the scene for writing then it may call
     /// lockRead().
     @(link_name = "PxScene_lockWrite_mut")
-    scene_lock_write_mut :: proc(self_: ^Scene, file: [^]_c.char, line: _c.uint32_t) ---
+    scene_lock_write_mut :: proc(self_: ^Scene, file: cstring, line: _c.uint32_t) ---
 
     /// Unlock the scene from writing.
     ///
@@ -8752,11 +8752,11 @@ foreign libphysx {
 
     /// Copy GPU softbody data from the internal GPU buffer to a user-provided device buffer.
     @(link_name = "PxScene_copySoftBodyData_mut")
-    scene_copy_soft_body_data_mut :: proc(self_: ^Scene, data: ^rawptr, dataSizes: rawptr, softBodyIndices: rawptr, flag: SoftBodyDataFlag, nbCopySoftBodies: _c.uint32_t, maxSize: _c.uint32_t, copyEvent: rawptr) ---
+    scene_copy_soft_body_data_mut :: proc(self_: ^Scene, data: [^]rawptr, dataSizes: rawptr, softBodyIndices: rawptr, flag: SoftBodyDataFlag, nbCopySoftBodies: _c.uint32_t, maxSize: _c.uint32_t, copyEvent: rawptr) ---
 
     /// Apply user-provided data to the internal softbody system.
     @(link_name = "PxScene_applySoftBodyData_mut")
-    scene_apply_soft_body_data_mut :: proc(self_: ^Scene, data: ^rawptr, dataSizes: rawptr, softBodyIndices: rawptr, flag: SoftBodyDataFlag, nbUpdatedSoftBodies: _c.uint32_t, maxSize: _c.uint32_t, applyEvent: rawptr) ---
+    scene_apply_soft_body_data_mut :: proc(self_: ^Scene, data: [^]rawptr, dataSizes: rawptr, softBodyIndices: rawptr, flag: SoftBodyDataFlag, nbUpdatedSoftBodies: _c.uint32_t, maxSize: _c.uint32_t, applyEvent: rawptr) ---
 
     /// Copy contact data from the internal GPU buffer to a user-provided device buffer.
     ///
@@ -8831,14 +8831,14 @@ foreign libphysx {
 
     /// Constructor
     @(link_name = "PxSceneReadLock_new_alloc")
-    scene_read_lock_new_alloc :: proc(scene: ^Scene, file: [^]_c.char, line: _c.uint32_t) -> ^SceneReadLock ---
+    scene_read_lock_new_alloc :: proc(scene: ^Scene, file: cstring, line: _c.uint32_t) -> ^SceneReadLock ---
 
     @(link_name = "PxSceneReadLock_delete")
     scene_read_lock_delete :: proc(self_: ^SceneReadLock) ---
 
     /// Constructor
     @(link_name = "PxSceneWriteLock_new_alloc")
-    scene_write_lock_new_alloc :: proc(scene: ^Scene, file: [^]_c.char, line: _c.uint32_t) -> ^SceneWriteLock ---
+    scene_write_lock_new_alloc :: proc(scene: ^Scene, file: cstring, line: _c.uint32_t) -> ^SceneWriteLock ---
 
     @(link_name = "PxSceneWriteLock_delete")
     scene_write_lock_delete :: proc(self_: ^SceneWriteLock) ---
@@ -8886,7 +8886,7 @@ foreign libphysx {
     ///
     /// Number of contact points written to the buffer.
     @(link_name = "PxContactPair_extractContacts")
-    contact_pair_extract_contacts :: proc(self_: ^ContactPair, userBuffer: [^]ContactPairPoint, bufferSize: _c.uint32_t) -> _c.uint32_t ---
+    contact_pair_extract_contacts :: proc(self_: ^ContactPair, userBuffer: ^ContactPairPoint, bufferSize: _c.uint32_t) -> _c.uint32_t ---
 
     /// Helper method to clone the contact pair and copy the contact data stream into a user buffer.
     ///
@@ -8896,7 +8896,7 @@ foreign libphysx {
     contact_pair_buffer_contacts :: proc(self_: ^ContactPair, newPair: ^ContactPair, bufferMemory: ^_c.uint8_t) ---
 
     @(link_name = "PxContactPair_getInternalFaceIndices")
-    contact_pair_get_internal_face_indices :: proc(self_: ^ContactPair) -> ^_c.uint32_t ---
+    contact_pair_get_internal_face_indices :: proc(self_: ^ContactPair) -> [^]_c.uint32_t ---
 
     @(link_name = "PxTriggerPair_new")
     trigger_pair_new :: proc() -> TriggerPair ---
@@ -8980,7 +8980,7 @@ foreign libphysx {
     /// The code in this callback should be lightweight as it can block the simulation, that is, the
     /// [`PxScene::fetchResults`]() call.
     @(link_name = "PxSimulationEventCallback_onAdvance_mut")
-    simulation_event_callback_on_advance_mut :: proc(self_: ^SimulationEventCallback, bodyBuffer: ^^RigidBody, poseBuffer: ^Transform, count: _c.uint32_t) ---
+    simulation_event_callback_on_advance_mut :: proc(self_: ^SimulationEventCallback, bodyBuffer: [^]^RigidBody, poseBuffer: ^Transform, count: _c.uint32_t) ---
 
     @(link_name = "PxSimulationEventCallback_delete")
     simulation_event_callback_delete :: proc(self_: ^SimulationEventCallback) ---
@@ -9027,7 +9027,7 @@ foreign libphysx {
     pruning_structure_get_dynamic_merge_data :: proc(self_: ^PruningStructure) -> rawptr ---
 
     @(link_name = "PxPruningStructure_getConcreteTypeName")
-    pruning_structure_get_concrete_type_name :: proc(self_: ^PruningStructure) -> [^]_c.char ---
+    pruning_structure_get_concrete_type_name :: proc(self_: ^PruningStructure) -> cstring ---
 
     @(link_name = "PxExtendedVec3_new")
     extended_vec3_new :: proc() -> ExtendedVec3 ---
@@ -9913,7 +9913,7 @@ foreign libphysx {
     default_memory_input_data_tell :: proc(self_: ^DefaultMemoryInputData) -> _c.uint32_t ---
 
     @(link_name = "PxDefaultFileOutputStream_new_alloc")
-    default_file_output_stream_new_alloc :: proc(name: [^]_c.char) -> ^DefaultFileOutputStream ---
+    default_file_output_stream_new_alloc :: proc(name: cstring) -> ^DefaultFileOutputStream ---
 
     @(link_name = "PxDefaultFileOutputStream_delete")
     default_file_output_stream_delete :: proc(self_: ^DefaultFileOutputStream) ---
@@ -9925,7 +9925,7 @@ foreign libphysx {
     default_file_output_stream_is_valid_mut :: proc(self_: ^DefaultFileOutputStream) -> _c.bool ---
 
     @(link_name = "PxDefaultFileInputData_new_alloc")
-    default_file_input_data_new_alloc :: proc(name: [^]_c.char) -> ^DefaultFileInputData ---
+    default_file_input_data_new_alloc :: proc(name: cstring) -> ^DefaultFileInputData ---
 
     @(link_name = "PxDefaultFileInputData_delete")
     default_file_input_data_delete :: proc(self_: ^DefaultFileInputData) ---
@@ -9952,7 +9952,7 @@ foreign libphysx {
     platform_aligned_free :: proc(ptr: rawptr) ---
 
     @(link_name = "PxDefaultAllocator_allocate_mut")
-    default_allocator_allocate_mut :: proc(self_: ^DefaultAllocator, size: _c.size_t, anon_param1: [^]_c.char, anon_param2: [^]_c.char, anon_param3: _c.int32_t) -> rawptr ---
+    default_allocator_allocate_mut :: proc(self_: ^DefaultAllocator, size: _c.size_t, anon_param1: cstring, anon_param2: cstring, anon_param3: _c.int32_t) -> rawptr ---
 
     @(link_name = "PxDefaultAllocator_deallocate_mut")
     default_allocator_deallocate_mut :: proc(self_: ^DefaultAllocator, ptr: rawptr) ---
@@ -10080,13 +10080,13 @@ foreign libphysx {
     /// This is for debugging and is not used by the SDK. The string is not copied by the SDK,
     /// only the pointer is stored.
     @(link_name = "PxJoint_setName_mut")
-    joint_set_name_mut :: proc(self_: ^Joint, name: [^]_c.char) ---
+    joint_set_name_mut :: proc(self_: ^Joint, name: cstring) ---
 
     /// Retrieves the name string set with setName().
     ///
     /// Name string associated with object.
     @(link_name = "PxJoint_getName")
-    joint_get_name :: proc(self_: ^Joint) -> [^]_c.char ---
+    joint_get_name :: proc(self_: ^Joint) -> cstring ---
 
     /// Deletes the joint.
     ///
@@ -10259,7 +10259,7 @@ foreign libphysx {
 
     /// Returns string name of PxDistanceJoint, used for serialization
     @(link_name = "PxDistanceJoint_getConcreteTypeName")
-    distance_joint_get_concrete_type_name :: proc(self_: ^DistanceJoint) -> [^]_c.char ---
+    distance_joint_get_concrete_type_name :: proc(self_: ^DistanceJoint) -> cstring ---
 
     /// Create a distance Joint.
     @(link_name = "phys_PxContactJointCreate")
@@ -10309,7 +10309,7 @@ foreign libphysx {
 
     /// Returns string name of PxContactJoint, used for serialization
     @(link_name = "PxContactJoint_getConcreteTypeName")
-    contact_joint_get_concrete_type_name :: proc(self_: ^ContactJoint) -> [^]_c.char ---
+    contact_joint_get_concrete_type_name :: proc(self_: ^ContactJoint) -> cstring ---
 
     @(link_name = "PxContactJoint_computeJacobians")
     contact_joint_compute_jacobians :: proc(self_: ^ContactJoint, jacobian: ^JacobianRow) ---
@@ -10323,7 +10323,7 @@ foreign libphysx {
 
     /// Returns string name of PxFixedJoint, used for serialization
     @(link_name = "PxFixedJoint_getConcreteTypeName")
-    fixed_joint_get_concrete_type_name :: proc(self_: ^FixedJoint) -> [^]_c.char ---
+    fixed_joint_get_concrete_type_name :: proc(self_: ^FixedJoint) -> cstring ---
 
     @(link_name = "PxJointLimitParameters_new_alloc")
     joint_limit_parameters_new_alloc :: proc() -> ^JointLimitParameters ---
@@ -10468,7 +10468,7 @@ foreign libphysx {
 
     /// Returns string name of PxPrismaticJoint, used for serialization
     @(link_name = "PxPrismaticJoint_getConcreteTypeName")
-    prismatic_joint_get_concrete_type_name :: proc(self_: ^PrismaticJoint) -> [^]_c.char ---
+    prismatic_joint_get_concrete_type_name :: proc(self_: ^PrismaticJoint) -> cstring ---
 
     /// Create a revolute joint.
     @(link_name = "phys_PxRevoluteJointCreate")
@@ -10573,7 +10573,7 @@ foreign libphysx {
 
     /// Returns string name of PxRevoluteJoint, used for serialization
     @(link_name = "PxRevoluteJoint_getConcreteTypeName")
-    revolute_joint_get_concrete_type_name :: proc(self_: ^RevoluteJoint) -> [^]_c.char ---
+    revolute_joint_get_concrete_type_name :: proc(self_: ^RevoluteJoint) -> cstring ---
 
     /// Create a spherical joint.
     @(link_name = "phys_PxSphericalJointCreate")
@@ -10619,7 +10619,7 @@ foreign libphysx {
 
     /// Returns string name of PxSphericalJoint, used for serialization
     @(link_name = "PxSphericalJoint_getConcreteTypeName")
-    spherical_joint_get_concrete_type_name :: proc(self_: ^SphericalJoint) -> [^]_c.char ---
+    spherical_joint_get_concrete_type_name :: proc(self_: ^SphericalJoint) -> cstring ---
 
     /// Create a D6 joint.
     @(link_name = "phys_PxD6JointCreate")
@@ -10824,7 +10824,7 @@ foreign libphysx {
 
     /// Returns string name of PxD6Joint, used for serialization
     @(link_name = "PxD6Joint_getConcreteTypeName")
-    d6_joint_get_concrete_type_name :: proc(self_: ^D6Joint) -> [^]_c.char ---
+    d6_joint_get_concrete_type_name :: proc(self_: ^D6Joint) -> cstring ---
 
     /// Create a gear Joint.
     @(link_name = "phys_PxGearJointCreate")
@@ -10863,7 +10863,7 @@ foreign libphysx {
     gear_joint_get_gear_ratio :: proc(self_: ^GearJoint) -> _c.float ---
 
     @(link_name = "PxGearJoint_getConcreteTypeName")
-    gear_joint_get_concrete_type_name :: proc(self_: ^GearJoint) -> [^]_c.char ---
+    gear_joint_get_concrete_type_name :: proc(self_: ^GearJoint) -> cstring ---
 
     /// Create a rack
     /// &
@@ -10922,7 +10922,7 @@ foreign libphysx {
     rack_and_pinion_joint_set_data_mut :: proc(self_: ^RackAndPinionJoint, nbRackTeeth: _c.uint32_t, nbPinionTeeth: _c.uint32_t, rackLength: _c.float) -> _c.bool ---
 
     @(link_name = "PxRackAndPinionJoint_getConcreteTypeName")
-    rack_and_pinion_joint_get_concrete_type_name :: proc(self_: ^RackAndPinionJoint) -> [^]_c.char ---
+    rack_and_pinion_joint_get_concrete_type_name :: proc(self_: ^RackAndPinionJoint) -> cstring ---
 
     @(link_name = "PxGroupsMask_new_alloc")
     groups_mask_new_alloc :: proc() -> ^GroupsMask ---
@@ -11020,7 +11020,7 @@ foreign libphysx {
     default_error_callback_delete :: proc(self_: ^DefaultErrorCallback) ---
 
     @(link_name = "PxDefaultErrorCallback_reportError_mut")
-    default_error_callback_report_error_mut :: proc(self_: ^DefaultErrorCallback, code: ErrorCode, message: [^]_c.char, file: [^]_c.char, line: _c.int32_t) ---
+    default_error_callback_report_error_mut :: proc(self_: ^DefaultErrorCallback, code: ErrorCode, message: cstring, file: cstring, line: _c.int32_t) ---
 
     /// Creates a new shape with default properties and a list of materials and adds it to the list of shapes of this actor.
     ///
@@ -11050,7 +11050,7 @@ foreign libphysx {
     ///
     /// The newly created shape.
     @(link_name = "PxRigidActorExt_createExclusiveShape")
-    rigid_actor_ext_create_exclusive_shape :: proc(actor: ^RigidActor, geometry: ^Geometry, materials: ^^Material, materialCount: _c.uint16_t, shapeFlags: ShapeFlags_Set) -> ^Shape ---
+    rigid_actor_ext_create_exclusive_shape :: proc(actor: ^RigidActor, geometry: ^Geometry, materials: [^]^Material, materialCount: _c.uint16_t, shapeFlags: ShapeFlags_Set) -> ^Shape ---
 
     /// Creates a new shape with default properties and a single material adds it to the list of shapes of this actor.
     ///
@@ -11207,7 +11207,7 @@ foreign libphysx {
     ///
     /// The mass properties from the combined shapes.
     @(link_name = "PxRigidBodyExt_computeMassPropertiesFromShapes")
-    rigid_body_ext_compute_mass_properties_from_shapes :: proc(shapes: ^^Shape, shapeCount: _c.uint32_t) -> MassProperties ---
+    rigid_body_ext_compute_mass_properties_from_shapes :: proc(shapes: [^]^Shape, shapeCount: _c.uint32_t) -> MassProperties ---
 
     /// Applies a force (or impulse) defined in the global coordinate frame, acting at a particular
     /// point in global coordinates, to the actor.
@@ -11408,7 +11408,7 @@ foreign libphysx {
     ///
     /// Indices of touched triangles
     @(link_name = "PxMeshOverlapUtil_getResults")
-    mesh_overlap_util_get_results :: proc(self_: ^MeshOverlapUtil) -> ^_c.uint32_t ---
+    mesh_overlap_util_get_results :: proc(self_: ^MeshOverlapUtil) -> [^]_c.uint32_t ---
 
     /// Retrieves number of triangle indices after a findOverlap call.
     ///
@@ -12077,7 +12077,7 @@ foreign libphysx {
     close_extensions :: proc() ---
 
     @(link_name = "PxRepXObject_new")
-    rep_x_object_new :: proc(inTypeName: [^]_c.char, inSerializable: rawptr, inId: _c.uint64_t) -> RepXObject ---
+    rep_x_object_new :: proc(inTypeName: cstring, inSerializable: rawptr, inId: _c.uint64_t) -> RepXObject ---
 
     @(link_name = "PxRepXObject_isValid")
     rep_x_object_is_valid :: proc(self_: ^RepXObject) -> _c.bool ---
@@ -12087,7 +12087,7 @@ foreign libphysx {
 
     /// The type this Serializer is meant to operate on.
     @(link_name = "PxRepXSerializer_getTypeName_mut")
-    rep_x_serializer_get_type_name_mut :: proc(self_: ^RepXSerializer) -> [^]_c.char ---
+    rep_x_serializer_get_type_name_mut :: proc(self_: ^RepXSerializer) -> cstring ---
 
     /// Convert from a RepX object to a key-value pair hierarchy
     @(link_name = "PxRepXSerializer_objectToFile_mut")
@@ -12167,10 +12167,10 @@ foreign libphysx {
 
     /// Create a default socket transport.
     @(link_name = "phys_PxDefaultPvdSocketTransportCreate")
-    default_pvd_socket_transport_create :: proc(host: [^]_c.char, port: _c.int32_t, timeoutInMilliseconds: _c.uint32_t) -> ^PvdTransport ---
+    default_pvd_socket_transport_create :: proc(host: cstring, port: _c.int32_t, timeoutInMilliseconds: _c.uint32_t) -> ^PvdTransport ---
 
     /// Create a default file transport.
     @(link_name = "phys_PxDefaultPvdFileTransportCreate")
-    default_pvd_file_transport_create :: proc(name: [^]_c.char) -> ^PvdTransport ---
+    default_pvd_file_transport_create :: proc(name: cstring) -> ^PvdTransport ---
 
 }

--- a/tests/layout_windows.odin
+++ b/tests/layout_windows.odin
@@ -52,8 +52,12 @@ test_layout_BitMap :: proc(t: ^testing.T) {
 @(test)
 test_layout_Vec3 :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(Vec3, x) == 0, "Wrong offset for Vec3.x, expected 0 got %v", offset_of(Vec3, x))
+    testing.expectf(t, size_of(Vec3{}.x) == 4, "Wrong size for Vec3.x, expected 4 got %v", size_of(Vec3{}.x))
     testing.expectf(t, offset_of(Vec3, y) == 4, "Wrong offset for Vec3.y, expected 4 got %v", offset_of(Vec3, y))
+    testing.expectf(t, size_of(Vec3{}.y) == 4, "Wrong size for Vec3.y, expected 4 got %v", size_of(Vec3{}.y))
     testing.expectf(t, offset_of(Vec3, z) == 8, "Wrong offset for Vec3.z, expected 8 got %v", offset_of(Vec3, z))
+    testing.expectf(t, size_of(Vec3{}.z) == 4, "Wrong size for Vec3.z, expected 4 got %v", size_of(Vec3{}.z))
     testing.expectf(t, size_of(Vec3) == 12, "Wrong size for type Vec3, expected 12 got %v", size_of(Vec3))
 }
 
@@ -61,44 +65,63 @@ test_layout_Vec3 :: proc(t: ^testing.T) {
 test_layout_Vec3Padded :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(Vec3Padded, padding) == 12, "Wrong offset for Vec3Padded.padding, expected 12 got %v", offset_of(Vec3Padded, padding))
+    testing.expectf(t, size_of(Vec3Padded{}.padding) == 4, "Wrong size for Vec3Padded.padding, expected 4 got %v", size_of(Vec3Padded{}.padding))
     testing.expectf(t, size_of(Vec3Padded) == 16, "Wrong size for type Vec3Padded, expected 16 got %v", size_of(Vec3Padded))
 }
 
 @(test)
 test_layout_Quat :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(Quat, x) == 0, "Wrong offset for Quat.x, expected 0 got %v", offset_of(Quat, x))
+    testing.expectf(t, size_of(Quat{}.x) == 4, "Wrong size for Quat.x, expected 4 got %v", size_of(Quat{}.x))
     testing.expectf(t, offset_of(Quat, y) == 4, "Wrong offset for Quat.y, expected 4 got %v", offset_of(Quat, y))
+    testing.expectf(t, size_of(Quat{}.y) == 4, "Wrong size for Quat.y, expected 4 got %v", size_of(Quat{}.y))
     testing.expectf(t, offset_of(Quat, z) == 8, "Wrong offset for Quat.z, expected 8 got %v", offset_of(Quat, z))
+    testing.expectf(t, size_of(Quat{}.z) == 4, "Wrong size for Quat.z, expected 4 got %v", size_of(Quat{}.z))
     testing.expectf(t, offset_of(Quat, w) == 12, "Wrong offset for Quat.w, expected 12 got %v", offset_of(Quat, w))
+    testing.expectf(t, size_of(Quat{}.w) == 4, "Wrong size for Quat.w, expected 4 got %v", size_of(Quat{}.w))
     testing.expectf(t, size_of(Quat) == 16, "Wrong size for type Quat, expected 16 got %v", size_of(Quat))
 }
 
 @(test)
 test_layout_Transform :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(Transform, q) == 0, "Wrong offset for Transform.q, expected 0 got %v", offset_of(Transform, q))
+    testing.expectf(t, size_of(Transform{}.q) == 16, "Wrong size for Transform.q, expected 16 got %v", size_of(Transform{}.q))
     testing.expectf(t, offset_of(Transform, p) == 16, "Wrong offset for Transform.p, expected 16 got %v", offset_of(Transform, p))
+    testing.expectf(t, size_of(Transform{}.p) == 12, "Wrong size for Transform.p, expected 12 got %v", size_of(Transform{}.p))
     testing.expectf(t, size_of(Transform) == 28, "Wrong size for type Transform, expected 28 got %v", size_of(Transform))
 }
 
 @(test)
 test_layout_TransformPadded :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(TransformPadded, transform) == 0, "Wrong offset for TransformPadded.transform, expected 0 got %v", offset_of(TransformPadded, transform))
+    testing.expectf(t, size_of(TransformPadded{}.transform) == 28, "Wrong size for TransformPadded.transform, expected 28 got %v", size_of(TransformPadded{}.transform))
     testing.expectf(t, offset_of(TransformPadded, padding) == 28, "Wrong offset for TransformPadded.padding, expected 28 got %v", offset_of(TransformPadded, padding))
+    testing.expectf(t, size_of(TransformPadded{}.padding) == 4, "Wrong size for TransformPadded.padding, expected 4 got %v", size_of(TransformPadded{}.padding))
     testing.expectf(t, size_of(TransformPadded) == 32, "Wrong size for type TransformPadded, expected 32 got %v", size_of(TransformPadded))
 }
 
 @(test)
 test_layout_Mat33 :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(Mat33, column0) == 0, "Wrong offset for Mat33.column0, expected 0 got %v", offset_of(Mat33, column0))
+    testing.expectf(t, size_of(Mat33{}.column0) == 12, "Wrong size for Mat33.column0, expected 12 got %v", size_of(Mat33{}.column0))
     testing.expectf(t, offset_of(Mat33, column1) == 12, "Wrong offset for Mat33.column1, expected 12 got %v", offset_of(Mat33, column1))
+    testing.expectf(t, size_of(Mat33{}.column1) == 12, "Wrong size for Mat33.column1, expected 12 got %v", size_of(Mat33{}.column1))
     testing.expectf(t, offset_of(Mat33, column2) == 24, "Wrong offset for Mat33.column2, expected 24 got %v", offset_of(Mat33, column2))
+    testing.expectf(t, size_of(Mat33{}.column2) == 12, "Wrong size for Mat33.column2, expected 12 got %v", size_of(Mat33{}.column2))
     testing.expectf(t, size_of(Mat33) == 36, "Wrong size for type Mat33, expected 36 got %v", size_of(Mat33))
 }
 
 @(test)
 test_layout_Bounds3 :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(Bounds3, minimum) == 0, "Wrong offset for Bounds3.minimum, expected 0 got %v", offset_of(Bounds3, minimum))
+    testing.expectf(t, size_of(Bounds3{}.minimum) == 12, "Wrong size for Bounds3.minimum, expected 12 got %v", size_of(Bounds3{}.minimum))
     testing.expectf(t, offset_of(Bounds3, maximum) == 12, "Wrong offset for Bounds3.maximum, expected 12 got %v", offset_of(Bounds3, maximum))
+    testing.expectf(t, size_of(Bounds3{}.maximum) == 12, "Wrong size for Bounds3.maximum, expected 12 got %v", size_of(Bounds3{}.maximum))
     testing.expectf(t, size_of(Bounds3) == 24, "Wrong size for type Bounds3, expected 24 got %v", size_of(Bounds3))
 }
 
@@ -147,25 +170,38 @@ test_layout_OutputStream :: proc(t: ^testing.T) {
 @(test)
 test_layout_Vec4 :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(Vec4, x) == 0, "Wrong offset for Vec4.x, expected 0 got %v", offset_of(Vec4, x))
+    testing.expectf(t, size_of(Vec4{}.x) == 4, "Wrong size for Vec4.x, expected 4 got %v", size_of(Vec4{}.x))
     testing.expectf(t, offset_of(Vec4, y) == 4, "Wrong offset for Vec4.y, expected 4 got %v", offset_of(Vec4, y))
+    testing.expectf(t, size_of(Vec4{}.y) == 4, "Wrong size for Vec4.y, expected 4 got %v", size_of(Vec4{}.y))
     testing.expectf(t, offset_of(Vec4, z) == 8, "Wrong offset for Vec4.z, expected 8 got %v", offset_of(Vec4, z))
+    testing.expectf(t, size_of(Vec4{}.z) == 4, "Wrong size for Vec4.z, expected 4 got %v", size_of(Vec4{}.z))
     testing.expectf(t, offset_of(Vec4, w) == 12, "Wrong offset for Vec4.w, expected 12 got %v", offset_of(Vec4, w))
+    testing.expectf(t, size_of(Vec4{}.w) == 4, "Wrong size for Vec4.w, expected 4 got %v", size_of(Vec4{}.w))
     testing.expectf(t, size_of(Vec4) == 16, "Wrong size for type Vec4, expected 16 got %v", size_of(Vec4))
 }
 
 @(test)
 test_layout_Mat44 :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(Mat44, column0) == 0, "Wrong offset for Mat44.column0, expected 0 got %v", offset_of(Mat44, column0))
+    testing.expectf(t, size_of(Mat44{}.column0) == 16, "Wrong size for Mat44.column0, expected 16 got %v", size_of(Mat44{}.column0))
     testing.expectf(t, offset_of(Mat44, column1) == 16, "Wrong offset for Mat44.column1, expected 16 got %v", offset_of(Mat44, column1))
+    testing.expectf(t, size_of(Mat44{}.column1) == 16, "Wrong size for Mat44.column1, expected 16 got %v", size_of(Mat44{}.column1))
     testing.expectf(t, offset_of(Mat44, column2) == 32, "Wrong offset for Mat44.column2, expected 32 got %v", offset_of(Mat44, column2))
+    testing.expectf(t, size_of(Mat44{}.column2) == 16, "Wrong size for Mat44.column2, expected 16 got %v", size_of(Mat44{}.column2))
     testing.expectf(t, offset_of(Mat44, column3) == 48, "Wrong offset for Mat44.column3, expected 48 got %v", offset_of(Mat44, column3))
+    testing.expectf(t, size_of(Mat44{}.column3) == 16, "Wrong size for Mat44.column3, expected 16 got %v", size_of(Mat44{}.column3))
     testing.expectf(t, size_of(Mat44) == 64, "Wrong size for type Mat44, expected 64 got %v", size_of(Mat44))
 }
 
 @(test)
 test_layout_Plane :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(Plane, n) == 0, "Wrong offset for Plane.n, expected 0 got %v", offset_of(Plane, n))
+    testing.expectf(t, size_of(Plane{}.n) == 12, "Wrong size for Plane.n, expected 12 got %v", size_of(Plane{}.n))
     testing.expectf(t, offset_of(Plane, d) == 12, "Wrong offset for Plane.d, expected 12 got %v", offset_of(Plane, d))
+    testing.expectf(t, size_of(Plane{}.d) == 4, "Wrong size for Plane.d, expected 4 got %v", size_of(Plane{}.d))
     testing.expectf(t, size_of(Plane) == 16, "Wrong size for type Plane, expected 16 got %v", size_of(Plane))
 }
 
@@ -186,10 +222,16 @@ test_layout_ProfilerCallback :: proc(t: ^testing.T) {
 @(test)
 test_layout_ProfileScoped :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(ProfileScoped, mCallback) == 0, "Wrong offset for ProfileScoped.mCallback, expected 0 got %v", offset_of(ProfileScoped, mCallback))
+    testing.expectf(t, size_of(ProfileScoped{}.mCallback) == 8, "Wrong size for ProfileScoped.mCallback, expected 8 got %v", size_of(ProfileScoped{}.mCallback))
     testing.expectf(t, offset_of(ProfileScoped, mEventName) == 8, "Wrong offset for ProfileScoped.mEventName, expected 8 got %v", offset_of(ProfileScoped, mEventName))
+    testing.expectf(t, size_of(ProfileScoped{}.mEventName) == 8, "Wrong size for ProfileScoped.mEventName, expected 8 got %v", size_of(ProfileScoped{}.mEventName))
     testing.expectf(t, offset_of(ProfileScoped, mProfilerData) == 16, "Wrong offset for ProfileScoped.mProfilerData, expected 16 got %v", offset_of(ProfileScoped, mProfilerData))
+    testing.expectf(t, size_of(ProfileScoped{}.mProfilerData) == 8, "Wrong size for ProfileScoped.mProfilerData, expected 8 got %v", size_of(ProfileScoped{}.mProfilerData))
     testing.expectf(t, offset_of(ProfileScoped, mContextId) == 24, "Wrong offset for ProfileScoped.mContextId, expected 24 got %v", offset_of(ProfileScoped, mContextId))
+    testing.expectf(t, size_of(ProfileScoped{}.mContextId) == 8, "Wrong size for ProfileScoped.mContextId, expected 8 got %v", size_of(ProfileScoped{}.mContextId))
     testing.expectf(t, offset_of(ProfileScoped, mDetached) == 32, "Wrong offset for ProfileScoped.mDetached, expected 32 got %v", offset_of(ProfileScoped, mDetached))
+    testing.expectf(t, size_of(ProfileScoped{}.mDetached) == 1, "Wrong size for ProfileScoped.mDetached, expected 1 got %v", size_of(ProfileScoped{}.mDetached))
     testing.expectf(t, size_of(ProfileScoped) == 40, "Wrong size for type ProfileScoped, expected 40 got %v", size_of(ProfileScoped))
 }
 
@@ -210,7 +252,10 @@ test_layout_Runnable :: proc(t: ^testing.T) {
 @(test)
 test_layout_CounterFrequencyToTensOfNanos :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(CounterFrequencyToTensOfNanos, mNumerator) == 0, "Wrong offset for CounterFrequencyToTensOfNanos.mNumerator, expected 0 got %v", offset_of(CounterFrequencyToTensOfNanos, mNumerator))
+    testing.expectf(t, size_of(CounterFrequencyToTensOfNanos{}.mNumerator) == 8, "Wrong size for CounterFrequencyToTensOfNanos.mNumerator, expected 8 got %v", size_of(CounterFrequencyToTensOfNanos{}.mNumerator))
     testing.expectf(t, offset_of(CounterFrequencyToTensOfNanos, mDenominator) == 8, "Wrong offset for CounterFrequencyToTensOfNanos.mDenominator, expected 8 got %v", offset_of(CounterFrequencyToTensOfNanos, mDenominator))
+    testing.expectf(t, size_of(CounterFrequencyToTensOfNanos{}.mDenominator) == 8, "Wrong size for CounterFrequencyToTensOfNanos.mDenominator, expected 8 got %v", size_of(CounterFrequencyToTensOfNanos{}.mDenominator))
     testing.expectf(t, size_of(CounterFrequencyToTensOfNanos) == 16, "Wrong size for type CounterFrequencyToTensOfNanos, expected 16 got %v", size_of(CounterFrequencyToTensOfNanos))
 }
 
@@ -223,14 +268,20 @@ test_layout_Time :: proc(t: ^testing.T) {
 @(test)
 test_layout_Vec2 :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(Vec2, x) == 0, "Wrong offset for Vec2.x, expected 0 got %v", offset_of(Vec2, x))
+    testing.expectf(t, size_of(Vec2{}.x) == 4, "Wrong size for Vec2.x, expected 4 got %v", size_of(Vec2{}.x))
     testing.expectf(t, offset_of(Vec2, y) == 4, "Wrong offset for Vec2.y, expected 4 got %v", offset_of(Vec2, y))
+    testing.expectf(t, size_of(Vec2{}.y) == 4, "Wrong size for Vec2.y, expected 4 got %v", size_of(Vec2{}.y))
     testing.expectf(t, size_of(Vec2) == 8, "Wrong size for type Vec2, expected 8 got %v", size_of(Vec2))
 }
 
 @(test)
 test_layout_StridedData :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(StridedData, stride) == 0, "Wrong offset for StridedData.stride, expected 0 got %v", offset_of(StridedData, stride))
+    testing.expectf(t, size_of(StridedData{}.stride) == 4, "Wrong size for StridedData.stride, expected 4 got %v", size_of(StridedData{}.stride))
     testing.expectf(t, offset_of(StridedData, data) == 8, "Wrong offset for StridedData.data, expected 8 got %v", offset_of(StridedData, data))
+    testing.expectf(t, size_of(StridedData{}.data) == 8, "Wrong size for StridedData.data, expected 8 got %v", size_of(StridedData{}.data))
     testing.expectf(t, size_of(StridedData) == 16, "Wrong size for type StridedData, expected 16 got %v", size_of(StridedData))
 }
 
@@ -238,42 +289,63 @@ test_layout_StridedData :: proc(t: ^testing.T) {
 test_layout_BoundedData :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(BoundedData, count) == 16, "Wrong offset for BoundedData.count, expected 16 got %v", offset_of(BoundedData, count))
+    testing.expectf(t, size_of(BoundedData{}.count) == 4, "Wrong size for BoundedData.count, expected 4 got %v", size_of(BoundedData{}.count))
     testing.expectf(t, size_of(BoundedData) == 24, "Wrong size for type BoundedData, expected 24 got %v", size_of(BoundedData))
 }
 
 @(test)
 test_layout_DebugPoint :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(DebugPoint, pos) == 0, "Wrong offset for DebugPoint.pos, expected 0 got %v", offset_of(DebugPoint, pos))
+    testing.expectf(t, size_of(DebugPoint{}.pos) == 12, "Wrong size for DebugPoint.pos, expected 12 got %v", size_of(DebugPoint{}.pos))
     testing.expectf(t, offset_of(DebugPoint, color) == 12, "Wrong offset for DebugPoint.color, expected 12 got %v", offset_of(DebugPoint, color))
+    testing.expectf(t, size_of(DebugPoint{}.color) == 4, "Wrong size for DebugPoint.color, expected 4 got %v", size_of(DebugPoint{}.color))
     testing.expectf(t, size_of(DebugPoint) == 16, "Wrong size for type DebugPoint, expected 16 got %v", size_of(DebugPoint))
 }
 
 @(test)
 test_layout_DebugLine :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(DebugLine, pos0) == 0, "Wrong offset for DebugLine.pos0, expected 0 got %v", offset_of(DebugLine, pos0))
+    testing.expectf(t, size_of(DebugLine{}.pos0) == 12, "Wrong size for DebugLine.pos0, expected 12 got %v", size_of(DebugLine{}.pos0))
     testing.expectf(t, offset_of(DebugLine, color0) == 12, "Wrong offset for DebugLine.color0, expected 12 got %v", offset_of(DebugLine, color0))
+    testing.expectf(t, size_of(DebugLine{}.color0) == 4, "Wrong size for DebugLine.color0, expected 4 got %v", size_of(DebugLine{}.color0))
     testing.expectf(t, offset_of(DebugLine, pos1) == 16, "Wrong offset for DebugLine.pos1, expected 16 got %v", offset_of(DebugLine, pos1))
+    testing.expectf(t, size_of(DebugLine{}.pos1) == 12, "Wrong size for DebugLine.pos1, expected 12 got %v", size_of(DebugLine{}.pos1))
     testing.expectf(t, offset_of(DebugLine, color1) == 28, "Wrong offset for DebugLine.color1, expected 28 got %v", offset_of(DebugLine, color1))
+    testing.expectf(t, size_of(DebugLine{}.color1) == 4, "Wrong size for DebugLine.color1, expected 4 got %v", size_of(DebugLine{}.color1))
     testing.expectf(t, size_of(DebugLine) == 32, "Wrong size for type DebugLine, expected 32 got %v", size_of(DebugLine))
 }
 
 @(test)
 test_layout_DebugTriangle :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(DebugTriangle, pos0) == 0, "Wrong offset for DebugTriangle.pos0, expected 0 got %v", offset_of(DebugTriangle, pos0))
+    testing.expectf(t, size_of(DebugTriangle{}.pos0) == 12, "Wrong size for DebugTriangle.pos0, expected 12 got %v", size_of(DebugTriangle{}.pos0))
     testing.expectf(t, offset_of(DebugTriangle, color0) == 12, "Wrong offset for DebugTriangle.color0, expected 12 got %v", offset_of(DebugTriangle, color0))
+    testing.expectf(t, size_of(DebugTriangle{}.color0) == 4, "Wrong size for DebugTriangle.color0, expected 4 got %v", size_of(DebugTriangle{}.color0))
     testing.expectf(t, offset_of(DebugTriangle, pos1) == 16, "Wrong offset for DebugTriangle.pos1, expected 16 got %v", offset_of(DebugTriangle, pos1))
+    testing.expectf(t, size_of(DebugTriangle{}.pos1) == 12, "Wrong size for DebugTriangle.pos1, expected 12 got %v", size_of(DebugTriangle{}.pos1))
     testing.expectf(t, offset_of(DebugTriangle, color1) == 28, "Wrong offset for DebugTriangle.color1, expected 28 got %v", offset_of(DebugTriangle, color1))
+    testing.expectf(t, size_of(DebugTriangle{}.color1) == 4, "Wrong size for DebugTriangle.color1, expected 4 got %v", size_of(DebugTriangle{}.color1))
     testing.expectf(t, offset_of(DebugTriangle, pos2) == 32, "Wrong offset for DebugTriangle.pos2, expected 32 got %v", offset_of(DebugTriangle, pos2))
+    testing.expectf(t, size_of(DebugTriangle{}.pos2) == 12, "Wrong size for DebugTriangle.pos2, expected 12 got %v", size_of(DebugTriangle{}.pos2))
     testing.expectf(t, offset_of(DebugTriangle, color2) == 44, "Wrong offset for DebugTriangle.color2, expected 44 got %v", offset_of(DebugTriangle, color2))
+    testing.expectf(t, size_of(DebugTriangle{}.color2) == 4, "Wrong size for DebugTriangle.color2, expected 4 got %v", size_of(DebugTriangle{}.color2))
     testing.expectf(t, size_of(DebugTriangle) == 48, "Wrong size for type DebugTriangle, expected 48 got %v", size_of(DebugTriangle))
 }
 
 @(test)
 test_layout_DebugText :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(DebugText, position) == 0, "Wrong offset for DebugText.position, expected 0 got %v", offset_of(DebugText, position))
+    testing.expectf(t, size_of(DebugText{}.position) == 12, "Wrong size for DebugText.position, expected 12 got %v", size_of(DebugText{}.position))
     testing.expectf(t, offset_of(DebugText, size) == 12, "Wrong offset for DebugText.size, expected 12 got %v", offset_of(DebugText, size))
+    testing.expectf(t, size_of(DebugText{}.size) == 4, "Wrong size for DebugText.size, expected 4 got %v", size_of(DebugText{}.size))
     testing.expectf(t, offset_of(DebugText, color) == 16, "Wrong offset for DebugText.color, expected 16 got %v", offset_of(DebugText, color))
+    testing.expectf(t, size_of(DebugText{}.color) == 4, "Wrong size for DebugText.color, expected 4 got %v", size_of(DebugText{}.color))
     testing.expectf(t, offset_of(DebugText, string) == 24, "Wrong offset for DebugText.string, expected 24 got %v", offset_of(DebugText, string))
+    testing.expectf(t, size_of(DebugText{}.string) == 8, "Wrong size for DebugText.string, expected 8 got %v", size_of(DebugText{}.string))
     testing.expectf(t, size_of(DebugText) == 32, "Wrong size for type DebugText, expected 32 got %v", size_of(DebugText))
 }
 
@@ -328,7 +400,10 @@ test_layout_RefCounted :: proc(t: ^testing.T) {
 @(test)
 test_layout_TolerancesScale :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(TolerancesScale, length) == 0, "Wrong offset for TolerancesScale.length, expected 0 got %v", offset_of(TolerancesScale, length))
+    testing.expectf(t, size_of(TolerancesScale{}.length) == 4, "Wrong size for TolerancesScale.length, expected 4 got %v", size_of(TolerancesScale{}.length))
     testing.expectf(t, offset_of(TolerancesScale, speed) == 4, "Wrong offset for TolerancesScale.speed, expected 4 got %v", offset_of(TolerancesScale, speed))
+    testing.expectf(t, size_of(TolerancesScale{}.speed) == 4, "Wrong size for TolerancesScale.speed, expected 4 got %v", size_of(TolerancesScale{}.speed))
     testing.expectf(t, size_of(TolerancesScale) == 8, "Wrong size for type TolerancesScale, expected 8 got %v", size_of(TolerancesScale))
 }
 
@@ -347,13 +422,22 @@ test_layout_Serializer :: proc(t: ^testing.T) {
 @(test)
 test_layout_MetaDataEntry :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(MetaDataEntry, type) == 0, "Wrong offset for MetaDataEntry.type, expected 0 got %v", offset_of(MetaDataEntry, type))
+    testing.expectf(t, size_of(MetaDataEntry{}.type) == 8, "Wrong size for MetaDataEntry.type, expected 8 got %v", size_of(MetaDataEntry{}.type))
     testing.expectf(t, offset_of(MetaDataEntry, name) == 8, "Wrong offset for MetaDataEntry.name, expected 8 got %v", offset_of(MetaDataEntry, name))
+    testing.expectf(t, size_of(MetaDataEntry{}.name) == 8, "Wrong size for MetaDataEntry.name, expected 8 got %v", size_of(MetaDataEntry{}.name))
     testing.expectf(t, offset_of(MetaDataEntry, offset) == 16, "Wrong offset for MetaDataEntry.offset, expected 16 got %v", offset_of(MetaDataEntry, offset))
+    testing.expectf(t, size_of(MetaDataEntry{}.offset) == 4, "Wrong size for MetaDataEntry.offset, expected 4 got %v", size_of(MetaDataEntry{}.offset))
     testing.expectf(t, offset_of(MetaDataEntry, size) == 20, "Wrong offset for MetaDataEntry.size, expected 20 got %v", offset_of(MetaDataEntry, size))
+    testing.expectf(t, size_of(MetaDataEntry{}.size) == 4, "Wrong size for MetaDataEntry.size, expected 4 got %v", size_of(MetaDataEntry{}.size))
     testing.expectf(t, offset_of(MetaDataEntry, count) == 24, "Wrong offset for MetaDataEntry.count, expected 24 got %v", offset_of(MetaDataEntry, count))
+    testing.expectf(t, size_of(MetaDataEntry{}.count) == 4, "Wrong size for MetaDataEntry.count, expected 4 got %v", size_of(MetaDataEntry{}.count))
     testing.expectf(t, offset_of(MetaDataEntry, offsetSize) == 28, "Wrong offset for MetaDataEntry.offsetSize, expected 28 got %v", offset_of(MetaDataEntry, offsetSize))
+    testing.expectf(t, size_of(MetaDataEntry{}.offsetSize) == 4, "Wrong size for MetaDataEntry.offsetSize, expected 4 got %v", size_of(MetaDataEntry{}.offsetSize))
     testing.expectf(t, offset_of(MetaDataEntry, flags) == 32, "Wrong offset for MetaDataEntry.flags, expected 32 got %v", offset_of(MetaDataEntry, flags))
+    testing.expectf(t, size_of(MetaDataEntry{}.flags) == 4, "Wrong size for MetaDataEntry.flags, expected 4 got %v", size_of(MetaDataEntry{}.flags))
     testing.expectf(t, offset_of(MetaDataEntry, alignment) == 36, "Wrong offset for MetaDataEntry.alignment, expected 36 got %v", offset_of(MetaDataEntry, alignment))
+    testing.expectf(t, size_of(MetaDataEntry{}.alignment) == 4, "Wrong size for MetaDataEntry.alignment, expected 4 got %v", size_of(MetaDataEntry{}.alignment))
     testing.expectf(t, size_of(MetaDataEntry) == 40, "Wrong size for type MetaDataEntry, expected 40 got %v", size_of(MetaDataEntry))
 }
 
@@ -397,6 +481,7 @@ test_layout_LightCpuTask :: proc(t: ^testing.T) {
 test_layout_Geometry :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(Geometry, mTypePadding) == 4, "Wrong offset for Geometry.mTypePadding, expected 4 got %v", offset_of(Geometry, mTypePadding))
+    testing.expectf(t, size_of(Geometry{}.mTypePadding) == 4, "Wrong size for Geometry.mTypePadding, expected 4 got %v", size_of(Geometry{}.mTypePadding))
     testing.expectf(t, size_of(Geometry) == 8, "Wrong size for type Geometry, expected 8 got %v", size_of(Geometry))
 }
 
@@ -404,6 +489,7 @@ test_layout_Geometry :: proc(t: ^testing.T) {
 test_layout_BoxGeometry :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(BoxGeometry, halfExtents) == 8, "Wrong offset for BoxGeometry.halfExtents, expected 8 got %v", offset_of(BoxGeometry, halfExtents))
+    testing.expectf(t, size_of(BoxGeometry{}.halfExtents) == 12, "Wrong size for BoxGeometry.halfExtents, expected 12 got %v", size_of(BoxGeometry{}.halfExtents))
     testing.expectf(t, size_of(BoxGeometry) == 20, "Wrong size for type BoxGeometry, expected 20 got %v", size_of(BoxGeometry))
 }
 
@@ -435,7 +521,9 @@ test_layout_BVH :: proc(t: ^testing.T) {
 test_layout_CapsuleGeometry :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(CapsuleGeometry, radius) == 8, "Wrong offset for CapsuleGeometry.radius, expected 8 got %v", offset_of(CapsuleGeometry, radius))
+    testing.expectf(t, size_of(CapsuleGeometry{}.radius) == 4, "Wrong size for CapsuleGeometry.radius, expected 4 got %v", size_of(CapsuleGeometry{}.radius))
     testing.expectf(t, offset_of(CapsuleGeometry, halfHeight) == 12, "Wrong offset for CapsuleGeometry.halfHeight, expected 12 got %v", offset_of(CapsuleGeometry, halfHeight))
+    testing.expectf(t, size_of(CapsuleGeometry{}.halfHeight) == 4, "Wrong size for CapsuleGeometry.halfHeight, expected 4 got %v", size_of(CapsuleGeometry{}.halfHeight))
     testing.expectf(t, size_of(CapsuleGeometry) == 16, "Wrong size for type CapsuleGeometry, expected 16 got %v", size_of(CapsuleGeometry))
 }
 
@@ -443,7 +531,9 @@ test_layout_CapsuleGeometry :: proc(t: ^testing.T) {
 test_layout_HullPolygon :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(HullPolygon, mNbVerts) == 16, "Wrong offset for HullPolygon.mNbVerts, expected 16 got %v", offset_of(HullPolygon, mNbVerts))
+    testing.expectf(t, size_of(HullPolygon{}.mNbVerts) == 2, "Wrong size for HullPolygon.mNbVerts, expected 2 got %v", size_of(HullPolygon{}.mNbVerts))
     testing.expectf(t, offset_of(HullPolygon, mIndexBase) == 18, "Wrong offset for HullPolygon.mIndexBase, expected 18 got %v", offset_of(HullPolygon, mIndexBase))
+    testing.expectf(t, size_of(HullPolygon{}.mIndexBase) == 2, "Wrong size for HullPolygon.mIndexBase, expected 2 got %v", size_of(HullPolygon{}.mIndexBase))
     testing.expectf(t, size_of(HullPolygon) == 20, "Wrong size for type HullPolygon, expected 20 got %v", size_of(HullPolygon))
 }
 
@@ -456,7 +546,10 @@ test_layout_ConvexMesh :: proc(t: ^testing.T) {
 @(test)
 test_layout_MeshScale :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(MeshScale, scale) == 0, "Wrong offset for MeshScale.scale, expected 0 got %v", offset_of(MeshScale, scale))
+    testing.expectf(t, size_of(MeshScale{}.scale) == 12, "Wrong size for MeshScale.scale, expected 12 got %v", size_of(MeshScale{}.scale))
     testing.expectf(t, offset_of(MeshScale, rotation) == 12, "Wrong offset for MeshScale.rotation, expected 12 got %v", offset_of(MeshScale, rotation))
+    testing.expectf(t, size_of(MeshScale{}.rotation) == 16, "Wrong size for MeshScale.rotation, expected 16 got %v", size_of(MeshScale{}.rotation))
     testing.expectf(t, size_of(MeshScale) == 28, "Wrong size for type MeshScale, expected 28 got %v", size_of(MeshScale))
 }
 
@@ -464,8 +557,11 @@ test_layout_MeshScale :: proc(t: ^testing.T) {
 test_layout_ConvexMeshGeometry :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(ConvexMeshGeometry, scale) == 8, "Wrong offset for ConvexMeshGeometry.scale, expected 8 got %v", offset_of(ConvexMeshGeometry, scale))
+    testing.expectf(t, size_of(ConvexMeshGeometry{}.scale) == 28, "Wrong size for ConvexMeshGeometry.scale, expected 28 got %v", size_of(ConvexMeshGeometry{}.scale))
     testing.expectf(t, offset_of(ConvexMeshGeometry, convexMesh) == 40, "Wrong offset for ConvexMeshGeometry.convexMesh, expected 40 got %v", offset_of(ConvexMeshGeometry, convexMesh))
+    testing.expectf(t, size_of(ConvexMeshGeometry{}.convexMesh) == 8, "Wrong size for ConvexMeshGeometry.convexMesh, expected 8 got %v", size_of(ConvexMeshGeometry{}.convexMesh))
     testing.expectf(t, offset_of(ConvexMeshGeometry, meshFlags) == 48, "Wrong offset for ConvexMeshGeometry.meshFlags, expected 48 got %v", offset_of(ConvexMeshGeometry, meshFlags))
+    testing.expectf(t, size_of(ConvexMeshGeometry{}.meshFlags) == 1, "Wrong size for ConvexMeshGeometry.meshFlags, expected 1 got %v", size_of(ConvexMeshGeometry{}.meshFlags))
     testing.expectf(t, size_of(ConvexMeshGeometry) == 56, "Wrong size for type ConvexMeshGeometry, expected 56 got %v", size_of(ConvexMeshGeometry))
 }
 
@@ -473,6 +569,7 @@ test_layout_ConvexMeshGeometry :: proc(t: ^testing.T) {
 test_layout_SphereGeometry :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(SphereGeometry, radius) == 8, "Wrong offset for SphereGeometry.radius, expected 8 got %v", offset_of(SphereGeometry, radius))
+    testing.expectf(t, size_of(SphereGeometry{}.radius) == 4, "Wrong size for SphereGeometry.radius, expected 4 got %v", size_of(SphereGeometry{}.radius))
     testing.expectf(t, size_of(SphereGeometry) == 12, "Wrong size for type SphereGeometry, expected 12 got %v", size_of(SphereGeometry))
 }
 
@@ -486,8 +583,11 @@ test_layout_PlaneGeometry :: proc(t: ^testing.T) {
 test_layout_TriangleMeshGeometry :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(TriangleMeshGeometry, scale) == 8, "Wrong offset for TriangleMeshGeometry.scale, expected 8 got %v", offset_of(TriangleMeshGeometry, scale))
+    testing.expectf(t, size_of(TriangleMeshGeometry{}.scale) == 28, "Wrong size for TriangleMeshGeometry.scale, expected 28 got %v", size_of(TriangleMeshGeometry{}.scale))
     testing.expectf(t, offset_of(TriangleMeshGeometry, meshFlags) == 36, "Wrong offset for TriangleMeshGeometry.meshFlags, expected 36 got %v", offset_of(TriangleMeshGeometry, meshFlags))
+    testing.expectf(t, size_of(TriangleMeshGeometry{}.meshFlags) == 1, "Wrong size for TriangleMeshGeometry.meshFlags, expected 1 got %v", size_of(TriangleMeshGeometry{}.meshFlags))
     testing.expectf(t, offset_of(TriangleMeshGeometry, triangleMesh) == 40, "Wrong offset for TriangleMeshGeometry.triangleMesh, expected 40 got %v", offset_of(TriangleMeshGeometry, triangleMesh))
+    testing.expectf(t, size_of(TriangleMeshGeometry{}.triangleMesh) == 8, "Wrong size for TriangleMeshGeometry.triangleMesh, expected 8 got %v", size_of(TriangleMeshGeometry{}.triangleMesh))
     testing.expectf(t, size_of(TriangleMeshGeometry) == 48, "Wrong size for type TriangleMeshGeometry, expected 48 got %v", size_of(TriangleMeshGeometry))
 }
 
@@ -495,10 +595,15 @@ test_layout_TriangleMeshGeometry :: proc(t: ^testing.T) {
 test_layout_HeightFieldGeometry :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(HeightFieldGeometry, heightField) == 8, "Wrong offset for HeightFieldGeometry.heightField, expected 8 got %v", offset_of(HeightFieldGeometry, heightField))
+    testing.expectf(t, size_of(HeightFieldGeometry{}.heightField) == 8, "Wrong size for HeightFieldGeometry.heightField, expected 8 got %v", size_of(HeightFieldGeometry{}.heightField))
     testing.expectf(t, offset_of(HeightFieldGeometry, heightScale) == 16, "Wrong offset for HeightFieldGeometry.heightScale, expected 16 got %v", offset_of(HeightFieldGeometry, heightScale))
+    testing.expectf(t, size_of(HeightFieldGeometry{}.heightScale) == 4, "Wrong size for HeightFieldGeometry.heightScale, expected 4 got %v", size_of(HeightFieldGeometry{}.heightScale))
     testing.expectf(t, offset_of(HeightFieldGeometry, rowScale) == 20, "Wrong offset for HeightFieldGeometry.rowScale, expected 20 got %v", offset_of(HeightFieldGeometry, rowScale))
+    testing.expectf(t, size_of(HeightFieldGeometry{}.rowScale) == 4, "Wrong size for HeightFieldGeometry.rowScale, expected 4 got %v", size_of(HeightFieldGeometry{}.rowScale))
     testing.expectf(t, offset_of(HeightFieldGeometry, columnScale) == 24, "Wrong offset for HeightFieldGeometry.columnScale, expected 24 got %v", offset_of(HeightFieldGeometry, columnScale))
+    testing.expectf(t, size_of(HeightFieldGeometry{}.columnScale) == 4, "Wrong size for HeightFieldGeometry.columnScale, expected 4 got %v", size_of(HeightFieldGeometry{}.columnScale))
     testing.expectf(t, offset_of(HeightFieldGeometry, heightFieldFlags) == 28, "Wrong offset for HeightFieldGeometry.heightFieldFlags, expected 28 got %v", offset_of(HeightFieldGeometry, heightFieldFlags))
+    testing.expectf(t, size_of(HeightFieldGeometry{}.heightFieldFlags) == 1, "Wrong size for HeightFieldGeometry.heightFieldFlags, expected 1 got %v", size_of(HeightFieldGeometry{}.heightFieldFlags))
     testing.expectf(t, size_of(HeightFieldGeometry) == 32, "Wrong size for type HeightFieldGeometry, expected 32 got %v", size_of(HeightFieldGeometry))
 }
 
@@ -506,6 +611,7 @@ test_layout_HeightFieldGeometry :: proc(t: ^testing.T) {
 test_layout_ParticleSystemGeometry :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(ParticleSystemGeometry, mSolverType) == 8, "Wrong offset for ParticleSystemGeometry.mSolverType, expected 8 got %v", offset_of(ParticleSystemGeometry, mSolverType))
+    testing.expectf(t, size_of(ParticleSystemGeometry{}.mSolverType) == 4, "Wrong size for ParticleSystemGeometry.mSolverType, expected 4 got %v", size_of(ParticleSystemGeometry{}.mSolverType))
     testing.expectf(t, size_of(ParticleSystemGeometry) == 12, "Wrong size for type ParticleSystemGeometry, expected 12 got %v", size_of(ParticleSystemGeometry))
 }
 
@@ -519,12 +625,15 @@ test_layout_HairSystemGeometry :: proc(t: ^testing.T) {
 test_layout_TetrahedronMeshGeometry :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(TetrahedronMeshGeometry, tetrahedronMesh) == 8, "Wrong offset for TetrahedronMeshGeometry.tetrahedronMesh, expected 8 got %v", offset_of(TetrahedronMeshGeometry, tetrahedronMesh))
+    testing.expectf(t, size_of(TetrahedronMeshGeometry{}.tetrahedronMesh) == 8, "Wrong size for TetrahedronMeshGeometry.tetrahedronMesh, expected 8 got %v", size_of(TetrahedronMeshGeometry{}.tetrahedronMesh))
     testing.expectf(t, size_of(TetrahedronMeshGeometry) == 16, "Wrong size for type TetrahedronMeshGeometry, expected 16 got %v", size_of(TetrahedronMeshGeometry))
 }
 
 @(test)
 test_layout_QueryHit :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(QueryHit, faceIndex) == 0, "Wrong offset for QueryHit.faceIndex, expected 0 got %v", offset_of(QueryHit, faceIndex))
+    testing.expectf(t, size_of(QueryHit{}.faceIndex) == 4, "Wrong size for QueryHit.faceIndex, expected 4 got %v", size_of(QueryHit{}.faceIndex))
     testing.expectf(t, size_of(QueryHit) == 4, "Wrong size for type QueryHit, expected 4 got %v", size_of(QueryHit))
 }
 
@@ -532,9 +641,13 @@ test_layout_QueryHit :: proc(t: ^testing.T) {
 test_layout_LocationHit :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(LocationHit, flags) == 4, "Wrong offset for LocationHit.flags, expected 4 got %v", offset_of(LocationHit, flags))
+    testing.expectf(t, size_of(LocationHit{}.flags) == 2, "Wrong size for LocationHit.flags, expected 2 got %v", size_of(LocationHit{}.flags))
     testing.expectf(t, offset_of(LocationHit, position) == 8, "Wrong offset for LocationHit.position, expected 8 got %v", offset_of(LocationHit, position))
+    testing.expectf(t, size_of(LocationHit{}.position) == 12, "Wrong size for LocationHit.position, expected 12 got %v", size_of(LocationHit{}.position))
     testing.expectf(t, offset_of(LocationHit, normal) == 20, "Wrong offset for LocationHit.normal, expected 20 got %v", offset_of(LocationHit, normal))
+    testing.expectf(t, size_of(LocationHit{}.normal) == 12, "Wrong size for LocationHit.normal, expected 12 got %v", size_of(LocationHit{}.normal))
     testing.expectf(t, offset_of(LocationHit, distance) == 32, "Wrong offset for LocationHit.distance, expected 32 got %v", offset_of(LocationHit, distance))
+    testing.expectf(t, size_of(LocationHit{}.distance) == 4, "Wrong size for LocationHit.distance, expected 4 got %v", size_of(LocationHit{}.distance))
     testing.expectf(t, size_of(LocationHit) == 36, "Wrong size for type LocationHit, expected 36 got %v", size_of(LocationHit))
 }
 
@@ -542,7 +655,9 @@ test_layout_LocationHit :: proc(t: ^testing.T) {
 test_layout_GeomRaycastHit :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(GeomRaycastHit, u) == 36, "Wrong offset for GeomRaycastHit.u, expected 36 got %v", offset_of(GeomRaycastHit, u))
+    testing.expectf(t, size_of(GeomRaycastHit{}.u) == 4, "Wrong size for GeomRaycastHit.u, expected 4 got %v", size_of(GeomRaycastHit{}.u))
     testing.expectf(t, offset_of(GeomRaycastHit, v) == 40, "Wrong offset for GeomRaycastHit.v, expected 40 got %v", offset_of(GeomRaycastHit, v))
+    testing.expectf(t, size_of(GeomRaycastHit{}.v) == 4, "Wrong size for GeomRaycastHit.v, expected 4 got %v", size_of(GeomRaycastHit{}.v))
     testing.expectf(t, size_of(GeomRaycastHit) == 44, "Wrong size for type GeomRaycastHit, expected 44 got %v", size_of(GeomRaycastHit))
 }
 
@@ -561,7 +676,10 @@ test_layout_GeomSweepHit :: proc(t: ^testing.T) {
 @(test)
 test_layout_GeomIndexPair :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(GeomIndexPair, id0) == 0, "Wrong offset for GeomIndexPair.id0, expected 0 got %v", offset_of(GeomIndexPair, id0))
+    testing.expectf(t, size_of(GeomIndexPair{}.id0) == 4, "Wrong size for GeomIndexPair.id0, expected 4 got %v", size_of(GeomIndexPair{}.id0))
     testing.expectf(t, offset_of(GeomIndexPair, id1) == 4, "Wrong offset for GeomIndexPair.id1, expected 4 got %v", offset_of(GeomIndexPair, id1))
+    testing.expectf(t, size_of(GeomIndexPair{}.id1) == 4, "Wrong size for GeomIndexPair.id1, expected 4 got %v", size_of(GeomIndexPair{}.id1))
     testing.expectf(t, size_of(GeomIndexPair) == 8, "Wrong size for type GeomIndexPair, expected 8 got %v", size_of(GeomIndexPair))
 }
 
@@ -582,6 +700,7 @@ test_layout_CustomGeometryCallbacks :: proc(t: ^testing.T) {
 test_layout_CustomGeometry :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(CustomGeometry, callbacks) == 8, "Wrong offset for CustomGeometry.callbacks, expected 8 got %v", offset_of(CustomGeometry, callbacks))
+    testing.expectf(t, size_of(CustomGeometry{}.callbacks) == 8, "Wrong size for CustomGeometry.callbacks, expected 8 got %v", size_of(CustomGeometry{}.callbacks))
     testing.expectf(t, size_of(CustomGeometry) == 16, "Wrong size for type CustomGeometry, expected 16 got %v", size_of(CustomGeometry))
 }
 
@@ -595,8 +714,12 @@ test_layout_GeometryHolder :: proc(t: ^testing.T) {
 @(test)
 test_layout_HeightFieldSample :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(HeightFieldSample, height) == 0, "Wrong offset for HeightFieldSample.height, expected 0 got %v", offset_of(HeightFieldSample, height))
+    testing.expectf(t, size_of(HeightFieldSample{}.height) == 2, "Wrong size for HeightFieldSample.height, expected 2 got %v", size_of(HeightFieldSample{}.height))
     testing.expectf(t, offset_of(HeightFieldSample, materialIndex0) == 2, "Wrong offset for HeightFieldSample.materialIndex0, expected 2 got %v", offset_of(HeightFieldSample, materialIndex0))
+    testing.expectf(t, size_of(HeightFieldSample{}.materialIndex0) == 1, "Wrong size for HeightFieldSample.materialIndex0, expected 1 got %v", size_of(HeightFieldSample{}.materialIndex0))
     testing.expectf(t, offset_of(HeightFieldSample, materialIndex1) == 3, "Wrong offset for HeightFieldSample.materialIndex1, expected 3 got %v", offset_of(HeightFieldSample, materialIndex1))
+    testing.expectf(t, size_of(HeightFieldSample{}.materialIndex1) == 1, "Wrong size for HeightFieldSample.materialIndex1, expected 1 got %v", size_of(HeightFieldSample{}.materialIndex1))
     testing.expectf(t, size_of(HeightFieldSample) == 4, "Wrong size for type HeightFieldSample, expected 4 got %v", size_of(HeightFieldSample))
 }
 
@@ -609,11 +732,18 @@ test_layout_HeightField :: proc(t: ^testing.T) {
 @(test)
 test_layout_HeightFieldDesc :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(HeightFieldDesc, nbRows) == 0, "Wrong offset for HeightFieldDesc.nbRows, expected 0 got %v", offset_of(HeightFieldDesc, nbRows))
+    testing.expectf(t, size_of(HeightFieldDesc{}.nbRows) == 4, "Wrong size for HeightFieldDesc.nbRows, expected 4 got %v", size_of(HeightFieldDesc{}.nbRows))
     testing.expectf(t, offset_of(HeightFieldDesc, nbColumns) == 4, "Wrong offset for HeightFieldDesc.nbColumns, expected 4 got %v", offset_of(HeightFieldDesc, nbColumns))
+    testing.expectf(t, size_of(HeightFieldDesc{}.nbColumns) == 4, "Wrong size for HeightFieldDesc.nbColumns, expected 4 got %v", size_of(HeightFieldDesc{}.nbColumns))
     testing.expectf(t, offset_of(HeightFieldDesc, format) == 8, "Wrong offset for HeightFieldDesc.format, expected 8 got %v", offset_of(HeightFieldDesc, format))
+    testing.expectf(t, size_of(HeightFieldDesc{}.format) == 4, "Wrong size for HeightFieldDesc.format, expected 4 got %v", size_of(HeightFieldDesc{}.format))
     testing.expectf(t, offset_of(HeightFieldDesc, samples) == 16, "Wrong offset for HeightFieldDesc.samples, expected 16 got %v", offset_of(HeightFieldDesc, samples))
+    testing.expectf(t, size_of(HeightFieldDesc{}.samples) == 16, "Wrong size for HeightFieldDesc.samples, expected 16 got %v", size_of(HeightFieldDesc{}.samples))
     testing.expectf(t, offset_of(HeightFieldDesc, convexEdgeThreshold) == 32, "Wrong offset for HeightFieldDesc.convexEdgeThreshold, expected 32 got %v", offset_of(HeightFieldDesc, convexEdgeThreshold))
+    testing.expectf(t, size_of(HeightFieldDesc{}.convexEdgeThreshold) == 4, "Wrong size for HeightFieldDesc.convexEdgeThreshold, expected 4 got %v", size_of(HeightFieldDesc{}.convexEdgeThreshold))
     testing.expectf(t, offset_of(HeightFieldDesc, flags) == 36, "Wrong offset for HeightFieldDesc.flags, expected 36 got %v", offset_of(HeightFieldDesc, flags))
+    testing.expectf(t, size_of(HeightFieldDesc{}.flags) == 2, "Wrong size for HeightFieldDesc.flags, expected 2 got %v", size_of(HeightFieldDesc{}.flags))
     testing.expectf(t, size_of(HeightFieldDesc) == 40, "Wrong size for type HeightFieldDesc, expected 40 got %v", size_of(HeightFieldDesc))
 }
 
@@ -621,8 +751,12 @@ test_layout_HeightFieldDesc :: proc(t: ^testing.T) {
 @(test)
 test_layout_SimpleTriangleMesh :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(SimpleTriangleMesh, points) == 0, "Wrong offset for SimpleTriangleMesh.points, expected 0 got %v", offset_of(SimpleTriangleMesh, points))
+    testing.expectf(t, size_of(SimpleTriangleMesh{}.points) == 24, "Wrong size for SimpleTriangleMesh.points, expected 24 got %v", size_of(SimpleTriangleMesh{}.points))
     testing.expectf(t, offset_of(SimpleTriangleMesh, triangles) == 24, "Wrong offset for SimpleTriangleMesh.triangles, expected 24 got %v", offset_of(SimpleTriangleMesh, triangles))
+    testing.expectf(t, size_of(SimpleTriangleMesh{}.triangles) == 24, "Wrong size for SimpleTriangleMesh.triangles, expected 24 got %v", size_of(SimpleTriangleMesh{}.triangles))
     testing.expectf(t, offset_of(SimpleTriangleMesh, flags) == 48, "Wrong offset for SimpleTriangleMesh.flags, expected 48 got %v", offset_of(SimpleTriangleMesh, flags))
+    testing.expectf(t, size_of(SimpleTriangleMesh{}.flags) == 2, "Wrong size for SimpleTriangleMesh.flags, expected 2 got %v", size_of(SimpleTriangleMesh{}.flags))
     testing.expectf(t, size_of(SimpleTriangleMesh) == 56, "Wrong size for type SimpleTriangleMesh, expected 56 got %v", size_of(SimpleTriangleMesh))
 }
 
@@ -636,6 +770,7 @@ test_layout_Triangle :: proc(t: ^testing.T) {
 test_layout_TrianglePadded :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(TrianglePadded, padding) == 36, "Wrong offset for TrianglePadded.padding, expected 36 got %v", offset_of(TrianglePadded, padding))
+    testing.expectf(t, size_of(TrianglePadded{}.padding) == 4, "Wrong size for TrianglePadded.padding, expected 4 got %v", size_of(TrianglePadded{}.padding))
     testing.expectf(t, size_of(TrianglePadded) == 40, "Wrong size for type TrianglePadded, expected 40 got %v", size_of(TrianglePadded))
 }
 
@@ -700,6 +835,7 @@ test_layout_SimulationTetrahedronMeshData :: proc(t: ^testing.T) {
 test_layout_Actor :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(Actor, userData) == 16, "Wrong offset for Actor.userData, expected 16 got %v", offset_of(Actor, userData))
+    testing.expectf(t, size_of(Actor{}.userData) == 8, "Wrong size for Actor.userData, expected 8 got %v", size_of(Actor{}.userData))
     testing.expectf(t, size_of(Actor) == 24, "Wrong size for type Actor, expected 24 got %v", size_of(Actor))
 }
 
@@ -707,20 +843,27 @@ test_layout_Actor :: proc(t: ^testing.T) {
 test_layout_Aggregate :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(Aggregate, userData) == 16, "Wrong offset for Aggregate.userData, expected 16 got %v", offset_of(Aggregate, userData))
+    testing.expectf(t, size_of(Aggregate{}.userData) == 8, "Wrong size for Aggregate.userData, expected 8 got %v", size_of(Aggregate{}.userData))
     testing.expectf(t, size_of(Aggregate) == 24, "Wrong size for type Aggregate, expected 24 got %v", size_of(Aggregate))
 }
 
 @(test)
 test_layout_SpringModifiers :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(SpringModifiers, stiffness) == 0, "Wrong offset for SpringModifiers.stiffness, expected 0 got %v", offset_of(SpringModifiers, stiffness))
+    testing.expectf(t, size_of(SpringModifiers{}.stiffness) == 4, "Wrong size for SpringModifiers.stiffness, expected 4 got %v", size_of(SpringModifiers{}.stiffness))
     testing.expectf(t, offset_of(SpringModifiers, damping) == 4, "Wrong offset for SpringModifiers.damping, expected 4 got %v", offset_of(SpringModifiers, damping))
+    testing.expectf(t, size_of(SpringModifiers{}.damping) == 4, "Wrong size for SpringModifiers.damping, expected 4 got %v", size_of(SpringModifiers{}.damping))
     testing.expectf(t, size_of(SpringModifiers) == 16, "Wrong size for type SpringModifiers, expected 16 got %v", size_of(SpringModifiers))
 }
 
 @(test)
 test_layout_RestitutionModifiers :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(RestitutionModifiers, restitution) == 0, "Wrong offset for RestitutionModifiers.restitution, expected 0 got %v", offset_of(RestitutionModifiers, restitution))
+    testing.expectf(t, size_of(RestitutionModifiers{}.restitution) == 4, "Wrong size for RestitutionModifiers.restitution, expected 4 got %v", size_of(RestitutionModifiers{}.restitution))
     testing.expectf(t, offset_of(RestitutionModifiers, velocityThreshold) == 4, "Wrong offset for RestitutionModifiers.velocityThreshold, expected 4 got %v", offset_of(RestitutionModifiers, velocityThreshold))
+    testing.expectf(t, size_of(RestitutionModifiers{}.velocityThreshold) == 4, "Wrong size for RestitutionModifiers.velocityThreshold, expected 4 got %v", size_of(RestitutionModifiers{}.velocityThreshold))
     testing.expectf(t, size_of(RestitutionModifiers) == 16, "Wrong size for type RestitutionModifiers, expected 16 got %v", size_of(RestitutionModifiers))
 }
 
@@ -728,26 +871,44 @@ test_layout_RestitutionModifiers :: proc(t: ^testing.T) {
 @(test)
 test_layout_OneDConstraint :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(OneDConstraint, linear0) == 0, "Wrong offset for OneDConstraint.linear0, expected 0 got %v", offset_of(OneDConstraint, linear0))
+    testing.expectf(t, size_of(OneDConstraint{}.linear0) == 12, "Wrong size for OneDConstraint.linear0, expected 12 got %v", size_of(OneDConstraint{}.linear0))
     testing.expectf(t, offset_of(OneDConstraint, geometricError) == 12, "Wrong offset for OneDConstraint.geometricError, expected 12 got %v", offset_of(OneDConstraint, geometricError))
+    testing.expectf(t, size_of(OneDConstraint{}.geometricError) == 4, "Wrong size for OneDConstraint.geometricError, expected 4 got %v", size_of(OneDConstraint{}.geometricError))
     testing.expectf(t, offset_of(OneDConstraint, angular0) == 16, "Wrong offset for OneDConstraint.angular0, expected 16 got %v", offset_of(OneDConstraint, angular0))
+    testing.expectf(t, size_of(OneDConstraint{}.angular0) == 12, "Wrong size for OneDConstraint.angular0, expected 12 got %v", size_of(OneDConstraint{}.angular0))
     testing.expectf(t, offset_of(OneDConstraint, velocityTarget) == 28, "Wrong offset for OneDConstraint.velocityTarget, expected 28 got %v", offset_of(OneDConstraint, velocityTarget))
+    testing.expectf(t, size_of(OneDConstraint{}.velocityTarget) == 4, "Wrong size for OneDConstraint.velocityTarget, expected 4 got %v", size_of(OneDConstraint{}.velocityTarget))
     testing.expectf(t, offset_of(OneDConstraint, linear1) == 32, "Wrong offset for OneDConstraint.linear1, expected 32 got %v", offset_of(OneDConstraint, linear1))
+    testing.expectf(t, size_of(OneDConstraint{}.linear1) == 12, "Wrong size for OneDConstraint.linear1, expected 12 got %v", size_of(OneDConstraint{}.linear1))
     testing.expectf(t, offset_of(OneDConstraint, minImpulse) == 44, "Wrong offset for OneDConstraint.minImpulse, expected 44 got %v", offset_of(OneDConstraint, minImpulse))
+    testing.expectf(t, size_of(OneDConstraint{}.minImpulse) == 4, "Wrong size for OneDConstraint.minImpulse, expected 4 got %v", size_of(OneDConstraint{}.minImpulse))
     testing.expectf(t, offset_of(OneDConstraint, angular1) == 48, "Wrong offset for OneDConstraint.angular1, expected 48 got %v", offset_of(OneDConstraint, angular1))
+    testing.expectf(t, size_of(OneDConstraint{}.angular1) == 12, "Wrong size for OneDConstraint.angular1, expected 12 got %v", size_of(OneDConstraint{}.angular1))
     testing.expectf(t, offset_of(OneDConstraint, maxImpulse) == 60, "Wrong offset for OneDConstraint.maxImpulse, expected 60 got %v", offset_of(OneDConstraint, maxImpulse))
+    testing.expectf(t, size_of(OneDConstraint{}.maxImpulse) == 4, "Wrong size for OneDConstraint.maxImpulse, expected 4 got %v", size_of(OneDConstraint{}.maxImpulse))
     testing.expectf(t, offset_of(OneDConstraint, mods) == 64, "Wrong offset for OneDConstraint.mods, expected 64 got %v", offset_of(OneDConstraint, mods))
+    testing.expectf(t, size_of(OneDConstraint{}.mods) == 16, "Wrong size for OneDConstraint.mods, expected 16 got %v", size_of(OneDConstraint{}.mods))
     testing.expectf(t, offset_of(OneDConstraint, forInternalUse) == 80, "Wrong offset for OneDConstraint.forInternalUse, expected 80 got %v", offset_of(OneDConstraint, forInternalUse))
+    testing.expectf(t, size_of(OneDConstraint{}.forInternalUse) == 4, "Wrong size for OneDConstraint.forInternalUse, expected 4 got %v", size_of(OneDConstraint{}.forInternalUse))
     testing.expectf(t, offset_of(OneDConstraint, flags) == 84, "Wrong offset for OneDConstraint.flags, expected 84 got %v", offset_of(OneDConstraint, flags))
+    testing.expectf(t, size_of(OneDConstraint{}.flags) == 2, "Wrong size for OneDConstraint.flags, expected 2 got %v", size_of(OneDConstraint{}.flags))
     testing.expectf(t, offset_of(OneDConstraint, solveHint) == 86, "Wrong offset for OneDConstraint.solveHint, expected 86 got %v", offset_of(OneDConstraint, solveHint))
+    testing.expectf(t, size_of(OneDConstraint{}.solveHint) == 2, "Wrong size for OneDConstraint.solveHint, expected 2 got %v", size_of(OneDConstraint{}.solveHint))
     testing.expectf(t, size_of(OneDConstraint) == 96, "Wrong size for type OneDConstraint, expected 96 got %v", size_of(OneDConstraint))
 }
 
 @(test)
 test_layout_ConstraintInvMassScale :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(ConstraintInvMassScale, linear0) == 0, "Wrong offset for ConstraintInvMassScale.linear0, expected 0 got %v", offset_of(ConstraintInvMassScale, linear0))
+    testing.expectf(t, size_of(ConstraintInvMassScale{}.linear0) == 4, "Wrong size for ConstraintInvMassScale.linear0, expected 4 got %v", size_of(ConstraintInvMassScale{}.linear0))
     testing.expectf(t, offset_of(ConstraintInvMassScale, angular0) == 4, "Wrong offset for ConstraintInvMassScale.angular0, expected 4 got %v", offset_of(ConstraintInvMassScale, angular0))
+    testing.expectf(t, size_of(ConstraintInvMassScale{}.angular0) == 4, "Wrong size for ConstraintInvMassScale.angular0, expected 4 got %v", size_of(ConstraintInvMassScale{}.angular0))
     testing.expectf(t, offset_of(ConstraintInvMassScale, linear1) == 8, "Wrong offset for ConstraintInvMassScale.linear1, expected 8 got %v", offset_of(ConstraintInvMassScale, linear1))
+    testing.expectf(t, size_of(ConstraintInvMassScale{}.linear1) == 4, "Wrong size for ConstraintInvMassScale.linear1, expected 4 got %v", size_of(ConstraintInvMassScale{}.linear1))
     testing.expectf(t, offset_of(ConstraintInvMassScale, angular1) == 12, "Wrong offset for ConstraintInvMassScale.angular1, expected 12 got %v", offset_of(ConstraintInvMassScale, angular1))
+    testing.expectf(t, size_of(ConstraintInvMassScale{}.angular1) == 4, "Wrong size for ConstraintInvMassScale.angular1, expected 4 got %v", size_of(ConstraintInvMassScale{}.angular1))
     testing.expectf(t, size_of(ConstraintInvMassScale) == 16, "Wrong size for type ConstraintInvMassScale, expected 16 got %v", size_of(ConstraintInvMassScale))
 }
 
@@ -766,80 +927,136 @@ test_layout_ConstraintConnector :: proc(t: ^testing.T) {
 @(test)
 test_layout_ContactPoint :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(ContactPoint, normal) == 0, "Wrong offset for ContactPoint.normal, expected 0 got %v", offset_of(ContactPoint, normal))
+    testing.expectf(t, size_of(ContactPoint{}.normal) == 12, "Wrong size for ContactPoint.normal, expected 12 got %v", size_of(ContactPoint{}.normal))
     testing.expectf(t, offset_of(ContactPoint, separation) == 12, "Wrong offset for ContactPoint.separation, expected 12 got %v", offset_of(ContactPoint, separation))
+    testing.expectf(t, size_of(ContactPoint{}.separation) == 4, "Wrong size for ContactPoint.separation, expected 4 got %v", size_of(ContactPoint{}.separation))
     testing.expectf(t, offset_of(ContactPoint, point) == 16, "Wrong offset for ContactPoint.point, expected 16 got %v", offset_of(ContactPoint, point))
+    testing.expectf(t, size_of(ContactPoint{}.point) == 12, "Wrong size for ContactPoint.point, expected 12 got %v", size_of(ContactPoint{}.point))
     testing.expectf(t, offset_of(ContactPoint, maxImpulse) == 28, "Wrong offset for ContactPoint.maxImpulse, expected 28 got %v", offset_of(ContactPoint, maxImpulse))
+    testing.expectf(t, size_of(ContactPoint{}.maxImpulse) == 4, "Wrong size for ContactPoint.maxImpulse, expected 4 got %v", size_of(ContactPoint{}.maxImpulse))
     testing.expectf(t, offset_of(ContactPoint, targetVel) == 32, "Wrong offset for ContactPoint.targetVel, expected 32 got %v", offset_of(ContactPoint, targetVel))
+    testing.expectf(t, size_of(ContactPoint{}.targetVel) == 12, "Wrong size for ContactPoint.targetVel, expected 12 got %v", size_of(ContactPoint{}.targetVel))
     testing.expectf(t, offset_of(ContactPoint, staticFriction) == 44, "Wrong offset for ContactPoint.staticFriction, expected 44 got %v", offset_of(ContactPoint, staticFriction))
+    testing.expectf(t, size_of(ContactPoint{}.staticFriction) == 4, "Wrong size for ContactPoint.staticFriction, expected 4 got %v", size_of(ContactPoint{}.staticFriction))
     testing.expectf(t, offset_of(ContactPoint, materialFlags) == 48, "Wrong offset for ContactPoint.materialFlags, expected 48 got %v", offset_of(ContactPoint, materialFlags))
+    testing.expectf(t, size_of(ContactPoint{}.materialFlags) == 1, "Wrong size for ContactPoint.materialFlags, expected 1 got %v", size_of(ContactPoint{}.materialFlags))
     testing.expectf(t, offset_of(ContactPoint, internalFaceIndex1) == 52, "Wrong offset for ContactPoint.internalFaceIndex1, expected 52 got %v", offset_of(ContactPoint, internalFaceIndex1))
+    testing.expectf(t, size_of(ContactPoint{}.internalFaceIndex1) == 4, "Wrong size for ContactPoint.internalFaceIndex1, expected 4 got %v", size_of(ContactPoint{}.internalFaceIndex1))
     testing.expectf(t, offset_of(ContactPoint, dynamicFriction) == 56, "Wrong offset for ContactPoint.dynamicFriction, expected 56 got %v", offset_of(ContactPoint, dynamicFriction))
+    testing.expectf(t, size_of(ContactPoint{}.dynamicFriction) == 4, "Wrong size for ContactPoint.dynamicFriction, expected 4 got %v", size_of(ContactPoint{}.dynamicFriction))
     testing.expectf(t, offset_of(ContactPoint, restitution) == 60, "Wrong offset for ContactPoint.restitution, expected 60 got %v", offset_of(ContactPoint, restitution))
+    testing.expectf(t, size_of(ContactPoint{}.restitution) == 4, "Wrong size for ContactPoint.restitution, expected 4 got %v", size_of(ContactPoint{}.restitution))
     testing.expectf(t, offset_of(ContactPoint, damping) == 64, "Wrong offset for ContactPoint.damping, expected 64 got %v", offset_of(ContactPoint, damping))
+    testing.expectf(t, size_of(ContactPoint{}.damping) == 4, "Wrong size for ContactPoint.damping, expected 4 got %v", size_of(ContactPoint{}.damping))
     testing.expectf(t, size_of(ContactPoint) == 80, "Wrong size for type ContactPoint, expected 80 got %v", size_of(ContactPoint))
 }
 
 @(test)
 test_layout_SolverBody :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(SolverBody, linearVelocity) == 0, "Wrong offset for SolverBody.linearVelocity, expected 0 got %v", offset_of(SolverBody, linearVelocity))
+    testing.expectf(t, size_of(SolverBody{}.linearVelocity) == 12, "Wrong size for SolverBody.linearVelocity, expected 12 got %v", size_of(SolverBody{}.linearVelocity))
     testing.expectf(t, offset_of(SolverBody, maxSolverNormalProgress) == 12, "Wrong offset for SolverBody.maxSolverNormalProgress, expected 12 got %v", offset_of(SolverBody, maxSolverNormalProgress))
+    testing.expectf(t, size_of(SolverBody{}.maxSolverNormalProgress) == 2, "Wrong size for SolverBody.maxSolverNormalProgress, expected 2 got %v", size_of(SolverBody{}.maxSolverNormalProgress))
     testing.expectf(t, offset_of(SolverBody, maxSolverFrictionProgress) == 14, "Wrong offset for SolverBody.maxSolverFrictionProgress, expected 14 got %v", offset_of(SolverBody, maxSolverFrictionProgress))
+    testing.expectf(t, size_of(SolverBody{}.maxSolverFrictionProgress) == 2, "Wrong size for SolverBody.maxSolverFrictionProgress, expected 2 got %v", size_of(SolverBody{}.maxSolverFrictionProgress))
     testing.expectf(t, offset_of(SolverBody, angularState) == 16, "Wrong offset for SolverBody.angularState, expected 16 got %v", offset_of(SolverBody, angularState))
+    testing.expectf(t, size_of(SolverBody{}.angularState) == 12, "Wrong size for SolverBody.angularState, expected 12 got %v", size_of(SolverBody{}.angularState))
     testing.expectf(t, offset_of(SolverBody, solverProgress) == 28, "Wrong offset for SolverBody.solverProgress, expected 28 got %v", offset_of(SolverBody, solverProgress))
+    testing.expectf(t, size_of(SolverBody{}.solverProgress) == 4, "Wrong size for SolverBody.solverProgress, expected 4 got %v", size_of(SolverBody{}.solverProgress))
     testing.expectf(t, size_of(SolverBody) == 32, "Wrong size for type SolverBody, expected 32 got %v", size_of(SolverBody))
 }
 
 @(test)
 test_layout_SolverBodyData :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(SolverBodyData, linearVelocity) == 0, "Wrong offset for SolverBodyData.linearVelocity, expected 0 got %v", offset_of(SolverBodyData, linearVelocity))
+    testing.expectf(t, size_of(SolverBodyData{}.linearVelocity) == 12, "Wrong size for SolverBodyData.linearVelocity, expected 12 got %v", size_of(SolverBodyData{}.linearVelocity))
     testing.expectf(t, offset_of(SolverBodyData, invMass) == 12, "Wrong offset for SolverBodyData.invMass, expected 12 got %v", offset_of(SolverBodyData, invMass))
+    testing.expectf(t, size_of(SolverBodyData{}.invMass) == 4, "Wrong size for SolverBodyData.invMass, expected 4 got %v", size_of(SolverBodyData{}.invMass))
     testing.expectf(t, offset_of(SolverBodyData, angularVelocity) == 16, "Wrong offset for SolverBodyData.angularVelocity, expected 16 got %v", offset_of(SolverBodyData, angularVelocity))
+    testing.expectf(t, size_of(SolverBodyData{}.angularVelocity) == 12, "Wrong size for SolverBodyData.angularVelocity, expected 12 got %v", size_of(SolverBodyData{}.angularVelocity))
     testing.expectf(t, offset_of(SolverBodyData, reportThreshold) == 28, "Wrong offset for SolverBodyData.reportThreshold, expected 28 got %v", offset_of(SolverBodyData, reportThreshold))
+    testing.expectf(t, size_of(SolverBodyData{}.reportThreshold) == 4, "Wrong size for SolverBodyData.reportThreshold, expected 4 got %v", size_of(SolverBodyData{}.reportThreshold))
     testing.expectf(t, offset_of(SolverBodyData, sqrtInvInertia) == 32, "Wrong offset for SolverBodyData.sqrtInvInertia, expected 32 got %v", offset_of(SolverBodyData, sqrtInvInertia))
+    testing.expectf(t, size_of(SolverBodyData{}.sqrtInvInertia) == 36, "Wrong size for SolverBodyData.sqrtInvInertia, expected 36 got %v", size_of(SolverBodyData{}.sqrtInvInertia))
     testing.expectf(t, offset_of(SolverBodyData, penBiasClamp) == 68, "Wrong offset for SolverBodyData.penBiasClamp, expected 68 got %v", offset_of(SolverBodyData, penBiasClamp))
+    testing.expectf(t, size_of(SolverBodyData{}.penBiasClamp) == 4, "Wrong size for SolverBodyData.penBiasClamp, expected 4 got %v", size_of(SolverBodyData{}.penBiasClamp))
     testing.expectf(t, offset_of(SolverBodyData, nodeIndex) == 72, "Wrong offset for SolverBodyData.nodeIndex, expected 72 got %v", offset_of(SolverBodyData, nodeIndex))
+    testing.expectf(t, size_of(SolverBodyData{}.nodeIndex) == 4, "Wrong size for SolverBodyData.nodeIndex, expected 4 got %v", size_of(SolverBodyData{}.nodeIndex))
     testing.expectf(t, offset_of(SolverBodyData, maxContactImpulse) == 76, "Wrong offset for SolverBodyData.maxContactImpulse, expected 76 got %v", offset_of(SolverBodyData, maxContactImpulse))
+    testing.expectf(t, size_of(SolverBodyData{}.maxContactImpulse) == 4, "Wrong size for SolverBodyData.maxContactImpulse, expected 4 got %v", size_of(SolverBodyData{}.maxContactImpulse))
     testing.expectf(t, offset_of(SolverBodyData, body2World) == 80, "Wrong offset for SolverBodyData.body2World, expected 80 got %v", offset_of(SolverBodyData, body2World))
+    testing.expectf(t, size_of(SolverBodyData{}.body2World) == 28, "Wrong size for SolverBodyData.body2World, expected 28 got %v", size_of(SolverBodyData{}.body2World))
     testing.expectf(t, offset_of(SolverBodyData, pad) == 108, "Wrong offset for SolverBodyData.pad, expected 108 got %v", offset_of(SolverBodyData, pad))
+    testing.expectf(t, size_of(SolverBodyData{}.pad) == 2, "Wrong size for SolverBodyData.pad, expected 2 got %v", size_of(SolverBodyData{}.pad))
     testing.expectf(t, size_of(SolverBodyData) == 112, "Wrong size for type SolverBodyData, expected 112 got %v", size_of(SolverBodyData))
 }
 
 @(test)
 test_layout_ConstraintBatchHeader :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(ConstraintBatchHeader, startIndex) == 0, "Wrong offset for ConstraintBatchHeader.startIndex, expected 0 got %v", offset_of(ConstraintBatchHeader, startIndex))
+    testing.expectf(t, size_of(ConstraintBatchHeader{}.startIndex) == 4, "Wrong size for ConstraintBatchHeader.startIndex, expected 4 got %v", size_of(ConstraintBatchHeader{}.startIndex))
     testing.expectf(t, offset_of(ConstraintBatchHeader, stride) == 4, "Wrong offset for ConstraintBatchHeader.stride, expected 4 got %v", offset_of(ConstraintBatchHeader, stride))
+    testing.expectf(t, size_of(ConstraintBatchHeader{}.stride) == 2, "Wrong size for ConstraintBatchHeader.stride, expected 2 got %v", size_of(ConstraintBatchHeader{}.stride))
     testing.expectf(t, offset_of(ConstraintBatchHeader, constraintType) == 6, "Wrong offset for ConstraintBatchHeader.constraintType, expected 6 got %v", offset_of(ConstraintBatchHeader, constraintType))
+    testing.expectf(t, size_of(ConstraintBatchHeader{}.constraintType) == 2, "Wrong size for ConstraintBatchHeader.constraintType, expected 2 got %v", size_of(ConstraintBatchHeader{}.constraintType))
     testing.expectf(t, size_of(ConstraintBatchHeader) == 8, "Wrong size for type ConstraintBatchHeader, expected 8 got %v", size_of(ConstraintBatchHeader))
 }
 
 @(test)
 test_layout_SolverConstraintDesc :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(SolverConstraintDesc, bodyA) == 0, "Wrong offset for SolverConstraintDesc.bodyA, expected 0 got %v", offset_of(SolverConstraintDesc, bodyA))
+    testing.expectf(t, size_of(SolverConstraintDesc{}.bodyA) == 8, "Wrong size for SolverConstraintDesc.bodyA, expected 8 got %v", size_of(SolverConstraintDesc{}.bodyA))
     testing.expectf(t, offset_of(SolverConstraintDesc, bodyB) == 8, "Wrong offset for SolverConstraintDesc.bodyB, expected 8 got %v", offset_of(SolverConstraintDesc, bodyB))
+    testing.expectf(t, size_of(SolverConstraintDesc{}.bodyB) == 8, "Wrong size for SolverConstraintDesc.bodyB, expected 8 got %v", size_of(SolverConstraintDesc{}.bodyB))
     testing.expectf(t, offset_of(SolverConstraintDesc, bodyADataIndex) == 16, "Wrong offset for SolverConstraintDesc.bodyADataIndex, expected 16 got %v", offset_of(SolverConstraintDesc, bodyADataIndex))
+    testing.expectf(t, size_of(SolverConstraintDesc{}.bodyADataIndex) == 4, "Wrong size for SolverConstraintDesc.bodyADataIndex, expected 4 got %v", size_of(SolverConstraintDesc{}.bodyADataIndex))
     testing.expectf(t, offset_of(SolverConstraintDesc, bodyBDataIndex) == 20, "Wrong offset for SolverConstraintDesc.bodyBDataIndex, expected 20 got %v", offset_of(SolverConstraintDesc, bodyBDataIndex))
+    testing.expectf(t, size_of(SolverConstraintDesc{}.bodyBDataIndex) == 4, "Wrong size for SolverConstraintDesc.bodyBDataIndex, expected 4 got %v", size_of(SolverConstraintDesc{}.bodyBDataIndex))
     testing.expectf(t, offset_of(SolverConstraintDesc, linkIndexA) == 24, "Wrong offset for SolverConstraintDesc.linkIndexA, expected 24 got %v", offset_of(SolverConstraintDesc, linkIndexA))
+    testing.expectf(t, size_of(SolverConstraintDesc{}.linkIndexA) == 4, "Wrong size for SolverConstraintDesc.linkIndexA, expected 4 got %v", size_of(SolverConstraintDesc{}.linkIndexA))
     testing.expectf(t, offset_of(SolverConstraintDesc, linkIndexB) == 28, "Wrong offset for SolverConstraintDesc.linkIndexB, expected 28 got %v", offset_of(SolverConstraintDesc, linkIndexB))
+    testing.expectf(t, size_of(SolverConstraintDesc{}.linkIndexB) == 4, "Wrong size for SolverConstraintDesc.linkIndexB, expected 4 got %v", size_of(SolverConstraintDesc{}.linkIndexB))
     testing.expectf(t, offset_of(SolverConstraintDesc, constraint) == 32, "Wrong offset for SolverConstraintDesc.constraint, expected 32 got %v", offset_of(SolverConstraintDesc, constraint))
+    testing.expectf(t, size_of(SolverConstraintDesc{}.constraint) == 8, "Wrong size for SolverConstraintDesc.constraint, expected 8 got %v", size_of(SolverConstraintDesc{}.constraint))
     testing.expectf(t, offset_of(SolverConstraintDesc, writeBack) == 40, "Wrong offset for SolverConstraintDesc.writeBack, expected 40 got %v", offset_of(SolverConstraintDesc, writeBack))
+    testing.expectf(t, size_of(SolverConstraintDesc{}.writeBack) == 8, "Wrong size for SolverConstraintDesc.writeBack, expected 8 got %v", size_of(SolverConstraintDesc{}.writeBack))
     testing.expectf(t, offset_of(SolverConstraintDesc, progressA) == 48, "Wrong offset for SolverConstraintDesc.progressA, expected 48 got %v", offset_of(SolverConstraintDesc, progressA))
+    testing.expectf(t, size_of(SolverConstraintDesc{}.progressA) == 2, "Wrong size for SolverConstraintDesc.progressA, expected 2 got %v", size_of(SolverConstraintDesc{}.progressA))
     testing.expectf(t, offset_of(SolverConstraintDesc, progressB) == 50, "Wrong offset for SolverConstraintDesc.progressB, expected 50 got %v", offset_of(SolverConstraintDesc, progressB))
+    testing.expectf(t, size_of(SolverConstraintDesc{}.progressB) == 2, "Wrong size for SolverConstraintDesc.progressB, expected 2 got %v", size_of(SolverConstraintDesc{}.progressB))
     testing.expectf(t, offset_of(SolverConstraintDesc, constraintLengthOver16) == 52, "Wrong offset for SolverConstraintDesc.constraintLengthOver16, expected 52 got %v", offset_of(SolverConstraintDesc, constraintLengthOver16))
+    testing.expectf(t, size_of(SolverConstraintDesc{}.constraintLengthOver16) == 2, "Wrong size for SolverConstraintDesc.constraintLengthOver16, expected 2 got %v", size_of(SolverConstraintDesc{}.constraintLengthOver16))
     testing.expectf(t, size_of(SolverConstraintDesc) == 64, "Wrong size for type SolverConstraintDesc, expected 64 got %v", size_of(SolverConstraintDesc))
 }
 
 @(test)
 test_layout_SolverConstraintPrepDescBase :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(SolverConstraintPrepDescBase, invMassScales) == 0, "Wrong offset for SolverConstraintPrepDescBase.invMassScales, expected 0 got %v", offset_of(SolverConstraintPrepDescBase, invMassScales))
+    testing.expectf(t, size_of(SolverConstraintPrepDescBase{}.invMassScales) == 16, "Wrong size for SolverConstraintPrepDescBase.invMassScales, expected 16 got %v", size_of(SolverConstraintPrepDescBase{}.invMassScales))
     testing.expectf(t, offset_of(SolverConstraintPrepDescBase, desc) == 16, "Wrong offset for SolverConstraintPrepDescBase.desc, expected 16 got %v", offset_of(SolverConstraintPrepDescBase, desc))
+    testing.expectf(t, size_of(SolverConstraintPrepDescBase{}.desc) == 8, "Wrong size for SolverConstraintPrepDescBase.desc, expected 8 got %v", size_of(SolverConstraintPrepDescBase{}.desc))
     testing.expectf(t, offset_of(SolverConstraintPrepDescBase, body0) == 24, "Wrong offset for SolverConstraintPrepDescBase.body0, expected 24 got %v", offset_of(SolverConstraintPrepDescBase, body0))
+    testing.expectf(t, size_of(SolverConstraintPrepDescBase{}.body0) == 8, "Wrong size for SolverConstraintPrepDescBase.body0, expected 8 got %v", size_of(SolverConstraintPrepDescBase{}.body0))
     testing.expectf(t, offset_of(SolverConstraintPrepDescBase, body1) == 32, "Wrong offset for SolverConstraintPrepDescBase.body1, expected 32 got %v", offset_of(SolverConstraintPrepDescBase, body1))
+    testing.expectf(t, size_of(SolverConstraintPrepDescBase{}.body1) == 8, "Wrong size for SolverConstraintPrepDescBase.body1, expected 8 got %v", size_of(SolverConstraintPrepDescBase{}.body1))
     testing.expectf(t, offset_of(SolverConstraintPrepDescBase, data0) == 40, "Wrong offset for SolverConstraintPrepDescBase.data0, expected 40 got %v", offset_of(SolverConstraintPrepDescBase, data0))
+    testing.expectf(t, size_of(SolverConstraintPrepDescBase{}.data0) == 8, "Wrong size for SolverConstraintPrepDescBase.data0, expected 8 got %v", size_of(SolverConstraintPrepDescBase{}.data0))
     testing.expectf(t, offset_of(SolverConstraintPrepDescBase, data1) == 48, "Wrong offset for SolverConstraintPrepDescBase.data1, expected 48 got %v", offset_of(SolverConstraintPrepDescBase, data1))
+    testing.expectf(t, size_of(SolverConstraintPrepDescBase{}.data1) == 8, "Wrong size for SolverConstraintPrepDescBase.data1, expected 8 got %v", size_of(SolverConstraintPrepDescBase{}.data1))
     testing.expectf(t, offset_of(SolverConstraintPrepDescBase, bodyFrame0) == 56, "Wrong offset for SolverConstraintPrepDescBase.bodyFrame0, expected 56 got %v", offset_of(SolverConstraintPrepDescBase, bodyFrame0))
+    testing.expectf(t, size_of(SolverConstraintPrepDescBase{}.bodyFrame0) == 28, "Wrong size for SolverConstraintPrepDescBase.bodyFrame0, expected 28 got %v", size_of(SolverConstraintPrepDescBase{}.bodyFrame0))
     testing.expectf(t, offset_of(SolverConstraintPrepDescBase, bodyFrame1) == 84, "Wrong offset for SolverConstraintPrepDescBase.bodyFrame1, expected 84 got %v", offset_of(SolverConstraintPrepDescBase, bodyFrame1))
+    testing.expectf(t, size_of(SolverConstraintPrepDescBase{}.bodyFrame1) == 28, "Wrong size for SolverConstraintPrepDescBase.bodyFrame1, expected 28 got %v", size_of(SolverConstraintPrepDescBase{}.bodyFrame1))
     testing.expectf(t, offset_of(SolverConstraintPrepDescBase, bodyState0) == 112, "Wrong offset for SolverConstraintPrepDescBase.bodyState0, expected 112 got %v", offset_of(SolverConstraintPrepDescBase, bodyState0))
+    testing.expectf(t, size_of(SolverConstraintPrepDescBase{}.bodyState0) == 4, "Wrong size for SolverConstraintPrepDescBase.bodyState0, expected 4 got %v", size_of(SolverConstraintPrepDescBase{}.bodyState0))
     testing.expectf(t, offset_of(SolverConstraintPrepDescBase, bodyState1) == 116, "Wrong offset for SolverConstraintPrepDescBase.bodyState1, expected 116 got %v", offset_of(SolverConstraintPrepDescBase, bodyState1))
+    testing.expectf(t, size_of(SolverConstraintPrepDescBase{}.bodyState1) == 4, "Wrong size for SolverConstraintPrepDescBase.bodyState1, expected 4 got %v", size_of(SolverConstraintPrepDescBase{}.bodyState1))
     testing.expectf(t, size_of(SolverConstraintPrepDescBase) == 128, "Wrong size for type SolverConstraintPrepDescBase, expected 128 got %v", size_of(SolverConstraintPrepDescBase))
 }
 
@@ -847,49 +1064,89 @@ test_layout_SolverConstraintPrepDescBase :: proc(t: ^testing.T) {
 test_layout_SolverConstraintPrepDesc :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(SolverConstraintPrepDesc, rows) == 128, "Wrong offset for SolverConstraintPrepDesc.rows, expected 128 got %v", offset_of(SolverConstraintPrepDesc, rows))
+    testing.expectf(t, size_of(SolverConstraintPrepDesc{}.rows) == 8, "Wrong size for SolverConstraintPrepDesc.rows, expected 8 got %v", size_of(SolverConstraintPrepDesc{}.rows))
     testing.expectf(t, offset_of(SolverConstraintPrepDesc, numRows) == 136, "Wrong offset for SolverConstraintPrepDesc.numRows, expected 136 got %v", offset_of(SolverConstraintPrepDesc, numRows))
+    testing.expectf(t, size_of(SolverConstraintPrepDesc{}.numRows) == 4, "Wrong size for SolverConstraintPrepDesc.numRows, expected 4 got %v", size_of(SolverConstraintPrepDesc{}.numRows))
     testing.expectf(t, offset_of(SolverConstraintPrepDesc, linBreakForce) == 140, "Wrong offset for SolverConstraintPrepDesc.linBreakForce, expected 140 got %v", offset_of(SolverConstraintPrepDesc, linBreakForce))
+    testing.expectf(t, size_of(SolverConstraintPrepDesc{}.linBreakForce) == 4, "Wrong size for SolverConstraintPrepDesc.linBreakForce, expected 4 got %v", size_of(SolverConstraintPrepDesc{}.linBreakForce))
     testing.expectf(t, offset_of(SolverConstraintPrepDesc, angBreakForce) == 144, "Wrong offset for SolverConstraintPrepDesc.angBreakForce, expected 144 got %v", offset_of(SolverConstraintPrepDesc, angBreakForce))
+    testing.expectf(t, size_of(SolverConstraintPrepDesc{}.angBreakForce) == 4, "Wrong size for SolverConstraintPrepDesc.angBreakForce, expected 4 got %v", size_of(SolverConstraintPrepDesc{}.angBreakForce))
     testing.expectf(t, offset_of(SolverConstraintPrepDesc, minResponseThreshold) == 148, "Wrong offset for SolverConstraintPrepDesc.minResponseThreshold, expected 148 got %v", offset_of(SolverConstraintPrepDesc, minResponseThreshold))
+    testing.expectf(t, size_of(SolverConstraintPrepDesc{}.minResponseThreshold) == 4, "Wrong size for SolverConstraintPrepDesc.minResponseThreshold, expected 4 got %v", size_of(SolverConstraintPrepDesc{}.minResponseThreshold))
     testing.expectf(t, offset_of(SolverConstraintPrepDesc, writeback) == 152, "Wrong offset for SolverConstraintPrepDesc.writeback, expected 152 got %v", offset_of(SolverConstraintPrepDesc, writeback))
+    testing.expectf(t, size_of(SolverConstraintPrepDesc{}.writeback) == 8, "Wrong size for SolverConstraintPrepDesc.writeback, expected 8 got %v", size_of(SolverConstraintPrepDesc{}.writeback))
     testing.expectf(t, offset_of(SolverConstraintPrepDesc, disablePreprocessing) == 160, "Wrong offset for SolverConstraintPrepDesc.disablePreprocessing, expected 160 got %v", offset_of(SolverConstraintPrepDesc, disablePreprocessing))
+    testing.expectf(t, size_of(SolverConstraintPrepDesc{}.disablePreprocessing) == 1, "Wrong size for SolverConstraintPrepDesc.disablePreprocessing, expected 1 got %v", size_of(SolverConstraintPrepDesc{}.disablePreprocessing))
     testing.expectf(t, offset_of(SolverConstraintPrepDesc, improvedSlerp) == 161, "Wrong offset for SolverConstraintPrepDesc.improvedSlerp, expected 161 got %v", offset_of(SolverConstraintPrepDesc, improvedSlerp))
+    testing.expectf(t, size_of(SolverConstraintPrepDesc{}.improvedSlerp) == 1, "Wrong size for SolverConstraintPrepDesc.improvedSlerp, expected 1 got %v", size_of(SolverConstraintPrepDesc{}.improvedSlerp))
     testing.expectf(t, offset_of(SolverConstraintPrepDesc, driveLimitsAreForces) == 162, "Wrong offset for SolverConstraintPrepDesc.driveLimitsAreForces, expected 162 got %v", offset_of(SolverConstraintPrepDesc, driveLimitsAreForces))
+    testing.expectf(t, size_of(SolverConstraintPrepDesc{}.driveLimitsAreForces) == 1, "Wrong size for SolverConstraintPrepDesc.driveLimitsAreForces, expected 1 got %v", size_of(SolverConstraintPrepDesc{}.driveLimitsAreForces))
     testing.expectf(t, offset_of(SolverConstraintPrepDesc, extendedLimits) == 163, "Wrong offset for SolverConstraintPrepDesc.extendedLimits, expected 163 got %v", offset_of(SolverConstraintPrepDesc, extendedLimits))
+    testing.expectf(t, size_of(SolverConstraintPrepDesc{}.extendedLimits) == 1, "Wrong size for SolverConstraintPrepDesc.extendedLimits, expected 1 got %v", size_of(SolverConstraintPrepDesc{}.extendedLimits))
     testing.expectf(t, offset_of(SolverConstraintPrepDesc, disableConstraint) == 164, "Wrong offset for SolverConstraintPrepDesc.disableConstraint, expected 164 got %v", offset_of(SolverConstraintPrepDesc, disableConstraint))
+    testing.expectf(t, size_of(SolverConstraintPrepDesc{}.disableConstraint) == 1, "Wrong size for SolverConstraintPrepDesc.disableConstraint, expected 1 got %v", size_of(SolverConstraintPrepDesc{}.disableConstraint))
     testing.expectf(t, offset_of(SolverConstraintPrepDesc, body0WorldOffset) == 168, "Wrong offset for SolverConstraintPrepDesc.body0WorldOffset, expected 168 got %v", offset_of(SolverConstraintPrepDesc, body0WorldOffset))
+    testing.expectf(t, size_of(SolverConstraintPrepDesc{}.body0WorldOffset) == 16, "Wrong size for SolverConstraintPrepDesc.body0WorldOffset, expected 16 got %v", size_of(SolverConstraintPrepDesc{}.body0WorldOffset))
     testing.expectf(t, size_of(SolverConstraintPrepDesc) == 192, "Wrong size for type SolverConstraintPrepDesc, expected 192 got %v", size_of(SolverConstraintPrepDesc))
 }
 
 @(test)
 test_layout_SolverContactDesc :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(SolverContactDesc, invMassScales) == 0, "Wrong offset for SolverContactDesc.invMassScales, expected 0 got %v", offset_of(SolverContactDesc, invMassScales))
+    testing.expectf(t, size_of(SolverContactDesc{}.invMassScales) == 16, "Wrong size for SolverContactDesc.invMassScales, expected 16 got %v", size_of(SolverContactDesc{}.invMassScales))
     testing.expectf(t, offset_of(SolverContactDesc, desc) == 16, "Wrong offset for SolverContactDesc.desc, expected 16 got %v", offset_of(SolverContactDesc, desc))
+    testing.expectf(t, size_of(SolverContactDesc{}.desc) == 8, "Wrong size for SolverContactDesc.desc, expected 8 got %v", size_of(SolverContactDesc{}.desc))
     testing.expectf(t, offset_of(SolverContactDesc, body0) == 24, "Wrong offset for SolverContactDesc.body0, expected 24 got %v", offset_of(SolverContactDesc, body0))
+    testing.expectf(t, size_of(SolverContactDesc{}.body0) == 8, "Wrong size for SolverContactDesc.body0, expected 8 got %v", size_of(SolverContactDesc{}.body0))
     testing.expectf(t, offset_of(SolverContactDesc, body1) == 32, "Wrong offset for SolverContactDesc.body1, expected 32 got %v", offset_of(SolverContactDesc, body1))
+    testing.expectf(t, size_of(SolverContactDesc{}.body1) == 8, "Wrong size for SolverContactDesc.body1, expected 8 got %v", size_of(SolverContactDesc{}.body1))
     testing.expectf(t, offset_of(SolverContactDesc, data0) == 40, "Wrong offset for SolverContactDesc.data0, expected 40 got %v", offset_of(SolverContactDesc, data0))
+    testing.expectf(t, size_of(SolverContactDesc{}.data0) == 8, "Wrong size for SolverContactDesc.data0, expected 8 got %v", size_of(SolverContactDesc{}.data0))
     testing.expectf(t, offset_of(SolverContactDesc, data1) == 48, "Wrong offset for SolverContactDesc.data1, expected 48 got %v", offset_of(SolverContactDesc, data1))
+    testing.expectf(t, size_of(SolverContactDesc{}.data1) == 8, "Wrong size for SolverContactDesc.data1, expected 8 got %v", size_of(SolverContactDesc{}.data1))
     testing.expectf(t, offset_of(SolverContactDesc, bodyFrame0) == 56, "Wrong offset for SolverContactDesc.bodyFrame0, expected 56 got %v", offset_of(SolverContactDesc, bodyFrame0))
+    testing.expectf(t, size_of(SolverContactDesc{}.bodyFrame0) == 28, "Wrong size for SolverContactDesc.bodyFrame0, expected 28 got %v", size_of(SolverContactDesc{}.bodyFrame0))
     testing.expectf(t, offset_of(SolverContactDesc, bodyFrame1) == 84, "Wrong offset for SolverContactDesc.bodyFrame1, expected 84 got %v", offset_of(SolverContactDesc, bodyFrame1))
+    testing.expectf(t, size_of(SolverContactDesc{}.bodyFrame1) == 28, "Wrong size for SolverContactDesc.bodyFrame1, expected 28 got %v", size_of(SolverContactDesc{}.bodyFrame1))
     testing.expectf(t, offset_of(SolverContactDesc, bodyState0) == 112, "Wrong offset for SolverContactDesc.bodyState0, expected 112 got %v", offset_of(SolverContactDesc, bodyState0))
+    testing.expectf(t, size_of(SolverContactDesc{}.bodyState0) == 4, "Wrong size for SolverContactDesc.bodyState0, expected 4 got %v", size_of(SolverContactDesc{}.bodyState0))
     testing.expectf(t, offset_of(SolverContactDesc, bodyState1) == 116, "Wrong offset for SolverContactDesc.bodyState1, expected 116 got %v", offset_of(SolverContactDesc, bodyState1))
+    testing.expectf(t, size_of(SolverContactDesc{}.bodyState1) == 4, "Wrong size for SolverContactDesc.bodyState1, expected 4 got %v", size_of(SolverContactDesc{}.bodyState1))
     testing.expectf(t, offset_of(SolverContactDesc, shapeInteraction) == 128, "Wrong offset for SolverContactDesc.shapeInteraction, expected 128 got %v", offset_of(SolverContactDesc, shapeInteraction))
+    testing.expectf(t, size_of(SolverContactDesc{}.shapeInteraction) == 8, "Wrong size for SolverContactDesc.shapeInteraction, expected 8 got %v", size_of(SolverContactDesc{}.shapeInteraction))
     testing.expectf(t, offset_of(SolverContactDesc, contacts) == 136, "Wrong offset for SolverContactDesc.contacts, expected 136 got %v", offset_of(SolverContactDesc, contacts))
+    testing.expectf(t, size_of(SolverContactDesc{}.contacts) == 8, "Wrong size for SolverContactDesc.contacts, expected 8 got %v", size_of(SolverContactDesc{}.contacts))
     testing.expectf(t, offset_of(SolverContactDesc, numContacts) == 144, "Wrong offset for SolverContactDesc.numContacts, expected 144 got %v", offset_of(SolverContactDesc, numContacts))
+    testing.expectf(t, size_of(SolverContactDesc{}.numContacts) == 4, "Wrong size for SolverContactDesc.numContacts, expected 4 got %v", size_of(SolverContactDesc{}.numContacts))
     testing.expectf(t, offset_of(SolverContactDesc, hasMaxImpulse) == 148, "Wrong offset for SolverContactDesc.hasMaxImpulse, expected 148 got %v", offset_of(SolverContactDesc, hasMaxImpulse))
+    testing.expectf(t, size_of(SolverContactDesc{}.hasMaxImpulse) == 1, "Wrong size for SolverContactDesc.hasMaxImpulse, expected 1 got %v", size_of(SolverContactDesc{}.hasMaxImpulse))
     testing.expectf(t, offset_of(SolverContactDesc, disableStrongFriction) == 149, "Wrong offset for SolverContactDesc.disableStrongFriction, expected 149 got %v", offset_of(SolverContactDesc, disableStrongFriction))
+    testing.expectf(t, size_of(SolverContactDesc{}.disableStrongFriction) == 1, "Wrong size for SolverContactDesc.disableStrongFriction, expected 1 got %v", size_of(SolverContactDesc{}.disableStrongFriction))
     testing.expectf(t, offset_of(SolverContactDesc, hasForceThresholds) == 150, "Wrong offset for SolverContactDesc.hasForceThresholds, expected 150 got %v", offset_of(SolverContactDesc, hasForceThresholds))
+    testing.expectf(t, size_of(SolverContactDesc{}.hasForceThresholds) == 1, "Wrong size for SolverContactDesc.hasForceThresholds, expected 1 got %v", size_of(SolverContactDesc{}.hasForceThresholds))
     testing.expectf(t, offset_of(SolverContactDesc, restDistance) == 152, "Wrong offset for SolverContactDesc.restDistance, expected 152 got %v", offset_of(SolverContactDesc, restDistance))
+    testing.expectf(t, size_of(SolverContactDesc{}.restDistance) == 4, "Wrong size for SolverContactDesc.restDistance, expected 4 got %v", size_of(SolverContactDesc{}.restDistance))
     testing.expectf(t, offset_of(SolverContactDesc, maxCCDSeparation) == 156, "Wrong offset for SolverContactDesc.maxCCDSeparation, expected 156 got %v", offset_of(SolverContactDesc, maxCCDSeparation))
+    testing.expectf(t, size_of(SolverContactDesc{}.maxCCDSeparation) == 4, "Wrong size for SolverContactDesc.maxCCDSeparation, expected 4 got %v", size_of(SolverContactDesc{}.maxCCDSeparation))
     testing.expectf(t, offset_of(SolverContactDesc, frictionPtr) == 160, "Wrong offset for SolverContactDesc.frictionPtr, expected 160 got %v", offset_of(SolverContactDesc, frictionPtr))
+    testing.expectf(t, size_of(SolverContactDesc{}.frictionPtr) == 8, "Wrong size for SolverContactDesc.frictionPtr, expected 8 got %v", size_of(SolverContactDesc{}.frictionPtr))
     testing.expectf(t, offset_of(SolverContactDesc, frictionCount) == 168, "Wrong offset for SolverContactDesc.frictionCount, expected 168 got %v", offset_of(SolverContactDesc, frictionCount))
+    testing.expectf(t, size_of(SolverContactDesc{}.frictionCount) == 1, "Wrong size for SolverContactDesc.frictionCount, expected 1 got %v", size_of(SolverContactDesc{}.frictionCount))
     testing.expectf(t, offset_of(SolverContactDesc, contactForces) == 176, "Wrong offset for SolverContactDesc.contactForces, expected 176 got %v", offset_of(SolverContactDesc, contactForces))
+    testing.expectf(t, size_of(SolverContactDesc{}.contactForces) == 8, "Wrong size for SolverContactDesc.contactForces, expected 8 got %v", size_of(SolverContactDesc{}.contactForces))
     testing.expectf(t, offset_of(SolverContactDesc, startFrictionPatchIndex) == 184, "Wrong offset for SolverContactDesc.startFrictionPatchIndex, expected 184 got %v", offset_of(SolverContactDesc, startFrictionPatchIndex))
+    testing.expectf(t, size_of(SolverContactDesc{}.startFrictionPatchIndex) == 4, "Wrong size for SolverContactDesc.startFrictionPatchIndex, expected 4 got %v", size_of(SolverContactDesc{}.startFrictionPatchIndex))
     testing.expectf(t, offset_of(SolverContactDesc, numFrictionPatches) == 188, "Wrong offset for SolverContactDesc.numFrictionPatches, expected 188 got %v", offset_of(SolverContactDesc, numFrictionPatches))
+    testing.expectf(t, size_of(SolverContactDesc{}.numFrictionPatches) == 4, "Wrong size for SolverContactDesc.numFrictionPatches, expected 4 got %v", size_of(SolverContactDesc{}.numFrictionPatches))
     testing.expectf(t, offset_of(SolverContactDesc, startContactPatchIndex) == 192, "Wrong offset for SolverContactDesc.startContactPatchIndex, expected 192 got %v", offset_of(SolverContactDesc, startContactPatchIndex))
+    testing.expectf(t, size_of(SolverContactDesc{}.startContactPatchIndex) == 4, "Wrong size for SolverContactDesc.startContactPatchIndex, expected 4 got %v", size_of(SolverContactDesc{}.startContactPatchIndex))
     testing.expectf(t, offset_of(SolverContactDesc, numContactPatches) == 196, "Wrong offset for SolverContactDesc.numContactPatches, expected 196 got %v", offset_of(SolverContactDesc, numContactPatches))
+    testing.expectf(t, size_of(SolverContactDesc{}.numContactPatches) == 2, "Wrong size for SolverContactDesc.numContactPatches, expected 2 got %v", size_of(SolverContactDesc{}.numContactPatches))
     testing.expectf(t, offset_of(SolverContactDesc, axisConstraintCount) == 198, "Wrong offset for SolverContactDesc.axisConstraintCount, expected 198 got %v", offset_of(SolverContactDesc, axisConstraintCount))
+    testing.expectf(t, size_of(SolverContactDesc{}.axisConstraintCount) == 2, "Wrong size for SolverContactDesc.axisConstraintCount, expected 2 got %v", size_of(SolverContactDesc{}.axisConstraintCount))
     testing.expectf(t, offset_of(SolverContactDesc, offsetSlop) == 200, "Wrong offset for SolverContactDesc.offsetSlop, expected 200 got %v", offset_of(SolverContactDesc, offsetSlop))
+    testing.expectf(t, size_of(SolverContactDesc{}.offsetSlop) == 4, "Wrong size for SolverContactDesc.offsetSlop, expected 4 got %v", size_of(SolverContactDesc{}.offsetSlop))
     testing.expectf(t, size_of(SolverContactDesc) == 208, "Wrong size for type SolverContactDesc, expected 208 got %v", size_of(SolverContactDesc))
 }
 
@@ -902,144 +1159,252 @@ test_layout_ConstraintAllocator :: proc(t: ^testing.T) {
 @(test)
 test_layout_ArticulationLimit :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(ArticulationLimit, low) == 0, "Wrong offset for ArticulationLimit.low, expected 0 got %v", offset_of(ArticulationLimit, low))
+    testing.expectf(t, size_of(ArticulationLimit{}.low) == 4, "Wrong size for ArticulationLimit.low, expected 4 got %v", size_of(ArticulationLimit{}.low))
     testing.expectf(t, offset_of(ArticulationLimit, high) == 4, "Wrong offset for ArticulationLimit.high, expected 4 got %v", offset_of(ArticulationLimit, high))
+    testing.expectf(t, size_of(ArticulationLimit{}.high) == 4, "Wrong size for ArticulationLimit.high, expected 4 got %v", size_of(ArticulationLimit{}.high))
     testing.expectf(t, size_of(ArticulationLimit) == 8, "Wrong size for type ArticulationLimit, expected 8 got %v", size_of(ArticulationLimit))
 }
 
 @(test)
 test_layout_ArticulationDrive :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(ArticulationDrive, stiffness) == 0, "Wrong offset for ArticulationDrive.stiffness, expected 0 got %v", offset_of(ArticulationDrive, stiffness))
+    testing.expectf(t, size_of(ArticulationDrive{}.stiffness) == 4, "Wrong size for ArticulationDrive.stiffness, expected 4 got %v", size_of(ArticulationDrive{}.stiffness))
     testing.expectf(t, offset_of(ArticulationDrive, damping) == 4, "Wrong offset for ArticulationDrive.damping, expected 4 got %v", offset_of(ArticulationDrive, damping))
+    testing.expectf(t, size_of(ArticulationDrive{}.damping) == 4, "Wrong size for ArticulationDrive.damping, expected 4 got %v", size_of(ArticulationDrive{}.damping))
     testing.expectf(t, offset_of(ArticulationDrive, maxForce) == 8, "Wrong offset for ArticulationDrive.maxForce, expected 8 got %v", offset_of(ArticulationDrive, maxForce))
+    testing.expectf(t, size_of(ArticulationDrive{}.maxForce) == 4, "Wrong size for ArticulationDrive.maxForce, expected 4 got %v", size_of(ArticulationDrive{}.maxForce))
     testing.expectf(t, offset_of(ArticulationDrive, driveType) == 12, "Wrong offset for ArticulationDrive.driveType, expected 12 got %v", offset_of(ArticulationDrive, driveType))
+    testing.expectf(t, size_of(ArticulationDrive{}.driveType) == 4, "Wrong size for ArticulationDrive.driveType, expected 4 got %v", size_of(ArticulationDrive{}.driveType))
     testing.expectf(t, size_of(ArticulationDrive) == 16, "Wrong size for type ArticulationDrive, expected 16 got %v", size_of(ArticulationDrive))
 }
 
 @(test)
 test_layout_TGSSolverBodyVel :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(TGSSolverBodyVel, linearVelocity) == 0, "Wrong offset for TGSSolverBodyVel.linearVelocity, expected 0 got %v", offset_of(TGSSolverBodyVel, linearVelocity))
+    testing.expectf(t, size_of(TGSSolverBodyVel{}.linearVelocity) == 12, "Wrong size for TGSSolverBodyVel.linearVelocity, expected 12 got %v", size_of(TGSSolverBodyVel{}.linearVelocity))
     testing.expectf(t, offset_of(TGSSolverBodyVel, nbStaticInteractions) == 12, "Wrong offset for TGSSolverBodyVel.nbStaticInteractions, expected 12 got %v", offset_of(TGSSolverBodyVel, nbStaticInteractions))
+    testing.expectf(t, size_of(TGSSolverBodyVel{}.nbStaticInteractions) == 2, "Wrong size for TGSSolverBodyVel.nbStaticInteractions, expected 2 got %v", size_of(TGSSolverBodyVel{}.nbStaticInteractions))
     testing.expectf(t, offset_of(TGSSolverBodyVel, maxDynamicPartition) == 14, "Wrong offset for TGSSolverBodyVel.maxDynamicPartition, expected 14 got %v", offset_of(TGSSolverBodyVel, maxDynamicPartition))
+    testing.expectf(t, size_of(TGSSolverBodyVel{}.maxDynamicPartition) == 2, "Wrong size for TGSSolverBodyVel.maxDynamicPartition, expected 2 got %v", size_of(TGSSolverBodyVel{}.maxDynamicPartition))
     testing.expectf(t, offset_of(TGSSolverBodyVel, angularVelocity) == 16, "Wrong offset for TGSSolverBodyVel.angularVelocity, expected 16 got %v", offset_of(TGSSolverBodyVel, angularVelocity))
+    testing.expectf(t, size_of(TGSSolverBodyVel{}.angularVelocity) == 12, "Wrong size for TGSSolverBodyVel.angularVelocity, expected 12 got %v", size_of(TGSSolverBodyVel{}.angularVelocity))
     testing.expectf(t, offset_of(TGSSolverBodyVel, partitionMask) == 28, "Wrong offset for TGSSolverBodyVel.partitionMask, expected 28 got %v", offset_of(TGSSolverBodyVel, partitionMask))
+    testing.expectf(t, size_of(TGSSolverBodyVel{}.partitionMask) == 4, "Wrong size for TGSSolverBodyVel.partitionMask, expected 4 got %v", size_of(TGSSolverBodyVel{}.partitionMask))
     testing.expectf(t, offset_of(TGSSolverBodyVel, deltaAngDt) == 32, "Wrong offset for TGSSolverBodyVel.deltaAngDt, expected 32 got %v", offset_of(TGSSolverBodyVel, deltaAngDt))
+    testing.expectf(t, size_of(TGSSolverBodyVel{}.deltaAngDt) == 12, "Wrong size for TGSSolverBodyVel.deltaAngDt, expected 12 got %v", size_of(TGSSolverBodyVel{}.deltaAngDt))
     testing.expectf(t, offset_of(TGSSolverBodyVel, maxAngVel) == 44, "Wrong offset for TGSSolverBodyVel.maxAngVel, expected 44 got %v", offset_of(TGSSolverBodyVel, maxAngVel))
+    testing.expectf(t, size_of(TGSSolverBodyVel{}.maxAngVel) == 4, "Wrong size for TGSSolverBodyVel.maxAngVel, expected 4 got %v", size_of(TGSSolverBodyVel{}.maxAngVel))
     testing.expectf(t, offset_of(TGSSolverBodyVel, deltaLinDt) == 48, "Wrong offset for TGSSolverBodyVel.deltaLinDt, expected 48 got %v", offset_of(TGSSolverBodyVel, deltaLinDt))
+    testing.expectf(t, size_of(TGSSolverBodyVel{}.deltaLinDt) == 12, "Wrong size for TGSSolverBodyVel.deltaLinDt, expected 12 got %v", size_of(TGSSolverBodyVel{}.deltaLinDt))
     testing.expectf(t, offset_of(TGSSolverBodyVel, lockFlags) == 60, "Wrong offset for TGSSolverBodyVel.lockFlags, expected 60 got %v", offset_of(TGSSolverBodyVel, lockFlags))
+    testing.expectf(t, size_of(TGSSolverBodyVel{}.lockFlags) == 2, "Wrong size for TGSSolverBodyVel.lockFlags, expected 2 got %v", size_of(TGSSolverBodyVel{}.lockFlags))
     testing.expectf(t, offset_of(TGSSolverBodyVel, isKinematic) == 62, "Wrong offset for TGSSolverBodyVel.isKinematic, expected 62 got %v", offset_of(TGSSolverBodyVel, isKinematic))
+    testing.expectf(t, size_of(TGSSolverBodyVel{}.isKinematic) == 1, "Wrong size for TGSSolverBodyVel.isKinematic, expected 1 got %v", size_of(TGSSolverBodyVel{}.isKinematic))
     testing.expectf(t, offset_of(TGSSolverBodyVel, pad) == 63, "Wrong offset for TGSSolverBodyVel.pad, expected 63 got %v", offset_of(TGSSolverBodyVel, pad))
+    testing.expectf(t, size_of(TGSSolverBodyVel{}.pad) == 1, "Wrong size for TGSSolverBodyVel.pad, expected 1 got %v", size_of(TGSSolverBodyVel{}.pad))
     testing.expectf(t, size_of(TGSSolverBodyVel) == 64, "Wrong size for type TGSSolverBodyVel, expected 64 got %v", size_of(TGSSolverBodyVel))
 }
 
 @(test)
 test_layout_TGSSolverBodyTxInertia :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(TGSSolverBodyTxInertia, deltaBody2World) == 0, "Wrong offset for TGSSolverBodyTxInertia.deltaBody2World, expected 0 got %v", offset_of(TGSSolverBodyTxInertia, deltaBody2World))
+    testing.expectf(t, size_of(TGSSolverBodyTxInertia{}.deltaBody2World) == 28, "Wrong size for TGSSolverBodyTxInertia.deltaBody2World, expected 28 got %v", size_of(TGSSolverBodyTxInertia{}.deltaBody2World))
     testing.expectf(t, offset_of(TGSSolverBodyTxInertia, sqrtInvInertia) == 28, "Wrong offset for TGSSolverBodyTxInertia.sqrtInvInertia, expected 28 got %v", offset_of(TGSSolverBodyTxInertia, sqrtInvInertia))
+    testing.expectf(t, size_of(TGSSolverBodyTxInertia{}.sqrtInvInertia) == 36, "Wrong size for TGSSolverBodyTxInertia.sqrtInvInertia, expected 36 got %v", size_of(TGSSolverBodyTxInertia{}.sqrtInvInertia))
     testing.expectf(t, size_of(TGSSolverBodyTxInertia) == 64, "Wrong size for type TGSSolverBodyTxInertia, expected 64 got %v", size_of(TGSSolverBodyTxInertia))
 }
 
 @(test)
 test_layout_TGSSolverBodyData :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(TGSSolverBodyData, originalLinearVelocity) == 0, "Wrong offset for TGSSolverBodyData.originalLinearVelocity, expected 0 got %v", offset_of(TGSSolverBodyData, originalLinearVelocity))
+    testing.expectf(t, size_of(TGSSolverBodyData{}.originalLinearVelocity) == 12, "Wrong size for TGSSolverBodyData.originalLinearVelocity, expected 12 got %v", size_of(TGSSolverBodyData{}.originalLinearVelocity))
     testing.expectf(t, offset_of(TGSSolverBodyData, maxContactImpulse) == 12, "Wrong offset for TGSSolverBodyData.maxContactImpulse, expected 12 got %v", offset_of(TGSSolverBodyData, maxContactImpulse))
+    testing.expectf(t, size_of(TGSSolverBodyData{}.maxContactImpulse) == 4, "Wrong size for TGSSolverBodyData.maxContactImpulse, expected 4 got %v", size_of(TGSSolverBodyData{}.maxContactImpulse))
     testing.expectf(t, offset_of(TGSSolverBodyData, originalAngularVelocity) == 16, "Wrong offset for TGSSolverBodyData.originalAngularVelocity, expected 16 got %v", offset_of(TGSSolverBodyData, originalAngularVelocity))
+    testing.expectf(t, size_of(TGSSolverBodyData{}.originalAngularVelocity) == 12, "Wrong size for TGSSolverBodyData.originalAngularVelocity, expected 12 got %v", size_of(TGSSolverBodyData{}.originalAngularVelocity))
     testing.expectf(t, offset_of(TGSSolverBodyData, penBiasClamp) == 28, "Wrong offset for TGSSolverBodyData.penBiasClamp, expected 28 got %v", offset_of(TGSSolverBodyData, penBiasClamp))
+    testing.expectf(t, size_of(TGSSolverBodyData{}.penBiasClamp) == 4, "Wrong size for TGSSolverBodyData.penBiasClamp, expected 4 got %v", size_of(TGSSolverBodyData{}.penBiasClamp))
     testing.expectf(t, offset_of(TGSSolverBodyData, invMass) == 32, "Wrong offset for TGSSolverBodyData.invMass, expected 32 got %v", offset_of(TGSSolverBodyData, invMass))
+    testing.expectf(t, size_of(TGSSolverBodyData{}.invMass) == 4, "Wrong size for TGSSolverBodyData.invMass, expected 4 got %v", size_of(TGSSolverBodyData{}.invMass))
     testing.expectf(t, offset_of(TGSSolverBodyData, nodeIndex) == 36, "Wrong offset for TGSSolverBodyData.nodeIndex, expected 36 got %v", offset_of(TGSSolverBodyData, nodeIndex))
+    testing.expectf(t, size_of(TGSSolverBodyData{}.nodeIndex) == 4, "Wrong size for TGSSolverBodyData.nodeIndex, expected 4 got %v", size_of(TGSSolverBodyData{}.nodeIndex))
     testing.expectf(t, offset_of(TGSSolverBodyData, reportThreshold) == 40, "Wrong offset for TGSSolverBodyData.reportThreshold, expected 40 got %v", offset_of(TGSSolverBodyData, reportThreshold))
+    testing.expectf(t, size_of(TGSSolverBodyData{}.reportThreshold) == 4, "Wrong size for TGSSolverBodyData.reportThreshold, expected 4 got %v", size_of(TGSSolverBodyData{}.reportThreshold))
     testing.expectf(t, offset_of(TGSSolverBodyData, pad) == 44, "Wrong offset for TGSSolverBodyData.pad, expected 44 got %v", offset_of(TGSSolverBodyData, pad))
+    testing.expectf(t, size_of(TGSSolverBodyData{}.pad) == 4, "Wrong size for TGSSolverBodyData.pad, expected 4 got %v", size_of(TGSSolverBodyData{}.pad))
     testing.expectf(t, size_of(TGSSolverBodyData) == 48, "Wrong size for type TGSSolverBodyData, expected 48 got %v", size_of(TGSSolverBodyData))
 }
 
 @(test)
 test_layout_TGSSolverConstraintPrepDescBase :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(TGSSolverConstraintPrepDescBase, invMassScales) == 0, "Wrong offset for TGSSolverConstraintPrepDescBase.invMassScales, expected 0 got %v", offset_of(TGSSolverConstraintPrepDescBase, invMassScales))
+    testing.expectf(t, size_of(TGSSolverConstraintPrepDescBase{}.invMassScales) == 16, "Wrong size for TGSSolverConstraintPrepDescBase.invMassScales, expected 16 got %v", size_of(TGSSolverConstraintPrepDescBase{}.invMassScales))
     testing.expectf(t, offset_of(TGSSolverConstraintPrepDescBase, desc) == 16, "Wrong offset for TGSSolverConstraintPrepDescBase.desc, expected 16 got %v", offset_of(TGSSolverConstraintPrepDescBase, desc))
+    testing.expectf(t, size_of(TGSSolverConstraintPrepDescBase{}.desc) == 8, "Wrong size for TGSSolverConstraintPrepDescBase.desc, expected 8 got %v", size_of(TGSSolverConstraintPrepDescBase{}.desc))
     testing.expectf(t, offset_of(TGSSolverConstraintPrepDescBase, body0) == 24, "Wrong offset for TGSSolverConstraintPrepDescBase.body0, expected 24 got %v", offset_of(TGSSolverConstraintPrepDescBase, body0))
+    testing.expectf(t, size_of(TGSSolverConstraintPrepDescBase{}.body0) == 8, "Wrong size for TGSSolverConstraintPrepDescBase.body0, expected 8 got %v", size_of(TGSSolverConstraintPrepDescBase{}.body0))
     testing.expectf(t, offset_of(TGSSolverConstraintPrepDescBase, body1) == 32, "Wrong offset for TGSSolverConstraintPrepDescBase.body1, expected 32 got %v", offset_of(TGSSolverConstraintPrepDescBase, body1))
+    testing.expectf(t, size_of(TGSSolverConstraintPrepDescBase{}.body1) == 8, "Wrong size for TGSSolverConstraintPrepDescBase.body1, expected 8 got %v", size_of(TGSSolverConstraintPrepDescBase{}.body1))
     testing.expectf(t, offset_of(TGSSolverConstraintPrepDescBase, body0TxI) == 40, "Wrong offset for TGSSolverConstraintPrepDescBase.body0TxI, expected 40 got %v", offset_of(TGSSolverConstraintPrepDescBase, body0TxI))
+    testing.expectf(t, size_of(TGSSolverConstraintPrepDescBase{}.body0TxI) == 8, "Wrong size for TGSSolverConstraintPrepDescBase.body0TxI, expected 8 got %v", size_of(TGSSolverConstraintPrepDescBase{}.body0TxI))
     testing.expectf(t, offset_of(TGSSolverConstraintPrepDescBase, body1TxI) == 48, "Wrong offset for TGSSolverConstraintPrepDescBase.body1TxI, expected 48 got %v", offset_of(TGSSolverConstraintPrepDescBase, body1TxI))
+    testing.expectf(t, size_of(TGSSolverConstraintPrepDescBase{}.body1TxI) == 8, "Wrong size for TGSSolverConstraintPrepDescBase.body1TxI, expected 8 got %v", size_of(TGSSolverConstraintPrepDescBase{}.body1TxI))
     testing.expectf(t, offset_of(TGSSolverConstraintPrepDescBase, bodyData0) == 56, "Wrong offset for TGSSolverConstraintPrepDescBase.bodyData0, expected 56 got %v", offset_of(TGSSolverConstraintPrepDescBase, bodyData0))
+    testing.expectf(t, size_of(TGSSolverConstraintPrepDescBase{}.bodyData0) == 8, "Wrong size for TGSSolverConstraintPrepDescBase.bodyData0, expected 8 got %v", size_of(TGSSolverConstraintPrepDescBase{}.bodyData0))
     testing.expectf(t, offset_of(TGSSolverConstraintPrepDescBase, bodyData1) == 64, "Wrong offset for TGSSolverConstraintPrepDescBase.bodyData1, expected 64 got %v", offset_of(TGSSolverConstraintPrepDescBase, bodyData1))
+    testing.expectf(t, size_of(TGSSolverConstraintPrepDescBase{}.bodyData1) == 8, "Wrong size for TGSSolverConstraintPrepDescBase.bodyData1, expected 8 got %v", size_of(TGSSolverConstraintPrepDescBase{}.bodyData1))
     testing.expectf(t, offset_of(TGSSolverConstraintPrepDescBase, bodyFrame0) == 72, "Wrong offset for TGSSolverConstraintPrepDescBase.bodyFrame0, expected 72 got %v", offset_of(TGSSolverConstraintPrepDescBase, bodyFrame0))
+    testing.expectf(t, size_of(TGSSolverConstraintPrepDescBase{}.bodyFrame0) == 28, "Wrong size for TGSSolverConstraintPrepDescBase.bodyFrame0, expected 28 got %v", size_of(TGSSolverConstraintPrepDescBase{}.bodyFrame0))
     testing.expectf(t, offset_of(TGSSolverConstraintPrepDescBase, bodyFrame1) == 100, "Wrong offset for TGSSolverConstraintPrepDescBase.bodyFrame1, expected 100 got %v", offset_of(TGSSolverConstraintPrepDescBase, bodyFrame1))
+    testing.expectf(t, size_of(TGSSolverConstraintPrepDescBase{}.bodyFrame1) == 28, "Wrong size for TGSSolverConstraintPrepDescBase.bodyFrame1, expected 28 got %v", size_of(TGSSolverConstraintPrepDescBase{}.bodyFrame1))
     testing.expectf(t, offset_of(TGSSolverConstraintPrepDescBase, bodyState0) == 128, "Wrong offset for TGSSolverConstraintPrepDescBase.bodyState0, expected 128 got %v", offset_of(TGSSolverConstraintPrepDescBase, bodyState0))
+    testing.expectf(t, size_of(TGSSolverConstraintPrepDescBase{}.bodyState0) == 4, "Wrong size for TGSSolverConstraintPrepDescBase.bodyState0, expected 4 got %v", size_of(TGSSolverConstraintPrepDescBase{}.bodyState0))
     testing.expectf(t, offset_of(TGSSolverConstraintPrepDescBase, bodyState1) == 132, "Wrong offset for TGSSolverConstraintPrepDescBase.bodyState1, expected 132 got %v", offset_of(TGSSolverConstraintPrepDescBase, bodyState1))
+    testing.expectf(t, size_of(TGSSolverConstraintPrepDescBase{}.bodyState1) == 4, "Wrong size for TGSSolverConstraintPrepDescBase.bodyState1, expected 4 got %v", size_of(TGSSolverConstraintPrepDescBase{}.bodyState1))
     testing.expectf(t, size_of(TGSSolverConstraintPrepDescBase) == 144, "Wrong size for type TGSSolverConstraintPrepDescBase, expected 144 got %v", size_of(TGSSolverConstraintPrepDescBase))
 }
 
 @(test)
 test_layout_TGSSolverConstraintPrepDesc :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(TGSSolverConstraintPrepDesc, invMassScales) == 0, "Wrong offset for TGSSolverConstraintPrepDesc.invMassScales, expected 0 got %v", offset_of(TGSSolverConstraintPrepDesc, invMassScales))
+    testing.expectf(t, size_of(TGSSolverConstraintPrepDesc{}.invMassScales) == 16, "Wrong size for TGSSolverConstraintPrepDesc.invMassScales, expected 16 got %v", size_of(TGSSolverConstraintPrepDesc{}.invMassScales))
     testing.expectf(t, offset_of(TGSSolverConstraintPrepDesc, desc) == 16, "Wrong offset for TGSSolverConstraintPrepDesc.desc, expected 16 got %v", offset_of(TGSSolverConstraintPrepDesc, desc))
+    testing.expectf(t, size_of(TGSSolverConstraintPrepDesc{}.desc) == 8, "Wrong size for TGSSolverConstraintPrepDesc.desc, expected 8 got %v", size_of(TGSSolverConstraintPrepDesc{}.desc))
     testing.expectf(t, offset_of(TGSSolverConstraintPrepDesc, body0) == 24, "Wrong offset for TGSSolverConstraintPrepDesc.body0, expected 24 got %v", offset_of(TGSSolverConstraintPrepDesc, body0))
+    testing.expectf(t, size_of(TGSSolverConstraintPrepDesc{}.body0) == 8, "Wrong size for TGSSolverConstraintPrepDesc.body0, expected 8 got %v", size_of(TGSSolverConstraintPrepDesc{}.body0))
     testing.expectf(t, offset_of(TGSSolverConstraintPrepDesc, body1) == 32, "Wrong offset for TGSSolverConstraintPrepDesc.body1, expected 32 got %v", offset_of(TGSSolverConstraintPrepDesc, body1))
+    testing.expectf(t, size_of(TGSSolverConstraintPrepDesc{}.body1) == 8, "Wrong size for TGSSolverConstraintPrepDesc.body1, expected 8 got %v", size_of(TGSSolverConstraintPrepDesc{}.body1))
     testing.expectf(t, offset_of(TGSSolverConstraintPrepDesc, body0TxI) == 40, "Wrong offset for TGSSolverConstraintPrepDesc.body0TxI, expected 40 got %v", offset_of(TGSSolverConstraintPrepDesc, body0TxI))
+    testing.expectf(t, size_of(TGSSolverConstraintPrepDesc{}.body0TxI) == 8, "Wrong size for TGSSolverConstraintPrepDesc.body0TxI, expected 8 got %v", size_of(TGSSolverConstraintPrepDesc{}.body0TxI))
     testing.expectf(t, offset_of(TGSSolverConstraintPrepDesc, body1TxI) == 48, "Wrong offset for TGSSolverConstraintPrepDesc.body1TxI, expected 48 got %v", offset_of(TGSSolverConstraintPrepDesc, body1TxI))
+    testing.expectf(t, size_of(TGSSolverConstraintPrepDesc{}.body1TxI) == 8, "Wrong size for TGSSolverConstraintPrepDesc.body1TxI, expected 8 got %v", size_of(TGSSolverConstraintPrepDesc{}.body1TxI))
     testing.expectf(t, offset_of(TGSSolverConstraintPrepDesc, bodyData0) == 56, "Wrong offset for TGSSolverConstraintPrepDesc.bodyData0, expected 56 got %v", offset_of(TGSSolverConstraintPrepDesc, bodyData0))
+    testing.expectf(t, size_of(TGSSolverConstraintPrepDesc{}.bodyData0) == 8, "Wrong size for TGSSolverConstraintPrepDesc.bodyData0, expected 8 got %v", size_of(TGSSolverConstraintPrepDesc{}.bodyData0))
     testing.expectf(t, offset_of(TGSSolverConstraintPrepDesc, bodyData1) == 64, "Wrong offset for TGSSolverConstraintPrepDesc.bodyData1, expected 64 got %v", offset_of(TGSSolverConstraintPrepDesc, bodyData1))
+    testing.expectf(t, size_of(TGSSolverConstraintPrepDesc{}.bodyData1) == 8, "Wrong size for TGSSolverConstraintPrepDesc.bodyData1, expected 8 got %v", size_of(TGSSolverConstraintPrepDesc{}.bodyData1))
     testing.expectf(t, offset_of(TGSSolverConstraintPrepDesc, bodyFrame0) == 72, "Wrong offset for TGSSolverConstraintPrepDesc.bodyFrame0, expected 72 got %v", offset_of(TGSSolverConstraintPrepDesc, bodyFrame0))
+    testing.expectf(t, size_of(TGSSolverConstraintPrepDesc{}.bodyFrame0) == 28, "Wrong size for TGSSolverConstraintPrepDesc.bodyFrame0, expected 28 got %v", size_of(TGSSolverConstraintPrepDesc{}.bodyFrame0))
     testing.expectf(t, offset_of(TGSSolverConstraintPrepDesc, bodyFrame1) == 100, "Wrong offset for TGSSolverConstraintPrepDesc.bodyFrame1, expected 100 got %v", offset_of(TGSSolverConstraintPrepDesc, bodyFrame1))
+    testing.expectf(t, size_of(TGSSolverConstraintPrepDesc{}.bodyFrame1) == 28, "Wrong size for TGSSolverConstraintPrepDesc.bodyFrame1, expected 28 got %v", size_of(TGSSolverConstraintPrepDesc{}.bodyFrame1))
     testing.expectf(t, offset_of(TGSSolverConstraintPrepDesc, bodyState0) == 128, "Wrong offset for TGSSolverConstraintPrepDesc.bodyState0, expected 128 got %v", offset_of(TGSSolverConstraintPrepDesc, bodyState0))
+    testing.expectf(t, size_of(TGSSolverConstraintPrepDesc{}.bodyState0) == 4, "Wrong size for TGSSolverConstraintPrepDesc.bodyState0, expected 4 got %v", size_of(TGSSolverConstraintPrepDesc{}.bodyState0))
     testing.expectf(t, offset_of(TGSSolverConstraintPrepDesc, bodyState1) == 132, "Wrong offset for TGSSolverConstraintPrepDesc.bodyState1, expected 132 got %v", offset_of(TGSSolverConstraintPrepDesc, bodyState1))
+    testing.expectf(t, size_of(TGSSolverConstraintPrepDesc{}.bodyState1) == 4, "Wrong size for TGSSolverConstraintPrepDesc.bodyState1, expected 4 got %v", size_of(TGSSolverConstraintPrepDesc{}.bodyState1))
     testing.expectf(t, offset_of(TGSSolverConstraintPrepDesc, rows) == 144, "Wrong offset for TGSSolverConstraintPrepDesc.rows, expected 144 got %v", offset_of(TGSSolverConstraintPrepDesc, rows))
+    testing.expectf(t, size_of(TGSSolverConstraintPrepDesc{}.rows) == 8, "Wrong size for TGSSolverConstraintPrepDesc.rows, expected 8 got %v", size_of(TGSSolverConstraintPrepDesc{}.rows))
     testing.expectf(t, offset_of(TGSSolverConstraintPrepDesc, numRows) == 152, "Wrong offset for TGSSolverConstraintPrepDesc.numRows, expected 152 got %v", offset_of(TGSSolverConstraintPrepDesc, numRows))
+    testing.expectf(t, size_of(TGSSolverConstraintPrepDesc{}.numRows) == 4, "Wrong size for TGSSolverConstraintPrepDesc.numRows, expected 4 got %v", size_of(TGSSolverConstraintPrepDesc{}.numRows))
     testing.expectf(t, offset_of(TGSSolverConstraintPrepDesc, linBreakForce) == 156, "Wrong offset for TGSSolverConstraintPrepDesc.linBreakForce, expected 156 got %v", offset_of(TGSSolverConstraintPrepDesc, linBreakForce))
+    testing.expectf(t, size_of(TGSSolverConstraintPrepDesc{}.linBreakForce) == 4, "Wrong size for TGSSolverConstraintPrepDesc.linBreakForce, expected 4 got %v", size_of(TGSSolverConstraintPrepDesc{}.linBreakForce))
     testing.expectf(t, offset_of(TGSSolverConstraintPrepDesc, angBreakForce) == 160, "Wrong offset for TGSSolverConstraintPrepDesc.angBreakForce, expected 160 got %v", offset_of(TGSSolverConstraintPrepDesc, angBreakForce))
+    testing.expectf(t, size_of(TGSSolverConstraintPrepDesc{}.angBreakForce) == 4, "Wrong size for TGSSolverConstraintPrepDesc.angBreakForce, expected 4 got %v", size_of(TGSSolverConstraintPrepDesc{}.angBreakForce))
     testing.expectf(t, offset_of(TGSSolverConstraintPrepDesc, minResponseThreshold) == 164, "Wrong offset for TGSSolverConstraintPrepDesc.minResponseThreshold, expected 164 got %v", offset_of(TGSSolverConstraintPrepDesc, minResponseThreshold))
+    testing.expectf(t, size_of(TGSSolverConstraintPrepDesc{}.minResponseThreshold) == 4, "Wrong size for TGSSolverConstraintPrepDesc.minResponseThreshold, expected 4 got %v", size_of(TGSSolverConstraintPrepDesc{}.minResponseThreshold))
     testing.expectf(t, offset_of(TGSSolverConstraintPrepDesc, writeback) == 168, "Wrong offset for TGSSolverConstraintPrepDesc.writeback, expected 168 got %v", offset_of(TGSSolverConstraintPrepDesc, writeback))
+    testing.expectf(t, size_of(TGSSolverConstraintPrepDesc{}.writeback) == 8, "Wrong size for TGSSolverConstraintPrepDesc.writeback, expected 8 got %v", size_of(TGSSolverConstraintPrepDesc{}.writeback))
     testing.expectf(t, offset_of(TGSSolverConstraintPrepDesc, disablePreprocessing) == 176, "Wrong offset for TGSSolverConstraintPrepDesc.disablePreprocessing, expected 176 got %v", offset_of(TGSSolverConstraintPrepDesc, disablePreprocessing))
+    testing.expectf(t, size_of(TGSSolverConstraintPrepDesc{}.disablePreprocessing) == 1, "Wrong size for TGSSolverConstraintPrepDesc.disablePreprocessing, expected 1 got %v", size_of(TGSSolverConstraintPrepDesc{}.disablePreprocessing))
     testing.expectf(t, offset_of(TGSSolverConstraintPrepDesc, improvedSlerp) == 177, "Wrong offset for TGSSolverConstraintPrepDesc.improvedSlerp, expected 177 got %v", offset_of(TGSSolverConstraintPrepDesc, improvedSlerp))
+    testing.expectf(t, size_of(TGSSolverConstraintPrepDesc{}.improvedSlerp) == 1, "Wrong size for TGSSolverConstraintPrepDesc.improvedSlerp, expected 1 got %v", size_of(TGSSolverConstraintPrepDesc{}.improvedSlerp))
     testing.expectf(t, offset_of(TGSSolverConstraintPrepDesc, driveLimitsAreForces) == 178, "Wrong offset for TGSSolverConstraintPrepDesc.driveLimitsAreForces, expected 178 got %v", offset_of(TGSSolverConstraintPrepDesc, driveLimitsAreForces))
+    testing.expectf(t, size_of(TGSSolverConstraintPrepDesc{}.driveLimitsAreForces) == 1, "Wrong size for TGSSolverConstraintPrepDesc.driveLimitsAreForces, expected 1 got %v", size_of(TGSSolverConstraintPrepDesc{}.driveLimitsAreForces))
     testing.expectf(t, offset_of(TGSSolverConstraintPrepDesc, extendedLimits) == 179, "Wrong offset for TGSSolverConstraintPrepDesc.extendedLimits, expected 179 got %v", offset_of(TGSSolverConstraintPrepDesc, extendedLimits))
+    testing.expectf(t, size_of(TGSSolverConstraintPrepDesc{}.extendedLimits) == 1, "Wrong size for TGSSolverConstraintPrepDesc.extendedLimits, expected 1 got %v", size_of(TGSSolverConstraintPrepDesc{}.extendedLimits))
     testing.expectf(t, offset_of(TGSSolverConstraintPrepDesc, disableConstraint) == 180, "Wrong offset for TGSSolverConstraintPrepDesc.disableConstraint, expected 180 got %v", offset_of(TGSSolverConstraintPrepDesc, disableConstraint))
+    testing.expectf(t, size_of(TGSSolverConstraintPrepDesc{}.disableConstraint) == 1, "Wrong size for TGSSolverConstraintPrepDesc.disableConstraint, expected 1 got %v", size_of(TGSSolverConstraintPrepDesc{}.disableConstraint))
     testing.expectf(t, offset_of(TGSSolverConstraintPrepDesc, body0WorldOffset) == 184, "Wrong offset for TGSSolverConstraintPrepDesc.body0WorldOffset, expected 184 got %v", offset_of(TGSSolverConstraintPrepDesc, body0WorldOffset))
+    testing.expectf(t, size_of(TGSSolverConstraintPrepDesc{}.body0WorldOffset) == 16, "Wrong size for TGSSolverConstraintPrepDesc.body0WorldOffset, expected 16 got %v", size_of(TGSSolverConstraintPrepDesc{}.body0WorldOffset))
     testing.expectf(t, offset_of(TGSSolverConstraintPrepDesc, cA2w) == 200, "Wrong offset for TGSSolverConstraintPrepDesc.cA2w, expected 200 got %v", offset_of(TGSSolverConstraintPrepDesc, cA2w))
+    testing.expectf(t, size_of(TGSSolverConstraintPrepDesc{}.cA2w) == 16, "Wrong size for TGSSolverConstraintPrepDesc.cA2w, expected 16 got %v", size_of(TGSSolverConstraintPrepDesc{}.cA2w))
     testing.expectf(t, offset_of(TGSSolverConstraintPrepDesc, cB2w) == 216, "Wrong offset for TGSSolverConstraintPrepDesc.cB2w, expected 216 got %v", offset_of(TGSSolverConstraintPrepDesc, cB2w))
+    testing.expectf(t, size_of(TGSSolverConstraintPrepDesc{}.cB2w) == 16, "Wrong size for TGSSolverConstraintPrepDesc.cB2w, expected 16 got %v", size_of(TGSSolverConstraintPrepDesc{}.cB2w))
     testing.expectf(t, size_of(TGSSolverConstraintPrepDesc) == 240, "Wrong size for type TGSSolverConstraintPrepDesc, expected 240 got %v", size_of(TGSSolverConstraintPrepDesc))
 }
 
 @(test)
 test_layout_TGSSolverContactDesc :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(TGSSolverContactDesc, invMassScales) == 0, "Wrong offset for TGSSolverContactDesc.invMassScales, expected 0 got %v", offset_of(TGSSolverContactDesc, invMassScales))
+    testing.expectf(t, size_of(TGSSolverContactDesc{}.invMassScales) == 16, "Wrong size for TGSSolverContactDesc.invMassScales, expected 16 got %v", size_of(TGSSolverContactDesc{}.invMassScales))
     testing.expectf(t, offset_of(TGSSolverContactDesc, desc) == 16, "Wrong offset for TGSSolverContactDesc.desc, expected 16 got %v", offset_of(TGSSolverContactDesc, desc))
+    testing.expectf(t, size_of(TGSSolverContactDesc{}.desc) == 8, "Wrong size for TGSSolverContactDesc.desc, expected 8 got %v", size_of(TGSSolverContactDesc{}.desc))
     testing.expectf(t, offset_of(TGSSolverContactDesc, body0) == 24, "Wrong offset for TGSSolverContactDesc.body0, expected 24 got %v", offset_of(TGSSolverContactDesc, body0))
+    testing.expectf(t, size_of(TGSSolverContactDesc{}.body0) == 8, "Wrong size for TGSSolverContactDesc.body0, expected 8 got %v", size_of(TGSSolverContactDesc{}.body0))
     testing.expectf(t, offset_of(TGSSolverContactDesc, body1) == 32, "Wrong offset for TGSSolverContactDesc.body1, expected 32 got %v", offset_of(TGSSolverContactDesc, body1))
+    testing.expectf(t, size_of(TGSSolverContactDesc{}.body1) == 8, "Wrong size for TGSSolverContactDesc.body1, expected 8 got %v", size_of(TGSSolverContactDesc{}.body1))
     testing.expectf(t, offset_of(TGSSolverContactDesc, body0TxI) == 40, "Wrong offset for TGSSolverContactDesc.body0TxI, expected 40 got %v", offset_of(TGSSolverContactDesc, body0TxI))
+    testing.expectf(t, size_of(TGSSolverContactDesc{}.body0TxI) == 8, "Wrong size for TGSSolverContactDesc.body0TxI, expected 8 got %v", size_of(TGSSolverContactDesc{}.body0TxI))
     testing.expectf(t, offset_of(TGSSolverContactDesc, body1TxI) == 48, "Wrong offset for TGSSolverContactDesc.body1TxI, expected 48 got %v", offset_of(TGSSolverContactDesc, body1TxI))
+    testing.expectf(t, size_of(TGSSolverContactDesc{}.body1TxI) == 8, "Wrong size for TGSSolverContactDesc.body1TxI, expected 8 got %v", size_of(TGSSolverContactDesc{}.body1TxI))
     testing.expectf(t, offset_of(TGSSolverContactDesc, bodyData0) == 56, "Wrong offset for TGSSolverContactDesc.bodyData0, expected 56 got %v", offset_of(TGSSolverContactDesc, bodyData0))
+    testing.expectf(t, size_of(TGSSolverContactDesc{}.bodyData0) == 8, "Wrong size for TGSSolverContactDesc.bodyData0, expected 8 got %v", size_of(TGSSolverContactDesc{}.bodyData0))
     testing.expectf(t, offset_of(TGSSolverContactDesc, bodyData1) == 64, "Wrong offset for TGSSolverContactDesc.bodyData1, expected 64 got %v", offset_of(TGSSolverContactDesc, bodyData1))
+    testing.expectf(t, size_of(TGSSolverContactDesc{}.bodyData1) == 8, "Wrong size for TGSSolverContactDesc.bodyData1, expected 8 got %v", size_of(TGSSolverContactDesc{}.bodyData1))
     testing.expectf(t, offset_of(TGSSolverContactDesc, bodyFrame0) == 72, "Wrong offset for TGSSolverContactDesc.bodyFrame0, expected 72 got %v", offset_of(TGSSolverContactDesc, bodyFrame0))
+    testing.expectf(t, size_of(TGSSolverContactDesc{}.bodyFrame0) == 28, "Wrong size for TGSSolverContactDesc.bodyFrame0, expected 28 got %v", size_of(TGSSolverContactDesc{}.bodyFrame0))
     testing.expectf(t, offset_of(TGSSolverContactDesc, bodyFrame1) == 100, "Wrong offset for TGSSolverContactDesc.bodyFrame1, expected 100 got %v", offset_of(TGSSolverContactDesc, bodyFrame1))
+    testing.expectf(t, size_of(TGSSolverContactDesc{}.bodyFrame1) == 28, "Wrong size for TGSSolverContactDesc.bodyFrame1, expected 28 got %v", size_of(TGSSolverContactDesc{}.bodyFrame1))
     testing.expectf(t, offset_of(TGSSolverContactDesc, bodyState0) == 128, "Wrong offset for TGSSolverContactDesc.bodyState0, expected 128 got %v", offset_of(TGSSolverContactDesc, bodyState0))
+    testing.expectf(t, size_of(TGSSolverContactDesc{}.bodyState0) == 4, "Wrong size for TGSSolverContactDesc.bodyState0, expected 4 got %v", size_of(TGSSolverContactDesc{}.bodyState0))
     testing.expectf(t, offset_of(TGSSolverContactDesc, bodyState1) == 132, "Wrong offset for TGSSolverContactDesc.bodyState1, expected 132 got %v", offset_of(TGSSolverContactDesc, bodyState1))
+    testing.expectf(t, size_of(TGSSolverContactDesc{}.bodyState1) == 4, "Wrong size for TGSSolverContactDesc.bodyState1, expected 4 got %v", size_of(TGSSolverContactDesc{}.bodyState1))
     testing.expectf(t, offset_of(TGSSolverContactDesc, shapeInteraction) == 144, "Wrong offset for TGSSolverContactDesc.shapeInteraction, expected 144 got %v", offset_of(TGSSolverContactDesc, shapeInteraction))
+    testing.expectf(t, size_of(TGSSolverContactDesc{}.shapeInteraction) == 8, "Wrong size for TGSSolverContactDesc.shapeInteraction, expected 8 got %v", size_of(TGSSolverContactDesc{}.shapeInteraction))
     testing.expectf(t, offset_of(TGSSolverContactDesc, contacts) == 152, "Wrong offset for TGSSolverContactDesc.contacts, expected 152 got %v", offset_of(TGSSolverContactDesc, contacts))
+    testing.expectf(t, size_of(TGSSolverContactDesc{}.contacts) == 8, "Wrong size for TGSSolverContactDesc.contacts, expected 8 got %v", size_of(TGSSolverContactDesc{}.contacts))
     testing.expectf(t, offset_of(TGSSolverContactDesc, numContacts) == 160, "Wrong offset for TGSSolverContactDesc.numContacts, expected 160 got %v", offset_of(TGSSolverContactDesc, numContacts))
+    testing.expectf(t, size_of(TGSSolverContactDesc{}.numContacts) == 4, "Wrong size for TGSSolverContactDesc.numContacts, expected 4 got %v", size_of(TGSSolverContactDesc{}.numContacts))
     testing.expectf(t, offset_of(TGSSolverContactDesc, hasMaxImpulse) == 164, "Wrong offset for TGSSolverContactDesc.hasMaxImpulse, expected 164 got %v", offset_of(TGSSolverContactDesc, hasMaxImpulse))
+    testing.expectf(t, size_of(TGSSolverContactDesc{}.hasMaxImpulse) == 1, "Wrong size for TGSSolverContactDesc.hasMaxImpulse, expected 1 got %v", size_of(TGSSolverContactDesc{}.hasMaxImpulse))
     testing.expectf(t, offset_of(TGSSolverContactDesc, disableStrongFriction) == 165, "Wrong offset for TGSSolverContactDesc.disableStrongFriction, expected 165 got %v", offset_of(TGSSolverContactDesc, disableStrongFriction))
+    testing.expectf(t, size_of(TGSSolverContactDesc{}.disableStrongFriction) == 1, "Wrong size for TGSSolverContactDesc.disableStrongFriction, expected 1 got %v", size_of(TGSSolverContactDesc{}.disableStrongFriction))
     testing.expectf(t, offset_of(TGSSolverContactDesc, hasForceThresholds) == 166, "Wrong offset for TGSSolverContactDesc.hasForceThresholds, expected 166 got %v", offset_of(TGSSolverContactDesc, hasForceThresholds))
+    testing.expectf(t, size_of(TGSSolverContactDesc{}.hasForceThresholds) == 1, "Wrong size for TGSSolverContactDesc.hasForceThresholds, expected 1 got %v", size_of(TGSSolverContactDesc{}.hasForceThresholds))
     testing.expectf(t, offset_of(TGSSolverContactDesc, restDistance) == 168, "Wrong offset for TGSSolverContactDesc.restDistance, expected 168 got %v", offset_of(TGSSolverContactDesc, restDistance))
+    testing.expectf(t, size_of(TGSSolverContactDesc{}.restDistance) == 4, "Wrong size for TGSSolverContactDesc.restDistance, expected 4 got %v", size_of(TGSSolverContactDesc{}.restDistance))
     testing.expectf(t, offset_of(TGSSolverContactDesc, maxCCDSeparation) == 172, "Wrong offset for TGSSolverContactDesc.maxCCDSeparation, expected 172 got %v", offset_of(TGSSolverContactDesc, maxCCDSeparation))
+    testing.expectf(t, size_of(TGSSolverContactDesc{}.maxCCDSeparation) == 4, "Wrong size for TGSSolverContactDesc.maxCCDSeparation, expected 4 got %v", size_of(TGSSolverContactDesc{}.maxCCDSeparation))
     testing.expectf(t, offset_of(TGSSolverContactDesc, frictionPtr) == 176, "Wrong offset for TGSSolverContactDesc.frictionPtr, expected 176 got %v", offset_of(TGSSolverContactDesc, frictionPtr))
+    testing.expectf(t, size_of(TGSSolverContactDesc{}.frictionPtr) == 8, "Wrong size for TGSSolverContactDesc.frictionPtr, expected 8 got %v", size_of(TGSSolverContactDesc{}.frictionPtr))
     testing.expectf(t, offset_of(TGSSolverContactDesc, frictionCount) == 184, "Wrong offset for TGSSolverContactDesc.frictionCount, expected 184 got %v", offset_of(TGSSolverContactDesc, frictionCount))
+    testing.expectf(t, size_of(TGSSolverContactDesc{}.frictionCount) == 1, "Wrong size for TGSSolverContactDesc.frictionCount, expected 1 got %v", size_of(TGSSolverContactDesc{}.frictionCount))
     testing.expectf(t, offset_of(TGSSolverContactDesc, contactForces) == 192, "Wrong offset for TGSSolverContactDesc.contactForces, expected 192 got %v", offset_of(TGSSolverContactDesc, contactForces))
+    testing.expectf(t, size_of(TGSSolverContactDesc{}.contactForces) == 8, "Wrong size for TGSSolverContactDesc.contactForces, expected 8 got %v", size_of(TGSSolverContactDesc{}.contactForces))
     testing.expectf(t, offset_of(TGSSolverContactDesc, startFrictionPatchIndex) == 200, "Wrong offset for TGSSolverContactDesc.startFrictionPatchIndex, expected 200 got %v", offset_of(TGSSolverContactDesc, startFrictionPatchIndex))
+    testing.expectf(t, size_of(TGSSolverContactDesc{}.startFrictionPatchIndex) == 4, "Wrong size for TGSSolverContactDesc.startFrictionPatchIndex, expected 4 got %v", size_of(TGSSolverContactDesc{}.startFrictionPatchIndex))
     testing.expectf(t, offset_of(TGSSolverContactDesc, numFrictionPatches) == 204, "Wrong offset for TGSSolverContactDesc.numFrictionPatches, expected 204 got %v", offset_of(TGSSolverContactDesc, numFrictionPatches))
+    testing.expectf(t, size_of(TGSSolverContactDesc{}.numFrictionPatches) == 4, "Wrong size for TGSSolverContactDesc.numFrictionPatches, expected 4 got %v", size_of(TGSSolverContactDesc{}.numFrictionPatches))
     testing.expectf(t, offset_of(TGSSolverContactDesc, startContactPatchIndex) == 208, "Wrong offset for TGSSolverContactDesc.startContactPatchIndex, expected 208 got %v", offset_of(TGSSolverContactDesc, startContactPatchIndex))
+    testing.expectf(t, size_of(TGSSolverContactDesc{}.startContactPatchIndex) == 4, "Wrong size for TGSSolverContactDesc.startContactPatchIndex, expected 4 got %v", size_of(TGSSolverContactDesc{}.startContactPatchIndex))
     testing.expectf(t, offset_of(TGSSolverContactDesc, numContactPatches) == 212, "Wrong offset for TGSSolverContactDesc.numContactPatches, expected 212 got %v", offset_of(TGSSolverContactDesc, numContactPatches))
+    testing.expectf(t, size_of(TGSSolverContactDesc{}.numContactPatches) == 2, "Wrong size for TGSSolverContactDesc.numContactPatches, expected 2 got %v", size_of(TGSSolverContactDesc{}.numContactPatches))
     testing.expectf(t, offset_of(TGSSolverContactDesc, axisConstraintCount) == 214, "Wrong offset for TGSSolverContactDesc.axisConstraintCount, expected 214 got %v", offset_of(TGSSolverContactDesc, axisConstraintCount))
+    testing.expectf(t, size_of(TGSSolverContactDesc{}.axisConstraintCount) == 2, "Wrong size for TGSSolverContactDesc.axisConstraintCount, expected 2 got %v", size_of(TGSSolverContactDesc{}.axisConstraintCount))
     testing.expectf(t, offset_of(TGSSolverContactDesc, maxImpulse) == 216, "Wrong offset for TGSSolverContactDesc.maxImpulse, expected 216 got %v", offset_of(TGSSolverContactDesc, maxImpulse))
+    testing.expectf(t, size_of(TGSSolverContactDesc{}.maxImpulse) == 4, "Wrong size for TGSSolverContactDesc.maxImpulse, expected 4 got %v", size_of(TGSSolverContactDesc{}.maxImpulse))
     testing.expectf(t, offset_of(TGSSolverContactDesc, torsionalPatchRadius) == 220, "Wrong offset for TGSSolverContactDesc.torsionalPatchRadius, expected 220 got %v", offset_of(TGSSolverContactDesc, torsionalPatchRadius))
+    testing.expectf(t, size_of(TGSSolverContactDesc{}.torsionalPatchRadius) == 4, "Wrong size for TGSSolverContactDesc.torsionalPatchRadius, expected 4 got %v", size_of(TGSSolverContactDesc{}.torsionalPatchRadius))
     testing.expectf(t, offset_of(TGSSolverContactDesc, minTorsionalPatchRadius) == 224, "Wrong offset for TGSSolverContactDesc.minTorsionalPatchRadius, expected 224 got %v", offset_of(TGSSolverContactDesc, minTorsionalPatchRadius))
+    testing.expectf(t, size_of(TGSSolverContactDesc{}.minTorsionalPatchRadius) == 4, "Wrong size for TGSSolverContactDesc.minTorsionalPatchRadius, expected 4 got %v", size_of(TGSSolverContactDesc{}.minTorsionalPatchRadius))
     testing.expectf(t, offset_of(TGSSolverContactDesc, offsetSlop) == 228, "Wrong offset for TGSSolverContactDesc.offsetSlop, expected 228 got %v", offset_of(TGSSolverContactDesc, offsetSlop))
+    testing.expectf(t, size_of(TGSSolverContactDesc{}.offsetSlop) == 4, "Wrong size for TGSSolverContactDesc.offsetSlop, expected 4 got %v", size_of(TGSSolverContactDesc{}.offsetSlop))
     testing.expectf(t, size_of(TGSSolverContactDesc) == 240, "Wrong size for type TGSSolverContactDesc, expected 240 got %v", size_of(TGSSolverContactDesc))
 }
 
 @(test)
 test_layout_ArticulationTendonLimit :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(ArticulationTendonLimit, lowLimit) == 0, "Wrong offset for ArticulationTendonLimit.lowLimit, expected 0 got %v", offset_of(ArticulationTendonLimit, lowLimit))
+    testing.expectf(t, size_of(ArticulationTendonLimit{}.lowLimit) == 4, "Wrong size for ArticulationTendonLimit.lowLimit, expected 4 got %v", size_of(ArticulationTendonLimit{}.lowLimit))
     testing.expectf(t, offset_of(ArticulationTendonLimit, highLimit) == 4, "Wrong offset for ArticulationTendonLimit.highLimit, expected 4 got %v", offset_of(ArticulationTendonLimit, highLimit))
+    testing.expectf(t, size_of(ArticulationTendonLimit{}.highLimit) == 4, "Wrong size for ArticulationTendonLimit.highLimit, expected 4 got %v", size_of(ArticulationTendonLimit{}.highLimit))
     testing.expectf(t, size_of(ArticulationTendonLimit) == 8, "Wrong size for type ArticulationTendonLimit, expected 8 got %v", size_of(ArticulationTendonLimit))
 }
 
@@ -1047,6 +1412,7 @@ test_layout_ArticulationTendonLimit :: proc(t: ^testing.T) {
 test_layout_ArticulationAttachment :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(ArticulationAttachment, userData) == 16, "Wrong offset for ArticulationAttachment.userData, expected 16 got %v", offset_of(ArticulationAttachment, userData))
+    testing.expectf(t, size_of(ArticulationAttachment{}.userData) == 8, "Wrong size for ArticulationAttachment.userData, expected 8 got %v", size_of(ArticulationAttachment{}.userData))
     testing.expectf(t, size_of(ArticulationAttachment) == 24, "Wrong size for type ArticulationAttachment, expected 24 got %v", size_of(ArticulationAttachment))
 }
 
@@ -1054,6 +1420,7 @@ test_layout_ArticulationAttachment :: proc(t: ^testing.T) {
 test_layout_ArticulationTendonJoint :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(ArticulationTendonJoint, userData) == 16, "Wrong offset for ArticulationTendonJoint.userData, expected 16 got %v", offset_of(ArticulationTendonJoint, userData))
+    testing.expectf(t, size_of(ArticulationTendonJoint{}.userData) == 8, "Wrong size for ArticulationTendonJoint.userData, expected 8 got %v", size_of(ArticulationTendonJoint{}.userData))
     testing.expectf(t, size_of(ArticulationTendonJoint) == 24, "Wrong size for type ArticulationTendonJoint, expected 24 got %v", size_of(ArticulationTendonJoint))
 }
 
@@ -1061,6 +1428,7 @@ test_layout_ArticulationTendonJoint :: proc(t: ^testing.T) {
 test_layout_ArticulationTendon :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(ArticulationTendon, userData) == 16, "Wrong offset for ArticulationTendon.userData, expected 16 got %v", offset_of(ArticulationTendon, userData))
+    testing.expectf(t, size_of(ArticulationTendon{}.userData) == 8, "Wrong size for ArticulationTendon.userData, expected 8 got %v", size_of(ArticulationTendon{}.userData))
     testing.expectf(t, size_of(ArticulationTendon) == 24, "Wrong size for type ArticulationTendon, expected 24 got %v", size_of(ArticulationTendon))
 }
 
@@ -1079,50 +1447,84 @@ test_layout_ArticulationFixedTendon :: proc(t: ^testing.T) {
 @(test)
 test_layout_SpatialForce :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(SpatialForce, force) == 0, "Wrong offset for SpatialForce.force, expected 0 got %v", offset_of(SpatialForce, force))
+    testing.expectf(t, size_of(SpatialForce{}.force) == 12, "Wrong size for SpatialForce.force, expected 12 got %v", size_of(SpatialForce{}.force))
     testing.expectf(t, offset_of(SpatialForce, pad0) == 12, "Wrong offset for SpatialForce.pad0, expected 12 got %v", offset_of(SpatialForce, pad0))
+    testing.expectf(t, size_of(SpatialForce{}.pad0) == 4, "Wrong size for SpatialForce.pad0, expected 4 got %v", size_of(SpatialForce{}.pad0))
     testing.expectf(t, offset_of(SpatialForce, torque) == 16, "Wrong offset for SpatialForce.torque, expected 16 got %v", offset_of(SpatialForce, torque))
+    testing.expectf(t, size_of(SpatialForce{}.torque) == 12, "Wrong size for SpatialForce.torque, expected 12 got %v", size_of(SpatialForce{}.torque))
     testing.expectf(t, offset_of(SpatialForce, pad1) == 28, "Wrong offset for SpatialForce.pad1, expected 28 got %v", offset_of(SpatialForce, pad1))
+    testing.expectf(t, size_of(SpatialForce{}.pad1) == 4, "Wrong size for SpatialForce.pad1, expected 4 got %v", size_of(SpatialForce{}.pad1))
     testing.expectf(t, size_of(SpatialForce) == 32, "Wrong size for type SpatialForce, expected 32 got %v", size_of(SpatialForce))
 }
 
 @(test)
 test_layout_SpatialVelocity :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(SpatialVelocity, linear) == 0, "Wrong offset for SpatialVelocity.linear, expected 0 got %v", offset_of(SpatialVelocity, linear))
+    testing.expectf(t, size_of(SpatialVelocity{}.linear) == 12, "Wrong size for SpatialVelocity.linear, expected 12 got %v", size_of(SpatialVelocity{}.linear))
     testing.expectf(t, offset_of(SpatialVelocity, pad0) == 12, "Wrong offset for SpatialVelocity.pad0, expected 12 got %v", offset_of(SpatialVelocity, pad0))
+    testing.expectf(t, size_of(SpatialVelocity{}.pad0) == 4, "Wrong size for SpatialVelocity.pad0, expected 4 got %v", size_of(SpatialVelocity{}.pad0))
     testing.expectf(t, offset_of(SpatialVelocity, angular) == 16, "Wrong offset for SpatialVelocity.angular, expected 16 got %v", offset_of(SpatialVelocity, angular))
+    testing.expectf(t, size_of(SpatialVelocity{}.angular) == 12, "Wrong size for SpatialVelocity.angular, expected 12 got %v", size_of(SpatialVelocity{}.angular))
     testing.expectf(t, offset_of(SpatialVelocity, pad1) == 28, "Wrong offset for SpatialVelocity.pad1, expected 28 got %v", offset_of(SpatialVelocity, pad1))
+    testing.expectf(t, size_of(SpatialVelocity{}.pad1) == 4, "Wrong size for SpatialVelocity.pad1, expected 4 got %v", size_of(SpatialVelocity{}.pad1))
     testing.expectf(t, size_of(SpatialVelocity) == 32, "Wrong size for type SpatialVelocity, expected 32 got %v", size_of(SpatialVelocity))
 }
 
 @(test)
 test_layout_ArticulationRootLinkData :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(ArticulationRootLinkData, transform) == 0, "Wrong offset for ArticulationRootLinkData.transform, expected 0 got %v", offset_of(ArticulationRootLinkData, transform))
+    testing.expectf(t, size_of(ArticulationRootLinkData{}.transform) == 28, "Wrong size for ArticulationRootLinkData.transform, expected 28 got %v", size_of(ArticulationRootLinkData{}.transform))
     testing.expectf(t, offset_of(ArticulationRootLinkData, worldLinVel) == 28, "Wrong offset for ArticulationRootLinkData.worldLinVel, expected 28 got %v", offset_of(ArticulationRootLinkData, worldLinVel))
+    testing.expectf(t, size_of(ArticulationRootLinkData{}.worldLinVel) == 12, "Wrong size for ArticulationRootLinkData.worldLinVel, expected 12 got %v", size_of(ArticulationRootLinkData{}.worldLinVel))
     testing.expectf(t, offset_of(ArticulationRootLinkData, worldAngVel) == 40, "Wrong offset for ArticulationRootLinkData.worldAngVel, expected 40 got %v", offset_of(ArticulationRootLinkData, worldAngVel))
+    testing.expectf(t, size_of(ArticulationRootLinkData{}.worldAngVel) == 12, "Wrong size for ArticulationRootLinkData.worldAngVel, expected 12 got %v", size_of(ArticulationRootLinkData{}.worldAngVel))
     testing.expectf(t, offset_of(ArticulationRootLinkData, worldLinAccel) == 52, "Wrong offset for ArticulationRootLinkData.worldLinAccel, expected 52 got %v", offset_of(ArticulationRootLinkData, worldLinAccel))
+    testing.expectf(t, size_of(ArticulationRootLinkData{}.worldLinAccel) == 12, "Wrong size for ArticulationRootLinkData.worldLinAccel, expected 12 got %v", size_of(ArticulationRootLinkData{}.worldLinAccel))
     testing.expectf(t, offset_of(ArticulationRootLinkData, worldAngAccel) == 64, "Wrong offset for ArticulationRootLinkData.worldAngAccel, expected 64 got %v", offset_of(ArticulationRootLinkData, worldAngAccel))
+    testing.expectf(t, size_of(ArticulationRootLinkData{}.worldAngAccel) == 12, "Wrong size for ArticulationRootLinkData.worldAngAccel, expected 12 got %v", size_of(ArticulationRootLinkData{}.worldAngAccel))
     testing.expectf(t, size_of(ArticulationRootLinkData) == 76, "Wrong size for type ArticulationRootLinkData, expected 76 got %v", size_of(ArticulationRootLinkData))
 }
 
 @(test)
 test_layout_ArticulationCache :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(ArticulationCache, externalForces) == 0, "Wrong offset for ArticulationCache.externalForces, expected 0 got %v", offset_of(ArticulationCache, externalForces))
+    testing.expectf(t, size_of(ArticulationCache{}.externalForces) == 8, "Wrong size for ArticulationCache.externalForces, expected 8 got %v", size_of(ArticulationCache{}.externalForces))
     testing.expectf(t, offset_of(ArticulationCache, denseJacobian) == 8, "Wrong offset for ArticulationCache.denseJacobian, expected 8 got %v", offset_of(ArticulationCache, denseJacobian))
+    testing.expectf(t, size_of(ArticulationCache{}.denseJacobian) == 8, "Wrong size for ArticulationCache.denseJacobian, expected 8 got %v", size_of(ArticulationCache{}.denseJacobian))
     testing.expectf(t, offset_of(ArticulationCache, massMatrix) == 16, "Wrong offset for ArticulationCache.massMatrix, expected 16 got %v", offset_of(ArticulationCache, massMatrix))
+    testing.expectf(t, size_of(ArticulationCache{}.massMatrix) == 8, "Wrong size for ArticulationCache.massMatrix, expected 8 got %v", size_of(ArticulationCache{}.massMatrix))
     testing.expectf(t, offset_of(ArticulationCache, jointVelocity) == 24, "Wrong offset for ArticulationCache.jointVelocity, expected 24 got %v", offset_of(ArticulationCache, jointVelocity))
+    testing.expectf(t, size_of(ArticulationCache{}.jointVelocity) == 8, "Wrong size for ArticulationCache.jointVelocity, expected 8 got %v", size_of(ArticulationCache{}.jointVelocity))
     testing.expectf(t, offset_of(ArticulationCache, jointAcceleration) == 32, "Wrong offset for ArticulationCache.jointAcceleration, expected 32 got %v", offset_of(ArticulationCache, jointAcceleration))
+    testing.expectf(t, size_of(ArticulationCache{}.jointAcceleration) == 8, "Wrong size for ArticulationCache.jointAcceleration, expected 8 got %v", size_of(ArticulationCache{}.jointAcceleration))
     testing.expectf(t, offset_of(ArticulationCache, jointPosition) == 40, "Wrong offset for ArticulationCache.jointPosition, expected 40 got %v", offset_of(ArticulationCache, jointPosition))
+    testing.expectf(t, size_of(ArticulationCache{}.jointPosition) == 8, "Wrong size for ArticulationCache.jointPosition, expected 8 got %v", size_of(ArticulationCache{}.jointPosition))
     testing.expectf(t, offset_of(ArticulationCache, jointForce) == 48, "Wrong offset for ArticulationCache.jointForce, expected 48 got %v", offset_of(ArticulationCache, jointForce))
+    testing.expectf(t, size_of(ArticulationCache{}.jointForce) == 8, "Wrong size for ArticulationCache.jointForce, expected 8 got %v", size_of(ArticulationCache{}.jointForce))
     testing.expectf(t, offset_of(ArticulationCache, jointSolverForces) == 56, "Wrong offset for ArticulationCache.jointSolverForces, expected 56 got %v", offset_of(ArticulationCache, jointSolverForces))
+    testing.expectf(t, size_of(ArticulationCache{}.jointSolverForces) == 8, "Wrong size for ArticulationCache.jointSolverForces, expected 8 got %v", size_of(ArticulationCache{}.jointSolverForces))
     testing.expectf(t, offset_of(ArticulationCache, linkVelocity) == 64, "Wrong offset for ArticulationCache.linkVelocity, expected 64 got %v", offset_of(ArticulationCache, linkVelocity))
+    testing.expectf(t, size_of(ArticulationCache{}.linkVelocity) == 8, "Wrong size for ArticulationCache.linkVelocity, expected 8 got %v", size_of(ArticulationCache{}.linkVelocity))
     testing.expectf(t, offset_of(ArticulationCache, linkAcceleration) == 72, "Wrong offset for ArticulationCache.linkAcceleration, expected 72 got %v", offset_of(ArticulationCache, linkAcceleration))
+    testing.expectf(t, size_of(ArticulationCache{}.linkAcceleration) == 8, "Wrong size for ArticulationCache.linkAcceleration, expected 8 got %v", size_of(ArticulationCache{}.linkAcceleration))
     testing.expectf(t, offset_of(ArticulationCache, rootLinkData) == 80, "Wrong offset for ArticulationCache.rootLinkData, expected 80 got %v", offset_of(ArticulationCache, rootLinkData))
+    testing.expectf(t, size_of(ArticulationCache{}.rootLinkData) == 8, "Wrong size for ArticulationCache.rootLinkData, expected 8 got %v", size_of(ArticulationCache{}.rootLinkData))
     testing.expectf(t, offset_of(ArticulationCache, sensorForces) == 88, "Wrong offset for ArticulationCache.sensorForces, expected 88 got %v", offset_of(ArticulationCache, sensorForces))
+    testing.expectf(t, size_of(ArticulationCache{}.sensorForces) == 8, "Wrong size for ArticulationCache.sensorForces, expected 8 got %v", size_of(ArticulationCache{}.sensorForces))
     testing.expectf(t, offset_of(ArticulationCache, coefficientMatrix) == 96, "Wrong offset for ArticulationCache.coefficientMatrix, expected 96 got %v", offset_of(ArticulationCache, coefficientMatrix))
+    testing.expectf(t, size_of(ArticulationCache{}.coefficientMatrix) == 8, "Wrong size for ArticulationCache.coefficientMatrix, expected 8 got %v", size_of(ArticulationCache{}.coefficientMatrix))
     testing.expectf(t, offset_of(ArticulationCache, lambda) == 104, "Wrong offset for ArticulationCache.lambda, expected 104 got %v", offset_of(ArticulationCache, lambda))
+    testing.expectf(t, size_of(ArticulationCache{}.lambda) == 8, "Wrong size for ArticulationCache.lambda, expected 8 got %v", size_of(ArticulationCache{}.lambda))
     testing.expectf(t, offset_of(ArticulationCache, scratchMemory) == 112, "Wrong offset for ArticulationCache.scratchMemory, expected 112 got %v", offset_of(ArticulationCache, scratchMemory))
+    testing.expectf(t, size_of(ArticulationCache{}.scratchMemory) == 8, "Wrong size for ArticulationCache.scratchMemory, expected 8 got %v", size_of(ArticulationCache{}.scratchMemory))
     testing.expectf(t, offset_of(ArticulationCache, scratchAllocator) == 120, "Wrong offset for ArticulationCache.scratchAllocator, expected 120 got %v", offset_of(ArticulationCache, scratchAllocator))
+    testing.expectf(t, size_of(ArticulationCache{}.scratchAllocator) == 8, "Wrong size for ArticulationCache.scratchAllocator, expected 8 got %v", size_of(ArticulationCache{}.scratchAllocator))
     testing.expectf(t, offset_of(ArticulationCache, version) == 128, "Wrong offset for ArticulationCache.version, expected 128 got %v", offset_of(ArticulationCache, version))
+    testing.expectf(t, size_of(ArticulationCache{}.version) == 4, "Wrong size for ArticulationCache.version, expected 4 got %v", size_of(ArticulationCache{}.version))
     testing.expectf(t, size_of(ArticulationCache) == 136, "Wrong size for type ArticulationCache, expected 136 got %v", size_of(ArticulationCache))
 }
 
@@ -1130,6 +1532,7 @@ test_layout_ArticulationCache :: proc(t: ^testing.T) {
 test_layout_ArticulationSensor :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(ArticulationSensor, userData) == 16, "Wrong offset for ArticulationSensor.userData, expected 16 got %v", offset_of(ArticulationSensor, userData))
+    testing.expectf(t, size_of(ArticulationSensor{}.userData) == 8, "Wrong size for ArticulationSensor.userData, expected 8 got %v", size_of(ArticulationSensor{}.userData))
     testing.expectf(t, size_of(ArticulationSensor) == 24, "Wrong size for type ArticulationSensor, expected 24 got %v", size_of(ArticulationSensor))
 }
 
@@ -1137,6 +1540,7 @@ test_layout_ArticulationSensor :: proc(t: ^testing.T) {
 test_layout_ArticulationReducedCoordinate :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(ArticulationReducedCoordinate, userData) == 16, "Wrong offset for ArticulationReducedCoordinate.userData, expected 16 got %v", offset_of(ArticulationReducedCoordinate, userData))
+    testing.expectf(t, size_of(ArticulationReducedCoordinate{}.userData) == 8, "Wrong size for ArticulationReducedCoordinate.userData, expected 8 got %v", size_of(ArticulationReducedCoordinate{}.userData))
     testing.expectf(t, size_of(ArticulationReducedCoordinate) == 24, "Wrong size for type ArticulationReducedCoordinate, expected 24 got %v", size_of(ArticulationReducedCoordinate))
 }
 
@@ -1144,6 +1548,7 @@ test_layout_ArticulationReducedCoordinate :: proc(t: ^testing.T) {
 test_layout_ArticulationJointReducedCoordinate :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(ArticulationJointReducedCoordinate, userData) == 16, "Wrong offset for ArticulationJointReducedCoordinate.userData, expected 16 got %v", offset_of(ArticulationJointReducedCoordinate, userData))
+    testing.expectf(t, size_of(ArticulationJointReducedCoordinate{}.userData) == 8, "Wrong size for ArticulationJointReducedCoordinate.userData, expected 8 got %v", size_of(ArticulationJointReducedCoordinate{}.userData))
     testing.expectf(t, size_of(ArticulationJointReducedCoordinate) == 24, "Wrong size for type ArticulationJointReducedCoordinate, expected 24 got %v", size_of(ArticulationJointReducedCoordinate))
 }
 
@@ -1151,6 +1556,7 @@ test_layout_ArticulationJointReducedCoordinate :: proc(t: ^testing.T) {
 test_layout_Shape :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(Shape, userData) == 16, "Wrong offset for Shape.userData, expected 16 got %v", offset_of(Shape, userData))
+    testing.expectf(t, size_of(Shape{}.userData) == 8, "Wrong size for Shape.userData, expected 8 got %v", size_of(Shape{}.userData))
     testing.expectf(t, size_of(Shape) == 24, "Wrong size for type Shape, expected 24 got %v", size_of(Shape))
 }
 
@@ -1181,24 +1587,36 @@ test_layout_ArticulationLink :: proc(t: ^testing.T) {
 @(test)
 test_layout_ConeLimitedConstraint :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(ConeLimitedConstraint, mAxis) == 0, "Wrong offset for ConeLimitedConstraint.mAxis, expected 0 got %v", offset_of(ConeLimitedConstraint, mAxis))
+    testing.expectf(t, size_of(ConeLimitedConstraint{}.mAxis) == 12, "Wrong size for ConeLimitedConstraint.mAxis, expected 12 got %v", size_of(ConeLimitedConstraint{}.mAxis))
     testing.expectf(t, offset_of(ConeLimitedConstraint, mAngle) == 12, "Wrong offset for ConeLimitedConstraint.mAngle, expected 12 got %v", offset_of(ConeLimitedConstraint, mAngle))
+    testing.expectf(t, size_of(ConeLimitedConstraint{}.mAngle) == 4, "Wrong size for ConeLimitedConstraint.mAngle, expected 4 got %v", size_of(ConeLimitedConstraint{}.mAngle))
     testing.expectf(t, offset_of(ConeLimitedConstraint, mLowLimit) == 16, "Wrong offset for ConeLimitedConstraint.mLowLimit, expected 16 got %v", offset_of(ConeLimitedConstraint, mLowLimit))
+    testing.expectf(t, size_of(ConeLimitedConstraint{}.mLowLimit) == 4, "Wrong size for ConeLimitedConstraint.mLowLimit, expected 4 got %v", size_of(ConeLimitedConstraint{}.mLowLimit))
     testing.expectf(t, offset_of(ConeLimitedConstraint, mHighLimit) == 20, "Wrong offset for ConeLimitedConstraint.mHighLimit, expected 20 got %v", offset_of(ConeLimitedConstraint, mHighLimit))
+    testing.expectf(t, size_of(ConeLimitedConstraint{}.mHighLimit) == 4, "Wrong size for ConeLimitedConstraint.mHighLimit, expected 4 got %v", size_of(ConeLimitedConstraint{}.mHighLimit))
     testing.expectf(t, size_of(ConeLimitedConstraint) == 24, "Wrong size for type ConeLimitedConstraint, expected 24 got %v", size_of(ConeLimitedConstraint))
 }
 
 @(test)
 test_layout_ConeLimitParams :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(ConeLimitParams, lowHighLimits) == 0, "Wrong offset for ConeLimitParams.lowHighLimits, expected 0 got %v", offset_of(ConeLimitParams, lowHighLimits))
+    testing.expectf(t, size_of(ConeLimitParams{}.lowHighLimits) == 16, "Wrong size for ConeLimitParams.lowHighLimits, expected 16 got %v", size_of(ConeLimitParams{}.lowHighLimits))
     testing.expectf(t, offset_of(ConeLimitParams, axisAngle) == 16, "Wrong offset for ConeLimitParams.axisAngle, expected 16 got %v", offset_of(ConeLimitParams, axisAngle))
+    testing.expectf(t, size_of(ConeLimitParams{}.axisAngle) == 16, "Wrong size for ConeLimitParams.axisAngle, expected 16 got %v", size_of(ConeLimitParams{}.axisAngle))
     testing.expectf(t, size_of(ConeLimitParams) == 32, "Wrong size for type ConeLimitParams, expected 32 got %v", size_of(ConeLimitParams))
 }
 
 @(test)
 test_layout_ConstraintShaderTable :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(ConstraintShaderTable, solverPrep) == 0, "Wrong offset for ConstraintShaderTable.solverPrep, expected 0 got %v", offset_of(ConstraintShaderTable, solverPrep))
+    testing.expectf(t, size_of(ConstraintShaderTable{}.solverPrep) == 8, "Wrong size for ConstraintShaderTable.solverPrep, expected 8 got %v", size_of(ConstraintShaderTable{}.solverPrep))
     testing.expectf(t, offset_of(ConstraintShaderTable, visualize) == 16, "Wrong offset for ConstraintShaderTable.visualize, expected 16 got %v", offset_of(ConstraintShaderTable, visualize))
+    testing.expectf(t, size_of(ConstraintShaderTable{}.visualize) == 8, "Wrong size for ConstraintShaderTable.visualize, expected 8 got %v", size_of(ConstraintShaderTable{}.visualize))
     testing.expectf(t, offset_of(ConstraintShaderTable, flag) == 24, "Wrong offset for ConstraintShaderTable.flag, expected 24 got %v", offset_of(ConstraintShaderTable, flag))
+    testing.expectf(t, size_of(ConstraintShaderTable{}.flag) == 4, "Wrong size for ConstraintShaderTable.flag, expected 4 got %v", size_of(ConstraintShaderTable{}.flag))
     testing.expectf(t, size_of(ConstraintShaderTable) == 32, "Wrong size for type ConstraintShaderTable, expected 32 got %v", size_of(ConstraintShaderTable))
 }
 
@@ -1206,39 +1624,61 @@ test_layout_ConstraintShaderTable :: proc(t: ^testing.T) {
 test_layout_Constraint :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(Constraint, userData) == 16, "Wrong offset for Constraint.userData, expected 16 got %v", offset_of(Constraint, userData))
+    testing.expectf(t, size_of(Constraint{}.userData) == 8, "Wrong size for Constraint.userData, expected 8 got %v", size_of(Constraint{}.userData))
     testing.expectf(t, size_of(Constraint) == 24, "Wrong size for type Constraint, expected 24 got %v", size_of(Constraint))
 }
 
 @(test)
 test_layout_MassModificationProps :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(MassModificationProps, mInvMassScale0) == 0, "Wrong offset for MassModificationProps.mInvMassScale0, expected 0 got %v", offset_of(MassModificationProps, mInvMassScale0))
+    testing.expectf(t, size_of(MassModificationProps{}.mInvMassScale0) == 4, "Wrong size for MassModificationProps.mInvMassScale0, expected 4 got %v", size_of(MassModificationProps{}.mInvMassScale0))
     testing.expectf(t, offset_of(MassModificationProps, mInvInertiaScale0) == 4, "Wrong offset for MassModificationProps.mInvInertiaScale0, expected 4 got %v", offset_of(MassModificationProps, mInvInertiaScale0))
+    testing.expectf(t, size_of(MassModificationProps{}.mInvInertiaScale0) == 4, "Wrong size for MassModificationProps.mInvInertiaScale0, expected 4 got %v", size_of(MassModificationProps{}.mInvInertiaScale0))
     testing.expectf(t, offset_of(MassModificationProps, mInvMassScale1) == 8, "Wrong offset for MassModificationProps.mInvMassScale1, expected 8 got %v", offset_of(MassModificationProps, mInvMassScale1))
+    testing.expectf(t, size_of(MassModificationProps{}.mInvMassScale1) == 4, "Wrong size for MassModificationProps.mInvMassScale1, expected 4 got %v", size_of(MassModificationProps{}.mInvMassScale1))
     testing.expectf(t, offset_of(MassModificationProps, mInvInertiaScale1) == 12, "Wrong offset for MassModificationProps.mInvInertiaScale1, expected 12 got %v", offset_of(MassModificationProps, mInvInertiaScale1))
+    testing.expectf(t, size_of(MassModificationProps{}.mInvInertiaScale1) == 4, "Wrong size for MassModificationProps.mInvInertiaScale1, expected 4 got %v", size_of(MassModificationProps{}.mInvInertiaScale1))
     testing.expectf(t, size_of(MassModificationProps) == 16, "Wrong size for type MassModificationProps, expected 16 got %v", size_of(MassModificationProps))
 }
 
 @(test)
 test_layout_ContactPatch :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(ContactPatch, mMassModification) == 0, "Wrong offset for ContactPatch.mMassModification, expected 0 got %v", offset_of(ContactPatch, mMassModification))
+    testing.expectf(t, size_of(ContactPatch{}.mMassModification) == 16, "Wrong size for ContactPatch.mMassModification, expected 16 got %v", size_of(ContactPatch{}.mMassModification))
     testing.expectf(t, offset_of(ContactPatch, normal) == 16, "Wrong offset for ContactPatch.normal, expected 16 got %v", offset_of(ContactPatch, normal))
+    testing.expectf(t, size_of(ContactPatch{}.normal) == 12, "Wrong size for ContactPatch.normal, expected 12 got %v", size_of(ContactPatch{}.normal))
     testing.expectf(t, offset_of(ContactPatch, restitution) == 28, "Wrong offset for ContactPatch.restitution, expected 28 got %v", offset_of(ContactPatch, restitution))
+    testing.expectf(t, size_of(ContactPatch{}.restitution) == 4, "Wrong size for ContactPatch.restitution, expected 4 got %v", size_of(ContactPatch{}.restitution))
     testing.expectf(t, offset_of(ContactPatch, dynamicFriction) == 32, "Wrong offset for ContactPatch.dynamicFriction, expected 32 got %v", offset_of(ContactPatch, dynamicFriction))
+    testing.expectf(t, size_of(ContactPatch{}.dynamicFriction) == 4, "Wrong size for ContactPatch.dynamicFriction, expected 4 got %v", size_of(ContactPatch{}.dynamicFriction))
     testing.expectf(t, offset_of(ContactPatch, staticFriction) == 36, "Wrong offset for ContactPatch.staticFriction, expected 36 got %v", offset_of(ContactPatch, staticFriction))
+    testing.expectf(t, size_of(ContactPatch{}.staticFriction) == 4, "Wrong size for ContactPatch.staticFriction, expected 4 got %v", size_of(ContactPatch{}.staticFriction))
     testing.expectf(t, offset_of(ContactPatch, damping) == 40, "Wrong offset for ContactPatch.damping, expected 40 got %v", offset_of(ContactPatch, damping))
+    testing.expectf(t, size_of(ContactPatch{}.damping) == 4, "Wrong size for ContactPatch.damping, expected 4 got %v", size_of(ContactPatch{}.damping))
     testing.expectf(t, offset_of(ContactPatch, startContactIndex) == 44, "Wrong offset for ContactPatch.startContactIndex, expected 44 got %v", offset_of(ContactPatch, startContactIndex))
+    testing.expectf(t, size_of(ContactPatch{}.startContactIndex) == 2, "Wrong size for ContactPatch.startContactIndex, expected 2 got %v", size_of(ContactPatch{}.startContactIndex))
     testing.expectf(t, offset_of(ContactPatch, nbContacts) == 46, "Wrong offset for ContactPatch.nbContacts, expected 46 got %v", offset_of(ContactPatch, nbContacts))
+    testing.expectf(t, size_of(ContactPatch{}.nbContacts) == 1, "Wrong size for ContactPatch.nbContacts, expected 1 got %v", size_of(ContactPatch{}.nbContacts))
     testing.expectf(t, offset_of(ContactPatch, materialFlags) == 47, "Wrong offset for ContactPatch.materialFlags, expected 47 got %v", offset_of(ContactPatch, materialFlags))
+    testing.expectf(t, size_of(ContactPatch{}.materialFlags) == 1, "Wrong size for ContactPatch.materialFlags, expected 1 got %v", size_of(ContactPatch{}.materialFlags))
     testing.expectf(t, offset_of(ContactPatch, internalFlags) == 48, "Wrong offset for ContactPatch.internalFlags, expected 48 got %v", offset_of(ContactPatch, internalFlags))
+    testing.expectf(t, size_of(ContactPatch{}.internalFlags) == 2, "Wrong size for ContactPatch.internalFlags, expected 2 got %v", size_of(ContactPatch{}.internalFlags))
     testing.expectf(t, offset_of(ContactPatch, materialIndex0) == 50, "Wrong offset for ContactPatch.materialIndex0, expected 50 got %v", offset_of(ContactPatch, materialIndex0))
+    testing.expectf(t, size_of(ContactPatch{}.materialIndex0) == 2, "Wrong size for ContactPatch.materialIndex0, expected 2 got %v", size_of(ContactPatch{}.materialIndex0))
     testing.expectf(t, offset_of(ContactPatch, materialIndex1) == 52, "Wrong offset for ContactPatch.materialIndex1, expected 52 got %v", offset_of(ContactPatch, materialIndex1))
+    testing.expectf(t, size_of(ContactPatch{}.materialIndex1) == 2, "Wrong size for ContactPatch.materialIndex1, expected 2 got %v", size_of(ContactPatch{}.materialIndex1))
     testing.expectf(t, size_of(ContactPatch) == 64, "Wrong size for type ContactPatch, expected 64 got %v", size_of(ContactPatch))
 }
 
 @(test)
 test_layout_Contact :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(Contact, contact) == 0, "Wrong offset for Contact.contact, expected 0 got %v", offset_of(Contact, contact))
+    testing.expectf(t, size_of(Contact{}.contact) == 12, "Wrong size for Contact.contact, expected 12 got %v", size_of(Contact{}.contact))
     testing.expectf(t, offset_of(Contact, separation) == 12, "Wrong offset for Contact.separation, expected 12 got %v", offset_of(Contact, separation))
+    testing.expectf(t, size_of(Contact{}.separation) == 4, "Wrong size for Contact.separation, expected 4 got %v", size_of(Contact{}.separation))
     testing.expectf(t, size_of(Contact) == 16, "Wrong size for type Contact, expected 16 got %v", size_of(Contact))
 }
 
@@ -1246,7 +1686,9 @@ test_layout_Contact :: proc(t: ^testing.T) {
 test_layout_ExtendedContact :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(ExtendedContact, targetVelocity) == 16, "Wrong offset for ExtendedContact.targetVelocity, expected 16 got %v", offset_of(ExtendedContact, targetVelocity))
+    testing.expectf(t, size_of(ExtendedContact{}.targetVelocity) == 12, "Wrong size for ExtendedContact.targetVelocity, expected 12 got %v", size_of(ExtendedContact{}.targetVelocity))
     testing.expectf(t, offset_of(ExtendedContact, maxImpulse) == 28, "Wrong offset for ExtendedContact.maxImpulse, expected 28 got %v", offset_of(ExtendedContact, maxImpulse))
+    testing.expectf(t, size_of(ExtendedContact{}.maxImpulse) == 4, "Wrong size for ExtendedContact.maxImpulse, expected 4 got %v", size_of(ExtendedContact{}.maxImpulse))
     testing.expectf(t, size_of(ExtendedContact) == 32, "Wrong size for type ExtendedContact, expected 32 got %v", size_of(ExtendedContact))
 }
 
@@ -1254,47 +1696,81 @@ test_layout_ExtendedContact :: proc(t: ^testing.T) {
 test_layout_ModifiableContact :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(ModifiableContact, normal) == 32, "Wrong offset for ModifiableContact.normal, expected 32 got %v", offset_of(ModifiableContact, normal))
+    testing.expectf(t, size_of(ModifiableContact{}.normal) == 12, "Wrong size for ModifiableContact.normal, expected 12 got %v", size_of(ModifiableContact{}.normal))
     testing.expectf(t, offset_of(ModifiableContact, restitution) == 44, "Wrong offset for ModifiableContact.restitution, expected 44 got %v", offset_of(ModifiableContact, restitution))
+    testing.expectf(t, size_of(ModifiableContact{}.restitution) == 4, "Wrong size for ModifiableContact.restitution, expected 4 got %v", size_of(ModifiableContact{}.restitution))
     testing.expectf(t, offset_of(ModifiableContact, materialFlags) == 48, "Wrong offset for ModifiableContact.materialFlags, expected 48 got %v", offset_of(ModifiableContact, materialFlags))
+    testing.expectf(t, size_of(ModifiableContact{}.materialFlags) == 4, "Wrong size for ModifiableContact.materialFlags, expected 4 got %v", size_of(ModifiableContact{}.materialFlags))
     testing.expectf(t, offset_of(ModifiableContact, materialIndex0) == 52, "Wrong offset for ModifiableContact.materialIndex0, expected 52 got %v", offset_of(ModifiableContact, materialIndex0))
+    testing.expectf(t, size_of(ModifiableContact{}.materialIndex0) == 2, "Wrong size for ModifiableContact.materialIndex0, expected 2 got %v", size_of(ModifiableContact{}.materialIndex0))
     testing.expectf(t, offset_of(ModifiableContact, materialIndex1) == 54, "Wrong offset for ModifiableContact.materialIndex1, expected 54 got %v", offset_of(ModifiableContact, materialIndex1))
+    testing.expectf(t, size_of(ModifiableContact{}.materialIndex1) == 2, "Wrong size for ModifiableContact.materialIndex1, expected 2 got %v", size_of(ModifiableContact{}.materialIndex1))
     testing.expectf(t, offset_of(ModifiableContact, staticFriction) == 56, "Wrong offset for ModifiableContact.staticFriction, expected 56 got %v", offset_of(ModifiableContact, staticFriction))
+    testing.expectf(t, size_of(ModifiableContact{}.staticFriction) == 4, "Wrong size for ModifiableContact.staticFriction, expected 4 got %v", size_of(ModifiableContact{}.staticFriction))
     testing.expectf(t, offset_of(ModifiableContact, dynamicFriction) == 60, "Wrong offset for ModifiableContact.dynamicFriction, expected 60 got %v", offset_of(ModifiableContact, dynamicFriction))
+    testing.expectf(t, size_of(ModifiableContact{}.dynamicFriction) == 4, "Wrong size for ModifiableContact.dynamicFriction, expected 4 got %v", size_of(ModifiableContact{}.dynamicFriction))
     testing.expectf(t, size_of(ModifiableContact) == 64, "Wrong size for type ModifiableContact, expected 64 got %v", size_of(ModifiableContact))
 }
 
 @(test)
 test_layout_ContactStreamIterator :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(ContactStreamIterator, zero) == 0, "Wrong offset for ContactStreamIterator.zero, expected 0 got %v", offset_of(ContactStreamIterator, zero))
+    testing.expectf(t, size_of(ContactStreamIterator{}.zero) == 12, "Wrong size for ContactStreamIterator.zero, expected 12 got %v", size_of(ContactStreamIterator{}.zero))
     testing.expectf(t, offset_of(ContactStreamIterator, patch) == 16, "Wrong offset for ContactStreamIterator.patch, expected 16 got %v", offset_of(ContactStreamIterator, patch))
+    testing.expectf(t, size_of(ContactStreamIterator{}.patch) == 8, "Wrong size for ContactStreamIterator.patch, expected 8 got %v", size_of(ContactStreamIterator{}.patch))
     testing.expectf(t, offset_of(ContactStreamIterator, contact) == 24, "Wrong offset for ContactStreamIterator.contact, expected 24 got %v", offset_of(ContactStreamIterator, contact))
+    testing.expectf(t, size_of(ContactStreamIterator{}.contact) == 8, "Wrong size for ContactStreamIterator.contact, expected 8 got %v", size_of(ContactStreamIterator{}.contact))
     testing.expectf(t, offset_of(ContactStreamIterator, faceIndice) == 32, "Wrong offset for ContactStreamIterator.faceIndice, expected 32 got %v", offset_of(ContactStreamIterator, faceIndice))
+    testing.expectf(t, size_of(ContactStreamIterator{}.faceIndice) == 8, "Wrong size for ContactStreamIterator.faceIndice, expected 8 got %v", size_of(ContactStreamIterator{}.faceIndice))
     testing.expectf(t, offset_of(ContactStreamIterator, totalPatches) == 40, "Wrong offset for ContactStreamIterator.totalPatches, expected 40 got %v", offset_of(ContactStreamIterator, totalPatches))
+    testing.expectf(t, size_of(ContactStreamIterator{}.totalPatches) == 4, "Wrong size for ContactStreamIterator.totalPatches, expected 4 got %v", size_of(ContactStreamIterator{}.totalPatches))
     testing.expectf(t, offset_of(ContactStreamIterator, totalContacts) == 44, "Wrong offset for ContactStreamIterator.totalContacts, expected 44 got %v", offset_of(ContactStreamIterator, totalContacts))
+    testing.expectf(t, size_of(ContactStreamIterator{}.totalContacts) == 4, "Wrong size for ContactStreamIterator.totalContacts, expected 4 got %v", size_of(ContactStreamIterator{}.totalContacts))
     testing.expectf(t, offset_of(ContactStreamIterator, nextContactIndex) == 48, "Wrong offset for ContactStreamIterator.nextContactIndex, expected 48 got %v", offset_of(ContactStreamIterator, nextContactIndex))
+    testing.expectf(t, size_of(ContactStreamIterator{}.nextContactIndex) == 4, "Wrong size for ContactStreamIterator.nextContactIndex, expected 4 got %v", size_of(ContactStreamIterator{}.nextContactIndex))
     testing.expectf(t, offset_of(ContactStreamIterator, nextPatchIndex) == 52, "Wrong offset for ContactStreamIterator.nextPatchIndex, expected 52 got %v", offset_of(ContactStreamIterator, nextPatchIndex))
+    testing.expectf(t, size_of(ContactStreamIterator{}.nextPatchIndex) == 4, "Wrong size for ContactStreamIterator.nextPatchIndex, expected 4 got %v", size_of(ContactStreamIterator{}.nextPatchIndex))
     testing.expectf(t, offset_of(ContactStreamIterator, contactPatchHeaderSize) == 56, "Wrong offset for ContactStreamIterator.contactPatchHeaderSize, expected 56 got %v", offset_of(ContactStreamIterator, contactPatchHeaderSize))
+    testing.expectf(t, size_of(ContactStreamIterator{}.contactPatchHeaderSize) == 4, "Wrong size for ContactStreamIterator.contactPatchHeaderSize, expected 4 got %v", size_of(ContactStreamIterator{}.contactPatchHeaderSize))
     testing.expectf(t, offset_of(ContactStreamIterator, contactPointSize) == 60, "Wrong offset for ContactStreamIterator.contactPointSize, expected 60 got %v", offset_of(ContactStreamIterator, contactPointSize))
+    testing.expectf(t, size_of(ContactStreamIterator{}.contactPointSize) == 4, "Wrong size for ContactStreamIterator.contactPointSize, expected 4 got %v", size_of(ContactStreamIterator{}.contactPointSize))
     testing.expectf(t, offset_of(ContactStreamIterator, mStreamFormat) == 64, "Wrong offset for ContactStreamIterator.mStreamFormat, expected 64 got %v", offset_of(ContactStreamIterator, mStreamFormat))
+    testing.expectf(t, size_of(ContactStreamIterator{}.mStreamFormat) == 4, "Wrong size for ContactStreamIterator.mStreamFormat, expected 4 got %v", size_of(ContactStreamIterator{}.mStreamFormat))
     testing.expectf(t, offset_of(ContactStreamIterator, forceNoResponse) == 68, "Wrong offset for ContactStreamIterator.forceNoResponse, expected 68 got %v", offset_of(ContactStreamIterator, forceNoResponse))
+    testing.expectf(t, size_of(ContactStreamIterator{}.forceNoResponse) == 4, "Wrong size for ContactStreamIterator.forceNoResponse, expected 4 got %v", size_of(ContactStreamIterator{}.forceNoResponse))
     testing.expectf(t, offset_of(ContactStreamIterator, pointStepped) == 72, "Wrong offset for ContactStreamIterator.pointStepped, expected 72 got %v", offset_of(ContactStreamIterator, pointStepped))
+    testing.expectf(t, size_of(ContactStreamIterator{}.pointStepped) == 1, "Wrong size for ContactStreamIterator.pointStepped, expected 1 got %v", size_of(ContactStreamIterator{}.pointStepped))
     testing.expectf(t, offset_of(ContactStreamIterator, hasFaceIndices) == 76, "Wrong offset for ContactStreamIterator.hasFaceIndices, expected 76 got %v", offset_of(ContactStreamIterator, hasFaceIndices))
+    testing.expectf(t, size_of(ContactStreamIterator{}.hasFaceIndices) == 4, "Wrong size for ContactStreamIterator.hasFaceIndices, expected 4 got %v", size_of(ContactStreamIterator{}.hasFaceIndices))
     testing.expectf(t, size_of(ContactStreamIterator) == 80, "Wrong size for type ContactStreamIterator, expected 80 got %v", size_of(ContactStreamIterator))
 }
 
 @(test)
 test_layout_GpuContactPair :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(GpuContactPair, contactPatches) == 0, "Wrong offset for GpuContactPair.contactPatches, expected 0 got %v", offset_of(GpuContactPair, contactPatches))
+    testing.expectf(t, size_of(GpuContactPair{}.contactPatches) == 8, "Wrong size for GpuContactPair.contactPatches, expected 8 got %v", size_of(GpuContactPair{}.contactPatches))
     testing.expectf(t, offset_of(GpuContactPair, contactPoints) == 8, "Wrong offset for GpuContactPair.contactPoints, expected 8 got %v", offset_of(GpuContactPair, contactPoints))
+    testing.expectf(t, size_of(GpuContactPair{}.contactPoints) == 8, "Wrong size for GpuContactPair.contactPoints, expected 8 got %v", size_of(GpuContactPair{}.contactPoints))
     testing.expectf(t, offset_of(GpuContactPair, contactForces) == 16, "Wrong offset for GpuContactPair.contactForces, expected 16 got %v", offset_of(GpuContactPair, contactForces))
+    testing.expectf(t, size_of(GpuContactPair{}.contactForces) == 8, "Wrong size for GpuContactPair.contactForces, expected 8 got %v", size_of(GpuContactPair{}.contactForces))
     testing.expectf(t, offset_of(GpuContactPair, transformCacheRef0) == 24, "Wrong offset for GpuContactPair.transformCacheRef0, expected 24 got %v", offset_of(GpuContactPair, transformCacheRef0))
+    testing.expectf(t, size_of(GpuContactPair{}.transformCacheRef0) == 4, "Wrong size for GpuContactPair.transformCacheRef0, expected 4 got %v", size_of(GpuContactPair{}.transformCacheRef0))
     testing.expectf(t, offset_of(GpuContactPair, transformCacheRef1) == 28, "Wrong offset for GpuContactPair.transformCacheRef1, expected 28 got %v", offset_of(GpuContactPair, transformCacheRef1))
+    testing.expectf(t, size_of(GpuContactPair{}.transformCacheRef1) == 4, "Wrong size for GpuContactPair.transformCacheRef1, expected 4 got %v", size_of(GpuContactPair{}.transformCacheRef1))
     testing.expectf(t, offset_of(GpuContactPair, nodeIndex0) == 32, "Wrong offset for GpuContactPair.nodeIndex0, expected 32 got %v", offset_of(GpuContactPair, nodeIndex0))
+    testing.expectf(t, size_of(GpuContactPair{}.nodeIndex0) == 8, "Wrong size for GpuContactPair.nodeIndex0, expected 8 got %v", size_of(GpuContactPair{}.nodeIndex0))
     testing.expectf(t, offset_of(GpuContactPair, nodeIndex1) == 40, "Wrong offset for GpuContactPair.nodeIndex1, expected 40 got %v", offset_of(GpuContactPair, nodeIndex1))
+    testing.expectf(t, size_of(GpuContactPair{}.nodeIndex1) == 8, "Wrong size for GpuContactPair.nodeIndex1, expected 8 got %v", size_of(GpuContactPair{}.nodeIndex1))
     testing.expectf(t, offset_of(GpuContactPair, actor0) == 48, "Wrong offset for GpuContactPair.actor0, expected 48 got %v", offset_of(GpuContactPair, actor0))
+    testing.expectf(t, size_of(GpuContactPair{}.actor0) == 8, "Wrong size for GpuContactPair.actor0, expected 8 got %v", size_of(GpuContactPair{}.actor0))
     testing.expectf(t, offset_of(GpuContactPair, actor1) == 56, "Wrong offset for GpuContactPair.actor1, expected 56 got %v", offset_of(GpuContactPair, actor1))
+    testing.expectf(t, size_of(GpuContactPair{}.actor1) == 8, "Wrong size for GpuContactPair.actor1, expected 8 got %v", size_of(GpuContactPair{}.actor1))
     testing.expectf(t, offset_of(GpuContactPair, nbContacts) == 64, "Wrong offset for GpuContactPair.nbContacts, expected 64 got %v", offset_of(GpuContactPair, nbContacts))
+    testing.expectf(t, size_of(GpuContactPair{}.nbContacts) == 2, "Wrong size for GpuContactPair.nbContacts, expected 2 got %v", size_of(GpuContactPair{}.nbContacts))
     testing.expectf(t, offset_of(GpuContactPair, nbPatches) == 66, "Wrong offset for GpuContactPair.nbPatches, expected 66 got %v", offset_of(GpuContactPair, nbPatches))
+    testing.expectf(t, size_of(GpuContactPair{}.nbPatches) == 2, "Wrong size for GpuContactPair.nbPatches, expected 2 got %v", size_of(GpuContactPair{}.nbPatches))
     testing.expectf(t, size_of(GpuContactPair) == 72, "Wrong size for type GpuContactPair, expected 72 got %v", size_of(GpuContactPair))
 }
 
@@ -1308,6 +1784,7 @@ test_layout_ContactSet :: proc(t: ^testing.T) {
 test_layout_ContactModifyPair :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(ContactModifyPair, contacts) == 88, "Wrong offset for ContactModifyPair.contacts, expected 88 got %v", offset_of(ContactModifyPair, contacts))
+    testing.expectf(t, size_of(ContactModifyPair{}.contacts) == 16, "Wrong size for ContactModifyPair.contacts, expected 16 got %v", size_of(ContactModifyPair{}.contacts))
     testing.expectf(t, size_of(ContactModifyPair) == 104, "Wrong size for type ContactModifyPair, expected 104 got %v", size_of(ContactModifyPair))
 }
 
@@ -1333,6 +1810,7 @@ test_layout_DeletionListener :: proc(t: ^testing.T) {
 test_layout_BaseMaterial :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(BaseMaterial, userData) == 16, "Wrong offset for BaseMaterial.userData, expected 16 got %v", offset_of(BaseMaterial, userData))
+    testing.expectf(t, size_of(BaseMaterial{}.userData) == 8, "Wrong size for BaseMaterial.userData, expected 8 got %v", size_of(BaseMaterial{}.userData))
     testing.expectf(t, size_of(BaseMaterial) == 24, "Wrong size for type BaseMaterial, expected 24 got %v", size_of(BaseMaterial))
 }
 
@@ -1345,9 +1823,14 @@ test_layout_FEMMaterial :: proc(t: ^testing.T) {
 @(test)
 test_layout_FilterData :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(FilterData, word0) == 0, "Wrong offset for FilterData.word0, expected 0 got %v", offset_of(FilterData, word0))
+    testing.expectf(t, size_of(FilterData{}.word0) == 4, "Wrong size for FilterData.word0, expected 4 got %v", size_of(FilterData{}.word0))
     testing.expectf(t, offset_of(FilterData, word1) == 4, "Wrong offset for FilterData.word1, expected 4 got %v", offset_of(FilterData, word1))
+    testing.expectf(t, size_of(FilterData{}.word1) == 4, "Wrong size for FilterData.word1, expected 4 got %v", size_of(FilterData{}.word1))
     testing.expectf(t, offset_of(FilterData, word2) == 8, "Wrong offset for FilterData.word2, expected 8 got %v", offset_of(FilterData, word2))
+    testing.expectf(t, size_of(FilterData{}.word2) == 4, "Wrong size for FilterData.word2, expected 4 got %v", size_of(FilterData{}.word2))
     testing.expectf(t, offset_of(FilterData, word3) == 12, "Wrong offset for FilterData.word3, expected 12 got %v", offset_of(FilterData, word3))
+    testing.expectf(t, size_of(FilterData{}.word3) == 4, "Wrong size for FilterData.word3, expected 4 got %v", size_of(FilterData{}.word3))
     testing.expectf(t, size_of(FilterData) == 16, "Wrong size for type FilterData, expected 16 got %v", size_of(FilterData))
 }
 
@@ -1360,7 +1843,10 @@ test_layout_SimulationFilterCallback :: proc(t: ^testing.T) {
 @(test)
 test_layout_ParticleRigidFilterPair :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(ParticleRigidFilterPair, mID0) == 0, "Wrong offset for ParticleRigidFilterPair.mID0, expected 0 got %v", offset_of(ParticleRigidFilterPair, mID0))
+    testing.expectf(t, size_of(ParticleRigidFilterPair{}.mID0) == 8, "Wrong size for ParticleRigidFilterPair.mID0, expected 8 got %v", size_of(ParticleRigidFilterPair{}.mID0))
     testing.expectf(t, offset_of(ParticleRigidFilterPair, mID1) == 8, "Wrong offset for ParticleRigidFilterPair.mID1, expected 8 got %v", offset_of(ParticleRigidFilterPair, mID1))
+    testing.expectf(t, size_of(ParticleRigidFilterPair{}.mID1) == 8, "Wrong size for ParticleRigidFilterPair.mID1, expected 8 got %v", size_of(ParticleRigidFilterPair{}.mID1))
     testing.expectf(t, size_of(ParticleRigidFilterPair) == 16, "Wrong size for type ParticleRigidFilterPair, expected 16 got %v", size_of(ParticleRigidFilterPair))
 }
 
@@ -1379,41 +1865,66 @@ test_layout_Material :: proc(t: ^testing.T) {
 @(test)
 test_layout_GpuParticleBufferIndexPair :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(GpuParticleBufferIndexPair, systemIndex) == 0, "Wrong offset for GpuParticleBufferIndexPair.systemIndex, expected 0 got %v", offset_of(GpuParticleBufferIndexPair, systemIndex))
+    testing.expectf(t, size_of(GpuParticleBufferIndexPair{}.systemIndex) == 4, "Wrong size for GpuParticleBufferIndexPair.systemIndex, expected 4 got %v", size_of(GpuParticleBufferIndexPair{}.systemIndex))
     testing.expectf(t, offset_of(GpuParticleBufferIndexPair, bufferIndex) == 4, "Wrong offset for GpuParticleBufferIndexPair.bufferIndex, expected 4 got %v", offset_of(GpuParticleBufferIndexPair, bufferIndex))
+    testing.expectf(t, size_of(GpuParticleBufferIndexPair{}.bufferIndex) == 4, "Wrong size for GpuParticleBufferIndexPair.bufferIndex, expected 4 got %v", size_of(GpuParticleBufferIndexPair{}.bufferIndex))
     testing.expectf(t, size_of(GpuParticleBufferIndexPair) == 8, "Wrong size for type GpuParticleBufferIndexPair, expected 8 got %v", size_of(GpuParticleBufferIndexPair))
 }
 
 @(test)
 test_layout_ParticleVolume :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(ParticleVolume, bound) == 0, "Wrong offset for ParticleVolume.bound, expected 0 got %v", offset_of(ParticleVolume, bound))
+    testing.expectf(t, size_of(ParticleVolume{}.bound) == 24, "Wrong size for ParticleVolume.bound, expected 24 got %v", size_of(ParticleVolume{}.bound))
     testing.expectf(t, offset_of(ParticleVolume, particleIndicesOffset) == 24, "Wrong offset for ParticleVolume.particleIndicesOffset, expected 24 got %v", offset_of(ParticleVolume, particleIndicesOffset))
+    testing.expectf(t, size_of(ParticleVolume{}.particleIndicesOffset) == 4, "Wrong size for ParticleVolume.particleIndicesOffset, expected 4 got %v", size_of(ParticleVolume{}.particleIndicesOffset))
     testing.expectf(t, offset_of(ParticleVolume, numParticles) == 28, "Wrong offset for ParticleVolume.numParticles, expected 28 got %v", offset_of(ParticleVolume, numParticles))
+    testing.expectf(t, size_of(ParticleVolume{}.numParticles) == 4, "Wrong size for ParticleVolume.numParticles, expected 4 got %v", size_of(ParticleVolume{}.numParticles))
     testing.expectf(t, size_of(ParticleVolume) == 32, "Wrong size for type ParticleVolume, expected 32 got %v", size_of(ParticleVolume))
 }
 
 @(test)
 test_layout_DiffuseParticleParams :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(DiffuseParticleParams, threshold) == 0, "Wrong offset for DiffuseParticleParams.threshold, expected 0 got %v", offset_of(DiffuseParticleParams, threshold))
+    testing.expectf(t, size_of(DiffuseParticleParams{}.threshold) == 4, "Wrong size for DiffuseParticleParams.threshold, expected 4 got %v", size_of(DiffuseParticleParams{}.threshold))
     testing.expectf(t, offset_of(DiffuseParticleParams, lifetime) == 4, "Wrong offset for DiffuseParticleParams.lifetime, expected 4 got %v", offset_of(DiffuseParticleParams, lifetime))
+    testing.expectf(t, size_of(DiffuseParticleParams{}.lifetime) == 4, "Wrong size for DiffuseParticleParams.lifetime, expected 4 got %v", size_of(DiffuseParticleParams{}.lifetime))
     testing.expectf(t, offset_of(DiffuseParticleParams, airDrag) == 8, "Wrong offset for DiffuseParticleParams.airDrag, expected 8 got %v", offset_of(DiffuseParticleParams, airDrag))
+    testing.expectf(t, size_of(DiffuseParticleParams{}.airDrag) == 4, "Wrong size for DiffuseParticleParams.airDrag, expected 4 got %v", size_of(DiffuseParticleParams{}.airDrag))
     testing.expectf(t, offset_of(DiffuseParticleParams, bubbleDrag) == 12, "Wrong offset for DiffuseParticleParams.bubbleDrag, expected 12 got %v", offset_of(DiffuseParticleParams, bubbleDrag))
+    testing.expectf(t, size_of(DiffuseParticleParams{}.bubbleDrag) == 4, "Wrong size for DiffuseParticleParams.bubbleDrag, expected 4 got %v", size_of(DiffuseParticleParams{}.bubbleDrag))
     testing.expectf(t, offset_of(DiffuseParticleParams, buoyancy) == 16, "Wrong offset for DiffuseParticleParams.buoyancy, expected 16 got %v", offset_of(DiffuseParticleParams, buoyancy))
+    testing.expectf(t, size_of(DiffuseParticleParams{}.buoyancy) == 4, "Wrong size for DiffuseParticleParams.buoyancy, expected 4 got %v", size_of(DiffuseParticleParams{}.buoyancy))
     testing.expectf(t, offset_of(DiffuseParticleParams, kineticEnergyWeight) == 20, "Wrong offset for DiffuseParticleParams.kineticEnergyWeight, expected 20 got %v", offset_of(DiffuseParticleParams, kineticEnergyWeight))
+    testing.expectf(t, size_of(DiffuseParticleParams{}.kineticEnergyWeight) == 4, "Wrong size for DiffuseParticleParams.kineticEnergyWeight, expected 4 got %v", size_of(DiffuseParticleParams{}.kineticEnergyWeight))
     testing.expectf(t, offset_of(DiffuseParticleParams, pressureWeight) == 24, "Wrong offset for DiffuseParticleParams.pressureWeight, expected 24 got %v", offset_of(DiffuseParticleParams, pressureWeight))
+    testing.expectf(t, size_of(DiffuseParticleParams{}.pressureWeight) == 4, "Wrong size for DiffuseParticleParams.pressureWeight, expected 4 got %v", size_of(DiffuseParticleParams{}.pressureWeight))
     testing.expectf(t, offset_of(DiffuseParticleParams, divergenceWeight) == 28, "Wrong offset for DiffuseParticleParams.divergenceWeight, expected 28 got %v", offset_of(DiffuseParticleParams, divergenceWeight))
+    testing.expectf(t, size_of(DiffuseParticleParams{}.divergenceWeight) == 4, "Wrong size for DiffuseParticleParams.divergenceWeight, expected 4 got %v", size_of(DiffuseParticleParams{}.divergenceWeight))
     testing.expectf(t, offset_of(DiffuseParticleParams, collisionDecay) == 32, "Wrong offset for DiffuseParticleParams.collisionDecay, expected 32 got %v", offset_of(DiffuseParticleParams, collisionDecay))
+    testing.expectf(t, size_of(DiffuseParticleParams{}.collisionDecay) == 4, "Wrong size for DiffuseParticleParams.collisionDecay, expected 4 got %v", size_of(DiffuseParticleParams{}.collisionDecay))
     testing.expectf(t, offset_of(DiffuseParticleParams, useAccurateVelocity) == 36, "Wrong offset for DiffuseParticleParams.useAccurateVelocity, expected 36 got %v", offset_of(DiffuseParticleParams, useAccurateVelocity))
+    testing.expectf(t, size_of(DiffuseParticleParams{}.useAccurateVelocity) == 1, "Wrong size for DiffuseParticleParams.useAccurateVelocity, expected 1 got %v", size_of(DiffuseParticleParams{}.useAccurateVelocity))
     testing.expectf(t, size_of(DiffuseParticleParams) == 40, "Wrong size for type DiffuseParticleParams, expected 40 got %v", size_of(DiffuseParticleParams))
 }
 
 @(test)
 test_layout_ParticleSpring :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(ParticleSpring, ind0) == 0, "Wrong offset for ParticleSpring.ind0, expected 0 got %v", offset_of(ParticleSpring, ind0))
+    testing.expectf(t, size_of(ParticleSpring{}.ind0) == 4, "Wrong size for ParticleSpring.ind0, expected 4 got %v", size_of(ParticleSpring{}.ind0))
     testing.expectf(t, offset_of(ParticleSpring, ind1) == 4, "Wrong offset for ParticleSpring.ind1, expected 4 got %v", offset_of(ParticleSpring, ind1))
+    testing.expectf(t, size_of(ParticleSpring{}.ind1) == 4, "Wrong size for ParticleSpring.ind1, expected 4 got %v", size_of(ParticleSpring{}.ind1))
     testing.expectf(t, offset_of(ParticleSpring, length) == 8, "Wrong offset for ParticleSpring.length, expected 8 got %v", offset_of(ParticleSpring, length))
+    testing.expectf(t, size_of(ParticleSpring{}.length) == 4, "Wrong size for ParticleSpring.length, expected 4 got %v", size_of(ParticleSpring{}.length))
     testing.expectf(t, offset_of(ParticleSpring, stiffness) == 12, "Wrong offset for ParticleSpring.stiffness, expected 12 got %v", offset_of(ParticleSpring, stiffness))
+    testing.expectf(t, size_of(ParticleSpring{}.stiffness) == 4, "Wrong size for ParticleSpring.stiffness, expected 4 got %v", size_of(ParticleSpring{}.stiffness))
     testing.expectf(t, offset_of(ParticleSpring, damping) == 16, "Wrong offset for ParticleSpring.damping, expected 16 got %v", offset_of(ParticleSpring, damping))
+    testing.expectf(t, size_of(ParticleSpring{}.damping) == 4, "Wrong size for ParticleSpring.damping, expected 4 got %v", size_of(ParticleSpring{}.damping))
     testing.expectf(t, offset_of(ParticleSpring, pad) == 20, "Wrong offset for ParticleSpring.pad, expected 20 got %v", offset_of(ParticleSpring, pad))
+    testing.expectf(t, size_of(ParticleSpring{}.pad) == 4, "Wrong size for ParticleSpring.pad, expected 4 got %v", size_of(ParticleSpring{}.pad))
     testing.expectf(t, size_of(ParticleSpring) == 24, "Wrong size for type ParticleSpring, expected 24 got %v", size_of(ParticleSpring))
 }
 
@@ -1432,7 +1943,10 @@ test_layout_Physics :: proc(t: ^testing.T) {
 @(test)
 test_layout_ActorShape :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(ActorShape, actor) == 0, "Wrong offset for ActorShape.actor, expected 0 got %v", offset_of(ActorShape, actor))
+    testing.expectf(t, size_of(ActorShape{}.actor) == 8, "Wrong size for ActorShape.actor, expected 8 got %v", size_of(ActorShape{}.actor))
     testing.expectf(t, offset_of(ActorShape, shape) == 8, "Wrong offset for ActorShape.shape, expected 8 got %v", offset_of(ActorShape, shape))
+    testing.expectf(t, size_of(ActorShape{}.shape) == 8, "Wrong size for ActorShape.shape, expected 8 got %v", size_of(ActorShape{}.shape))
     testing.expectf(t, size_of(ActorShape) == 16, "Wrong size for type ActorShape, expected 16 got %v", size_of(ActorShape))
 }
 
@@ -1458,10 +1972,15 @@ test_layout_SweepHit :: proc(t: ^testing.T) {
 test_layout_RaycastCallback :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(RaycastCallback, block) == 8, "Wrong offset for RaycastCallback.block, expected 8 got %v", offset_of(RaycastCallback, block))
+    testing.expectf(t, size_of(RaycastCallback{}.block) == 64, "Wrong size for RaycastCallback.block, expected 64 got %v", size_of(RaycastCallback{}.block))
     testing.expectf(t, offset_of(RaycastCallback, hasBlock) == 72, "Wrong offset for RaycastCallback.hasBlock, expected 72 got %v", offset_of(RaycastCallback, hasBlock))
+    testing.expectf(t, size_of(RaycastCallback{}.hasBlock) == 1, "Wrong size for RaycastCallback.hasBlock, expected 1 got %v", size_of(RaycastCallback{}.hasBlock))
     testing.expectf(t, offset_of(RaycastCallback, touches) == 80, "Wrong offset for RaycastCallback.touches, expected 80 got %v", offset_of(RaycastCallback, touches))
+    testing.expectf(t, size_of(RaycastCallback{}.touches) == 8, "Wrong size for RaycastCallback.touches, expected 8 got %v", size_of(RaycastCallback{}.touches))
     testing.expectf(t, offset_of(RaycastCallback, maxNbTouches) == 88, "Wrong offset for RaycastCallback.maxNbTouches, expected 88 got %v", offset_of(RaycastCallback, maxNbTouches))
+    testing.expectf(t, size_of(RaycastCallback{}.maxNbTouches) == 4, "Wrong size for RaycastCallback.maxNbTouches, expected 4 got %v", size_of(RaycastCallback{}.maxNbTouches))
     testing.expectf(t, offset_of(RaycastCallback, nbTouches) == 92, "Wrong offset for RaycastCallback.nbTouches, expected 92 got %v", offset_of(RaycastCallback, nbTouches))
+    testing.expectf(t, size_of(RaycastCallback{}.nbTouches) == 4, "Wrong size for RaycastCallback.nbTouches, expected 4 got %v", size_of(RaycastCallback{}.nbTouches))
     testing.expectf(t, size_of(RaycastCallback) == 96, "Wrong size for type RaycastCallback, expected 96 got %v", size_of(RaycastCallback))
 }
 
@@ -1469,10 +1988,15 @@ test_layout_RaycastCallback :: proc(t: ^testing.T) {
 test_layout_OverlapCallback :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(OverlapCallback, block) == 8, "Wrong offset for OverlapCallback.block, expected 8 got %v", offset_of(OverlapCallback, block))
+    testing.expectf(t, size_of(OverlapCallback{}.block) == 24, "Wrong size for OverlapCallback.block, expected 24 got %v", size_of(OverlapCallback{}.block))
     testing.expectf(t, offset_of(OverlapCallback, hasBlock) == 32, "Wrong offset for OverlapCallback.hasBlock, expected 32 got %v", offset_of(OverlapCallback, hasBlock))
+    testing.expectf(t, size_of(OverlapCallback{}.hasBlock) == 1, "Wrong size for OverlapCallback.hasBlock, expected 1 got %v", size_of(OverlapCallback{}.hasBlock))
     testing.expectf(t, offset_of(OverlapCallback, touches) == 40, "Wrong offset for OverlapCallback.touches, expected 40 got %v", offset_of(OverlapCallback, touches))
+    testing.expectf(t, size_of(OverlapCallback{}.touches) == 8, "Wrong size for OverlapCallback.touches, expected 8 got %v", size_of(OverlapCallback{}.touches))
     testing.expectf(t, offset_of(OverlapCallback, maxNbTouches) == 48, "Wrong offset for OverlapCallback.maxNbTouches, expected 48 got %v", offset_of(OverlapCallback, maxNbTouches))
+    testing.expectf(t, size_of(OverlapCallback{}.maxNbTouches) == 4, "Wrong size for OverlapCallback.maxNbTouches, expected 4 got %v", size_of(OverlapCallback{}.maxNbTouches))
     testing.expectf(t, offset_of(OverlapCallback, nbTouches) == 52, "Wrong offset for OverlapCallback.nbTouches, expected 52 got %v", offset_of(OverlapCallback, nbTouches))
+    testing.expectf(t, size_of(OverlapCallback{}.nbTouches) == 4, "Wrong size for OverlapCallback.nbTouches, expected 4 got %v", size_of(OverlapCallback{}.nbTouches))
     testing.expectf(t, size_of(OverlapCallback) == 56, "Wrong size for type OverlapCallback, expected 56 got %v", size_of(OverlapCallback))
 }
 
@@ -1480,10 +2004,15 @@ test_layout_OverlapCallback :: proc(t: ^testing.T) {
 test_layout_SweepCallback :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(SweepCallback, block) == 8, "Wrong offset for SweepCallback.block, expected 8 got %v", offset_of(SweepCallback, block))
+    testing.expectf(t, size_of(SweepCallback{}.block) == 56, "Wrong size for SweepCallback.block, expected 56 got %v", size_of(SweepCallback{}.block))
     testing.expectf(t, offset_of(SweepCallback, hasBlock) == 64, "Wrong offset for SweepCallback.hasBlock, expected 64 got %v", offset_of(SweepCallback, hasBlock))
+    testing.expectf(t, size_of(SweepCallback{}.hasBlock) == 1, "Wrong size for SweepCallback.hasBlock, expected 1 got %v", size_of(SweepCallback{}.hasBlock))
     testing.expectf(t, offset_of(SweepCallback, touches) == 72, "Wrong offset for SweepCallback.touches, expected 72 got %v", offset_of(SweepCallback, touches))
+    testing.expectf(t, size_of(SweepCallback{}.touches) == 8, "Wrong size for SweepCallback.touches, expected 8 got %v", size_of(SweepCallback{}.touches))
     testing.expectf(t, offset_of(SweepCallback, maxNbTouches) == 80, "Wrong offset for SweepCallback.maxNbTouches, expected 80 got %v", offset_of(SweepCallback, maxNbTouches))
+    testing.expectf(t, size_of(SweepCallback{}.maxNbTouches) == 4, "Wrong size for SweepCallback.maxNbTouches, expected 4 got %v", size_of(SweepCallback{}.maxNbTouches))
     testing.expectf(t, offset_of(SweepCallback, nbTouches) == 84, "Wrong offset for SweepCallback.nbTouches, expected 84 got %v", offset_of(SweepCallback, nbTouches))
+    testing.expectf(t, size_of(SweepCallback{}.nbTouches) == 4, "Wrong size for SweepCallback.nbTouches, expected 4 got %v", size_of(SweepCallback{}.nbTouches))
     testing.expectf(t, size_of(SweepCallback) == 88, "Wrong size for type SweepCallback, expected 88 got %v", size_of(SweepCallback))
 }
 
@@ -1491,10 +2020,15 @@ test_layout_SweepCallback :: proc(t: ^testing.T) {
 test_layout_RaycastBuffer :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(RaycastBuffer, block) == 8, "Wrong offset for RaycastBuffer.block, expected 8 got %v", offset_of(RaycastBuffer, block))
+    testing.expectf(t, size_of(RaycastBuffer{}.block) == 64, "Wrong size for RaycastBuffer.block, expected 64 got %v", size_of(RaycastBuffer{}.block))
     testing.expectf(t, offset_of(RaycastBuffer, hasBlock) == 72, "Wrong offset for RaycastBuffer.hasBlock, expected 72 got %v", offset_of(RaycastBuffer, hasBlock))
+    testing.expectf(t, size_of(RaycastBuffer{}.hasBlock) == 1, "Wrong size for RaycastBuffer.hasBlock, expected 1 got %v", size_of(RaycastBuffer{}.hasBlock))
     testing.expectf(t, offset_of(RaycastBuffer, touches) == 80, "Wrong offset for RaycastBuffer.touches, expected 80 got %v", offset_of(RaycastBuffer, touches))
+    testing.expectf(t, size_of(RaycastBuffer{}.touches) == 8, "Wrong size for RaycastBuffer.touches, expected 8 got %v", size_of(RaycastBuffer{}.touches))
     testing.expectf(t, offset_of(RaycastBuffer, maxNbTouches) == 88, "Wrong offset for RaycastBuffer.maxNbTouches, expected 88 got %v", offset_of(RaycastBuffer, maxNbTouches))
+    testing.expectf(t, size_of(RaycastBuffer{}.maxNbTouches) == 4, "Wrong size for RaycastBuffer.maxNbTouches, expected 4 got %v", size_of(RaycastBuffer{}.maxNbTouches))
     testing.expectf(t, offset_of(RaycastBuffer, nbTouches) == 92, "Wrong offset for RaycastBuffer.nbTouches, expected 92 got %v", offset_of(RaycastBuffer, nbTouches))
+    testing.expectf(t, size_of(RaycastBuffer{}.nbTouches) == 4, "Wrong size for RaycastBuffer.nbTouches, expected 4 got %v", size_of(RaycastBuffer{}.nbTouches))
     testing.expectf(t, size_of(RaycastBuffer) == 96, "Wrong size for type RaycastBuffer, expected 96 got %v", size_of(RaycastBuffer))
 }
 
@@ -1502,10 +2036,15 @@ test_layout_RaycastBuffer :: proc(t: ^testing.T) {
 test_layout_OverlapBuffer :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(OverlapBuffer, block) == 8, "Wrong offset for OverlapBuffer.block, expected 8 got %v", offset_of(OverlapBuffer, block))
+    testing.expectf(t, size_of(OverlapBuffer{}.block) == 24, "Wrong size for OverlapBuffer.block, expected 24 got %v", size_of(OverlapBuffer{}.block))
     testing.expectf(t, offset_of(OverlapBuffer, hasBlock) == 32, "Wrong offset for OverlapBuffer.hasBlock, expected 32 got %v", offset_of(OverlapBuffer, hasBlock))
+    testing.expectf(t, size_of(OverlapBuffer{}.hasBlock) == 1, "Wrong size for OverlapBuffer.hasBlock, expected 1 got %v", size_of(OverlapBuffer{}.hasBlock))
     testing.expectf(t, offset_of(OverlapBuffer, touches) == 40, "Wrong offset for OverlapBuffer.touches, expected 40 got %v", offset_of(OverlapBuffer, touches))
+    testing.expectf(t, size_of(OverlapBuffer{}.touches) == 8, "Wrong size for OverlapBuffer.touches, expected 8 got %v", size_of(OverlapBuffer{}.touches))
     testing.expectf(t, offset_of(OverlapBuffer, maxNbTouches) == 48, "Wrong offset for OverlapBuffer.maxNbTouches, expected 48 got %v", offset_of(OverlapBuffer, maxNbTouches))
+    testing.expectf(t, size_of(OverlapBuffer{}.maxNbTouches) == 4, "Wrong size for OverlapBuffer.maxNbTouches, expected 4 got %v", size_of(OverlapBuffer{}.maxNbTouches))
     testing.expectf(t, offset_of(OverlapBuffer, nbTouches) == 52, "Wrong offset for OverlapBuffer.nbTouches, expected 52 got %v", offset_of(OverlapBuffer, nbTouches))
+    testing.expectf(t, size_of(OverlapBuffer{}.nbTouches) == 4, "Wrong size for OverlapBuffer.nbTouches, expected 4 got %v", size_of(OverlapBuffer{}.nbTouches))
     testing.expectf(t, size_of(OverlapBuffer) == 56, "Wrong size for type OverlapBuffer, expected 56 got %v", size_of(OverlapBuffer))
 }
 
@@ -1513,25 +2052,37 @@ test_layout_OverlapBuffer :: proc(t: ^testing.T) {
 test_layout_SweepBuffer :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(SweepBuffer, block) == 8, "Wrong offset for SweepBuffer.block, expected 8 got %v", offset_of(SweepBuffer, block))
+    testing.expectf(t, size_of(SweepBuffer{}.block) == 56, "Wrong size for SweepBuffer.block, expected 56 got %v", size_of(SweepBuffer{}.block))
     testing.expectf(t, offset_of(SweepBuffer, hasBlock) == 64, "Wrong offset for SweepBuffer.hasBlock, expected 64 got %v", offset_of(SweepBuffer, hasBlock))
+    testing.expectf(t, size_of(SweepBuffer{}.hasBlock) == 1, "Wrong size for SweepBuffer.hasBlock, expected 1 got %v", size_of(SweepBuffer{}.hasBlock))
     testing.expectf(t, offset_of(SweepBuffer, touches) == 72, "Wrong offset for SweepBuffer.touches, expected 72 got %v", offset_of(SweepBuffer, touches))
+    testing.expectf(t, size_of(SweepBuffer{}.touches) == 8, "Wrong size for SweepBuffer.touches, expected 8 got %v", size_of(SweepBuffer{}.touches))
     testing.expectf(t, offset_of(SweepBuffer, maxNbTouches) == 80, "Wrong offset for SweepBuffer.maxNbTouches, expected 80 got %v", offset_of(SweepBuffer, maxNbTouches))
+    testing.expectf(t, size_of(SweepBuffer{}.maxNbTouches) == 4, "Wrong size for SweepBuffer.maxNbTouches, expected 4 got %v", size_of(SweepBuffer{}.maxNbTouches))
     testing.expectf(t, offset_of(SweepBuffer, nbTouches) == 84, "Wrong offset for SweepBuffer.nbTouches, expected 84 got %v", offset_of(SweepBuffer, nbTouches))
+    testing.expectf(t, size_of(SweepBuffer{}.nbTouches) == 4, "Wrong size for SweepBuffer.nbTouches, expected 4 got %v", size_of(SweepBuffer{}.nbTouches))
     testing.expectf(t, size_of(SweepBuffer) == 88, "Wrong size for type SweepBuffer, expected 88 got %v", size_of(SweepBuffer))
 }
 
 @(test)
 test_layout_QueryCache :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(QueryCache, shape) == 0, "Wrong offset for QueryCache.shape, expected 0 got %v", offset_of(QueryCache, shape))
+    testing.expectf(t, size_of(QueryCache{}.shape) == 8, "Wrong size for QueryCache.shape, expected 8 got %v", size_of(QueryCache{}.shape))
     testing.expectf(t, offset_of(QueryCache, actor) == 8, "Wrong offset for QueryCache.actor, expected 8 got %v", offset_of(QueryCache, actor))
+    testing.expectf(t, size_of(QueryCache{}.actor) == 8, "Wrong size for QueryCache.actor, expected 8 got %v", size_of(QueryCache{}.actor))
     testing.expectf(t, offset_of(QueryCache, faceIndex) == 16, "Wrong offset for QueryCache.faceIndex, expected 16 got %v", offset_of(QueryCache, faceIndex))
+    testing.expectf(t, size_of(QueryCache{}.faceIndex) == 4, "Wrong size for QueryCache.faceIndex, expected 4 got %v", size_of(QueryCache{}.faceIndex))
     testing.expectf(t, size_of(QueryCache) == 24, "Wrong size for type QueryCache, expected 24 got %v", size_of(QueryCache))
 }
 
 @(test)
 test_layout_QueryFilterData :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(QueryFilterData, data) == 0, "Wrong offset for QueryFilterData.data, expected 0 got %v", offset_of(QueryFilterData, data))
+    testing.expectf(t, size_of(QueryFilterData{}.data) == 16, "Wrong size for QueryFilterData.data, expected 16 got %v", size_of(QueryFilterData{}.data))
     testing.expectf(t, offset_of(QueryFilterData, flags) == 16, "Wrong offset for QueryFilterData.flags, expected 16 got %v", offset_of(QueryFilterData, flags))
+    testing.expectf(t, size_of(QueryFilterData{}.flags) == 2, "Wrong size for QueryFilterData.flags, expected 2 got %v", size_of(QueryFilterData{}.flags))
     testing.expectf(t, size_of(QueryFilterData) == 20, "Wrong size for type QueryFilterData, expected 20 got %v", size_of(QueryFilterData))
 }
 
@@ -1556,14 +2107,24 @@ test_layout_RigidStatic :: proc(t: ^testing.T) {
 @(test)
 test_layout_SceneQueryDesc :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(SceneQueryDesc, staticStructure) == 0, "Wrong offset for SceneQueryDesc.staticStructure, expected 0 got %v", offset_of(SceneQueryDesc, staticStructure))
+    testing.expectf(t, size_of(SceneQueryDesc{}.staticStructure) == 4, "Wrong size for SceneQueryDesc.staticStructure, expected 4 got %v", size_of(SceneQueryDesc{}.staticStructure))
     testing.expectf(t, offset_of(SceneQueryDesc, dynamicStructure) == 4, "Wrong offset for SceneQueryDesc.dynamicStructure, expected 4 got %v", offset_of(SceneQueryDesc, dynamicStructure))
+    testing.expectf(t, size_of(SceneQueryDesc{}.dynamicStructure) == 4, "Wrong size for SceneQueryDesc.dynamicStructure, expected 4 got %v", size_of(SceneQueryDesc{}.dynamicStructure))
     testing.expectf(t, offset_of(SceneQueryDesc, dynamicTreeRebuildRateHint) == 8, "Wrong offset for SceneQueryDesc.dynamicTreeRebuildRateHint, expected 8 got %v", offset_of(SceneQueryDesc, dynamicTreeRebuildRateHint))
+    testing.expectf(t, size_of(SceneQueryDesc{}.dynamicTreeRebuildRateHint) == 4, "Wrong size for SceneQueryDesc.dynamicTreeRebuildRateHint, expected 4 got %v", size_of(SceneQueryDesc{}.dynamicTreeRebuildRateHint))
     testing.expectf(t, offset_of(SceneQueryDesc, dynamicTreeSecondaryPruner) == 12, "Wrong offset for SceneQueryDesc.dynamicTreeSecondaryPruner, expected 12 got %v", offset_of(SceneQueryDesc, dynamicTreeSecondaryPruner))
+    testing.expectf(t, size_of(SceneQueryDesc{}.dynamicTreeSecondaryPruner) == 4, "Wrong size for SceneQueryDesc.dynamicTreeSecondaryPruner, expected 4 got %v", size_of(SceneQueryDesc{}.dynamicTreeSecondaryPruner))
     testing.expectf(t, offset_of(SceneQueryDesc, staticBVHBuildStrategy) == 16, "Wrong offset for SceneQueryDesc.staticBVHBuildStrategy, expected 16 got %v", offset_of(SceneQueryDesc, staticBVHBuildStrategy))
+    testing.expectf(t, size_of(SceneQueryDesc{}.staticBVHBuildStrategy) == 4, "Wrong size for SceneQueryDesc.staticBVHBuildStrategy, expected 4 got %v", size_of(SceneQueryDesc{}.staticBVHBuildStrategy))
     testing.expectf(t, offset_of(SceneQueryDesc, dynamicBVHBuildStrategy) == 20, "Wrong offset for SceneQueryDesc.dynamicBVHBuildStrategy, expected 20 got %v", offset_of(SceneQueryDesc, dynamicBVHBuildStrategy))
+    testing.expectf(t, size_of(SceneQueryDesc{}.dynamicBVHBuildStrategy) == 4, "Wrong size for SceneQueryDesc.dynamicBVHBuildStrategy, expected 4 got %v", size_of(SceneQueryDesc{}.dynamicBVHBuildStrategy))
     testing.expectf(t, offset_of(SceneQueryDesc, staticNbObjectsPerNode) == 24, "Wrong offset for SceneQueryDesc.staticNbObjectsPerNode, expected 24 got %v", offset_of(SceneQueryDesc, staticNbObjectsPerNode))
+    testing.expectf(t, size_of(SceneQueryDesc{}.staticNbObjectsPerNode) == 4, "Wrong size for SceneQueryDesc.staticNbObjectsPerNode, expected 4 got %v", size_of(SceneQueryDesc{}.staticNbObjectsPerNode))
     testing.expectf(t, offset_of(SceneQueryDesc, dynamicNbObjectsPerNode) == 28, "Wrong offset for SceneQueryDesc.dynamicNbObjectsPerNode, expected 28 got %v", offset_of(SceneQueryDesc, dynamicNbObjectsPerNode))
+    testing.expectf(t, size_of(SceneQueryDesc{}.dynamicNbObjectsPerNode) == 4, "Wrong size for SceneQueryDesc.dynamicNbObjectsPerNode, expected 4 got %v", size_of(SceneQueryDesc{}.dynamicNbObjectsPerNode))
     testing.expectf(t, offset_of(SceneQueryDesc, sceneQueryUpdateMode) == 32, "Wrong offset for SceneQueryDesc.sceneQueryUpdateMode, expected 32 got %v", offset_of(SceneQueryDesc, sceneQueryUpdateMode))
+    testing.expectf(t, size_of(SceneQueryDesc{}.sceneQueryUpdateMode) == 4, "Wrong size for SceneQueryDesc.sceneQueryUpdateMode, expected 4 got %v", size_of(SceneQueryDesc{}.sceneQueryUpdateMode))
     testing.expectf(t, size_of(SceneQueryDesc) == 36, "Wrong size for type SceneQueryDesc, expected 36 got %v", size_of(SceneQueryDesc))
 }
 
@@ -1588,64 +2149,100 @@ test_layout_SceneQuerySystem :: proc(t: ^testing.T) {
 @(test)
 test_layout_BroadPhaseRegion :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(BroadPhaseRegion, mBounds) == 0, "Wrong offset for BroadPhaseRegion.mBounds, expected 0 got %v", offset_of(BroadPhaseRegion, mBounds))
+    testing.expectf(t, size_of(BroadPhaseRegion{}.mBounds) == 24, "Wrong size for BroadPhaseRegion.mBounds, expected 24 got %v", size_of(BroadPhaseRegion{}.mBounds))
     testing.expectf(t, offset_of(BroadPhaseRegion, mUserData) == 24, "Wrong offset for BroadPhaseRegion.mUserData, expected 24 got %v", offset_of(BroadPhaseRegion, mUserData))
+    testing.expectf(t, size_of(BroadPhaseRegion{}.mUserData) == 8, "Wrong size for BroadPhaseRegion.mUserData, expected 8 got %v", size_of(BroadPhaseRegion{}.mUserData))
     testing.expectf(t, size_of(BroadPhaseRegion) == 32, "Wrong size for type BroadPhaseRegion, expected 32 got %v", size_of(BroadPhaseRegion))
 }
 
 @(test)
 test_layout_BroadPhaseRegionInfo :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(BroadPhaseRegionInfo, mRegion) == 0, "Wrong offset for BroadPhaseRegionInfo.mRegion, expected 0 got %v", offset_of(BroadPhaseRegionInfo, mRegion))
+    testing.expectf(t, size_of(BroadPhaseRegionInfo{}.mRegion) == 32, "Wrong size for BroadPhaseRegionInfo.mRegion, expected 32 got %v", size_of(BroadPhaseRegionInfo{}.mRegion))
     testing.expectf(t, offset_of(BroadPhaseRegionInfo, mNbStaticObjects) == 32, "Wrong offset for BroadPhaseRegionInfo.mNbStaticObjects, expected 32 got %v", offset_of(BroadPhaseRegionInfo, mNbStaticObjects))
+    testing.expectf(t, size_of(BroadPhaseRegionInfo{}.mNbStaticObjects) == 4, "Wrong size for BroadPhaseRegionInfo.mNbStaticObjects, expected 4 got %v", size_of(BroadPhaseRegionInfo{}.mNbStaticObjects))
     testing.expectf(t, offset_of(BroadPhaseRegionInfo, mNbDynamicObjects) == 36, "Wrong offset for BroadPhaseRegionInfo.mNbDynamicObjects, expected 36 got %v", offset_of(BroadPhaseRegionInfo, mNbDynamicObjects))
+    testing.expectf(t, size_of(BroadPhaseRegionInfo{}.mNbDynamicObjects) == 4, "Wrong size for BroadPhaseRegionInfo.mNbDynamicObjects, expected 4 got %v", size_of(BroadPhaseRegionInfo{}.mNbDynamicObjects))
     testing.expectf(t, offset_of(BroadPhaseRegionInfo, mActive) == 40, "Wrong offset for BroadPhaseRegionInfo.mActive, expected 40 got %v", offset_of(BroadPhaseRegionInfo, mActive))
+    testing.expectf(t, size_of(BroadPhaseRegionInfo{}.mActive) == 1, "Wrong size for BroadPhaseRegionInfo.mActive, expected 1 got %v", size_of(BroadPhaseRegionInfo{}.mActive))
     testing.expectf(t, offset_of(BroadPhaseRegionInfo, mOverlap) == 41, "Wrong offset for BroadPhaseRegionInfo.mOverlap, expected 41 got %v", offset_of(BroadPhaseRegionInfo, mOverlap))
+    testing.expectf(t, size_of(BroadPhaseRegionInfo{}.mOverlap) == 1, "Wrong size for BroadPhaseRegionInfo.mOverlap, expected 1 got %v", size_of(BroadPhaseRegionInfo{}.mOverlap))
     testing.expectf(t, size_of(BroadPhaseRegionInfo) == 48, "Wrong size for type BroadPhaseRegionInfo, expected 48 got %v", size_of(BroadPhaseRegionInfo))
 }
 
 @(test)
 test_layout_BroadPhaseCaps :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(BroadPhaseCaps, mMaxNbRegions) == 0, "Wrong offset for BroadPhaseCaps.mMaxNbRegions, expected 0 got %v", offset_of(BroadPhaseCaps, mMaxNbRegions))
+    testing.expectf(t, size_of(BroadPhaseCaps{}.mMaxNbRegions) == 4, "Wrong size for BroadPhaseCaps.mMaxNbRegions, expected 4 got %v", size_of(BroadPhaseCaps{}.mMaxNbRegions))
     testing.expectf(t, size_of(BroadPhaseCaps) == 4, "Wrong size for type BroadPhaseCaps, expected 4 got %v", size_of(BroadPhaseCaps))
 }
 
 @(test)
 test_layout_BroadPhaseDesc :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(BroadPhaseDesc, mType) == 0, "Wrong offset for BroadPhaseDesc.mType, expected 0 got %v", offset_of(BroadPhaseDesc, mType))
+    testing.expectf(t, size_of(BroadPhaseDesc{}.mType) == 4, "Wrong size for BroadPhaseDesc.mType, expected 4 got %v", size_of(BroadPhaseDesc{}.mType))
     testing.expectf(t, offset_of(BroadPhaseDesc, mContextID) == 8, "Wrong offset for BroadPhaseDesc.mContextID, expected 8 got %v", offset_of(BroadPhaseDesc, mContextID))
+    testing.expectf(t, size_of(BroadPhaseDesc{}.mContextID) == 8, "Wrong size for BroadPhaseDesc.mContextID, expected 8 got %v", size_of(BroadPhaseDesc{}.mContextID))
     testing.expectf(t, offset_of(BroadPhaseDesc, mFoundLostPairsCapacity) == 24, "Wrong offset for BroadPhaseDesc.mFoundLostPairsCapacity, expected 24 got %v", offset_of(BroadPhaseDesc, mFoundLostPairsCapacity))
+    testing.expectf(t, size_of(BroadPhaseDesc{}.mFoundLostPairsCapacity) == 4, "Wrong size for BroadPhaseDesc.mFoundLostPairsCapacity, expected 4 got %v", size_of(BroadPhaseDesc{}.mFoundLostPairsCapacity))
     testing.expectf(t, offset_of(BroadPhaseDesc, mDiscardStaticVsKinematic) == 28, "Wrong offset for BroadPhaseDesc.mDiscardStaticVsKinematic, expected 28 got %v", offset_of(BroadPhaseDesc, mDiscardStaticVsKinematic))
+    testing.expectf(t, size_of(BroadPhaseDesc{}.mDiscardStaticVsKinematic) == 1, "Wrong size for BroadPhaseDesc.mDiscardStaticVsKinematic, expected 1 got %v", size_of(BroadPhaseDesc{}.mDiscardStaticVsKinematic))
     testing.expectf(t, offset_of(BroadPhaseDesc, mDiscardKinematicVsKinematic) == 29, "Wrong offset for BroadPhaseDesc.mDiscardKinematicVsKinematic, expected 29 got %v", offset_of(BroadPhaseDesc, mDiscardKinematicVsKinematic))
+    testing.expectf(t, size_of(BroadPhaseDesc{}.mDiscardKinematicVsKinematic) == 1, "Wrong size for BroadPhaseDesc.mDiscardKinematicVsKinematic, expected 1 got %v", size_of(BroadPhaseDesc{}.mDiscardKinematicVsKinematic))
     testing.expectf(t, size_of(BroadPhaseDesc) == 32, "Wrong size for type BroadPhaseDesc, expected 32 got %v", size_of(BroadPhaseDesc))
 }
 
 @(test)
 test_layout_BroadPhaseUpdateData :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(BroadPhaseUpdateData, mCreated) == 0, "Wrong offset for BroadPhaseUpdateData.mCreated, expected 0 got %v", offset_of(BroadPhaseUpdateData, mCreated))
+    testing.expectf(t, size_of(BroadPhaseUpdateData{}.mCreated) == 8, "Wrong size for BroadPhaseUpdateData.mCreated, expected 8 got %v", size_of(BroadPhaseUpdateData{}.mCreated))
     testing.expectf(t, offset_of(BroadPhaseUpdateData, mNbCreated) == 8, "Wrong offset for BroadPhaseUpdateData.mNbCreated, expected 8 got %v", offset_of(BroadPhaseUpdateData, mNbCreated))
+    testing.expectf(t, size_of(BroadPhaseUpdateData{}.mNbCreated) == 4, "Wrong size for BroadPhaseUpdateData.mNbCreated, expected 4 got %v", size_of(BroadPhaseUpdateData{}.mNbCreated))
     testing.expectf(t, offset_of(BroadPhaseUpdateData, mUpdated) == 16, "Wrong offset for BroadPhaseUpdateData.mUpdated, expected 16 got %v", offset_of(BroadPhaseUpdateData, mUpdated))
+    testing.expectf(t, size_of(BroadPhaseUpdateData{}.mUpdated) == 8, "Wrong size for BroadPhaseUpdateData.mUpdated, expected 8 got %v", size_of(BroadPhaseUpdateData{}.mUpdated))
     testing.expectf(t, offset_of(BroadPhaseUpdateData, mNbUpdated) == 24, "Wrong offset for BroadPhaseUpdateData.mNbUpdated, expected 24 got %v", offset_of(BroadPhaseUpdateData, mNbUpdated))
+    testing.expectf(t, size_of(BroadPhaseUpdateData{}.mNbUpdated) == 4, "Wrong size for BroadPhaseUpdateData.mNbUpdated, expected 4 got %v", size_of(BroadPhaseUpdateData{}.mNbUpdated))
     testing.expectf(t, offset_of(BroadPhaseUpdateData, mRemoved) == 32, "Wrong offset for BroadPhaseUpdateData.mRemoved, expected 32 got %v", offset_of(BroadPhaseUpdateData, mRemoved))
+    testing.expectf(t, size_of(BroadPhaseUpdateData{}.mRemoved) == 8, "Wrong size for BroadPhaseUpdateData.mRemoved, expected 8 got %v", size_of(BroadPhaseUpdateData{}.mRemoved))
     testing.expectf(t, offset_of(BroadPhaseUpdateData, mNbRemoved) == 40, "Wrong offset for BroadPhaseUpdateData.mNbRemoved, expected 40 got %v", offset_of(BroadPhaseUpdateData, mNbRemoved))
+    testing.expectf(t, size_of(BroadPhaseUpdateData{}.mNbRemoved) == 4, "Wrong size for BroadPhaseUpdateData.mNbRemoved, expected 4 got %v", size_of(BroadPhaseUpdateData{}.mNbRemoved))
     testing.expectf(t, offset_of(BroadPhaseUpdateData, mBounds) == 48, "Wrong offset for BroadPhaseUpdateData.mBounds, expected 48 got %v", offset_of(BroadPhaseUpdateData, mBounds))
+    testing.expectf(t, size_of(BroadPhaseUpdateData{}.mBounds) == 8, "Wrong size for BroadPhaseUpdateData.mBounds, expected 8 got %v", size_of(BroadPhaseUpdateData{}.mBounds))
     testing.expectf(t, offset_of(BroadPhaseUpdateData, mGroups) == 56, "Wrong offset for BroadPhaseUpdateData.mGroups, expected 56 got %v", offset_of(BroadPhaseUpdateData, mGroups))
+    testing.expectf(t, size_of(BroadPhaseUpdateData{}.mGroups) == 8, "Wrong size for BroadPhaseUpdateData.mGroups, expected 8 got %v", size_of(BroadPhaseUpdateData{}.mGroups))
     testing.expectf(t, offset_of(BroadPhaseUpdateData, mDistances) == 64, "Wrong offset for BroadPhaseUpdateData.mDistances, expected 64 got %v", offset_of(BroadPhaseUpdateData, mDistances))
+    testing.expectf(t, size_of(BroadPhaseUpdateData{}.mDistances) == 8, "Wrong size for BroadPhaseUpdateData.mDistances, expected 8 got %v", size_of(BroadPhaseUpdateData{}.mDistances))
     testing.expectf(t, offset_of(BroadPhaseUpdateData, mCapacity) == 72, "Wrong offset for BroadPhaseUpdateData.mCapacity, expected 72 got %v", offset_of(BroadPhaseUpdateData, mCapacity))
+    testing.expectf(t, size_of(BroadPhaseUpdateData{}.mCapacity) == 4, "Wrong size for BroadPhaseUpdateData.mCapacity, expected 4 got %v", size_of(BroadPhaseUpdateData{}.mCapacity))
     testing.expectf(t, size_of(BroadPhaseUpdateData) == 80, "Wrong size for type BroadPhaseUpdateData, expected 80 got %v", size_of(BroadPhaseUpdateData))
 }
 
 @(test)
 test_layout_BroadPhasePair :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(BroadPhasePair, mID0) == 0, "Wrong offset for BroadPhasePair.mID0, expected 0 got %v", offset_of(BroadPhasePair, mID0))
+    testing.expectf(t, size_of(BroadPhasePair{}.mID0) == 4, "Wrong size for BroadPhasePair.mID0, expected 4 got %v", size_of(BroadPhasePair{}.mID0))
     testing.expectf(t, offset_of(BroadPhasePair, mID1) == 4, "Wrong offset for BroadPhasePair.mID1, expected 4 got %v", offset_of(BroadPhasePair, mID1))
+    testing.expectf(t, size_of(BroadPhasePair{}.mID1) == 4, "Wrong size for BroadPhasePair.mID1, expected 4 got %v", size_of(BroadPhasePair{}.mID1))
     testing.expectf(t, size_of(BroadPhasePair) == 8, "Wrong size for type BroadPhasePair, expected 8 got %v", size_of(BroadPhasePair))
 }
 
 @(test)
 test_layout_BroadPhaseResults :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(BroadPhaseResults, mNbCreatedPairs) == 0, "Wrong offset for BroadPhaseResults.mNbCreatedPairs, expected 0 got %v", offset_of(BroadPhaseResults, mNbCreatedPairs))
+    testing.expectf(t, size_of(BroadPhaseResults{}.mNbCreatedPairs) == 4, "Wrong size for BroadPhaseResults.mNbCreatedPairs, expected 4 got %v", size_of(BroadPhaseResults{}.mNbCreatedPairs))
     testing.expectf(t, offset_of(BroadPhaseResults, mCreatedPairs) == 8, "Wrong offset for BroadPhaseResults.mCreatedPairs, expected 8 got %v", offset_of(BroadPhaseResults, mCreatedPairs))
+    testing.expectf(t, size_of(BroadPhaseResults{}.mCreatedPairs) == 8, "Wrong size for BroadPhaseResults.mCreatedPairs, expected 8 got %v", size_of(BroadPhaseResults{}.mCreatedPairs))
     testing.expectf(t, offset_of(BroadPhaseResults, mNbDeletedPairs) == 16, "Wrong offset for BroadPhaseResults.mNbDeletedPairs, expected 16 got %v", offset_of(BroadPhaseResults, mNbDeletedPairs))
+    testing.expectf(t, size_of(BroadPhaseResults{}.mNbDeletedPairs) == 4, "Wrong size for BroadPhaseResults.mNbDeletedPairs, expected 4 got %v", size_of(BroadPhaseResults{}.mNbDeletedPairs))
     testing.expectf(t, offset_of(BroadPhaseResults, mDeletedPairs) == 24, "Wrong offset for BroadPhaseResults.mDeletedPairs, expected 24 got %v", offset_of(BroadPhaseResults, mDeletedPairs))
+    testing.expectf(t, size_of(BroadPhaseResults{}.mDeletedPairs) == 8, "Wrong size for BroadPhaseResults.mDeletedPairs, expected 8 got %v", size_of(BroadPhaseResults{}.mDeletedPairs))
     testing.expectf(t, size_of(BroadPhaseResults) == 32, "Wrong size for type BroadPhaseResults, expected 32 got %v", size_of(BroadPhaseResults))
 }
 
@@ -1670,30 +2267,52 @@ test_layout_AABBManager :: proc(t: ^testing.T) {
 @(test)
 test_layout_SceneLimits :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(SceneLimits, maxNbActors) == 0, "Wrong offset for SceneLimits.maxNbActors, expected 0 got %v", offset_of(SceneLimits, maxNbActors))
+    testing.expectf(t, size_of(SceneLimits{}.maxNbActors) == 4, "Wrong size for SceneLimits.maxNbActors, expected 4 got %v", size_of(SceneLimits{}.maxNbActors))
     testing.expectf(t, offset_of(SceneLimits, maxNbBodies) == 4, "Wrong offset for SceneLimits.maxNbBodies, expected 4 got %v", offset_of(SceneLimits, maxNbBodies))
+    testing.expectf(t, size_of(SceneLimits{}.maxNbBodies) == 4, "Wrong size for SceneLimits.maxNbBodies, expected 4 got %v", size_of(SceneLimits{}.maxNbBodies))
     testing.expectf(t, offset_of(SceneLimits, maxNbStaticShapes) == 8, "Wrong offset for SceneLimits.maxNbStaticShapes, expected 8 got %v", offset_of(SceneLimits, maxNbStaticShapes))
+    testing.expectf(t, size_of(SceneLimits{}.maxNbStaticShapes) == 4, "Wrong size for SceneLimits.maxNbStaticShapes, expected 4 got %v", size_of(SceneLimits{}.maxNbStaticShapes))
     testing.expectf(t, offset_of(SceneLimits, maxNbDynamicShapes) == 12, "Wrong offset for SceneLimits.maxNbDynamicShapes, expected 12 got %v", offset_of(SceneLimits, maxNbDynamicShapes))
+    testing.expectf(t, size_of(SceneLimits{}.maxNbDynamicShapes) == 4, "Wrong size for SceneLimits.maxNbDynamicShapes, expected 4 got %v", size_of(SceneLimits{}.maxNbDynamicShapes))
     testing.expectf(t, offset_of(SceneLimits, maxNbAggregates) == 16, "Wrong offset for SceneLimits.maxNbAggregates, expected 16 got %v", offset_of(SceneLimits, maxNbAggregates))
+    testing.expectf(t, size_of(SceneLimits{}.maxNbAggregates) == 4, "Wrong size for SceneLimits.maxNbAggregates, expected 4 got %v", size_of(SceneLimits{}.maxNbAggregates))
     testing.expectf(t, offset_of(SceneLimits, maxNbConstraints) == 20, "Wrong offset for SceneLimits.maxNbConstraints, expected 20 got %v", offset_of(SceneLimits, maxNbConstraints))
+    testing.expectf(t, size_of(SceneLimits{}.maxNbConstraints) == 4, "Wrong size for SceneLimits.maxNbConstraints, expected 4 got %v", size_of(SceneLimits{}.maxNbConstraints))
     testing.expectf(t, offset_of(SceneLimits, maxNbRegions) == 24, "Wrong offset for SceneLimits.maxNbRegions, expected 24 got %v", offset_of(SceneLimits, maxNbRegions))
+    testing.expectf(t, size_of(SceneLimits{}.maxNbRegions) == 4, "Wrong size for SceneLimits.maxNbRegions, expected 4 got %v", size_of(SceneLimits{}.maxNbRegions))
     testing.expectf(t, offset_of(SceneLimits, maxNbBroadPhaseOverlaps) == 28, "Wrong offset for SceneLimits.maxNbBroadPhaseOverlaps, expected 28 got %v", offset_of(SceneLimits, maxNbBroadPhaseOverlaps))
+    testing.expectf(t, size_of(SceneLimits{}.maxNbBroadPhaseOverlaps) == 4, "Wrong size for SceneLimits.maxNbBroadPhaseOverlaps, expected 4 got %v", size_of(SceneLimits{}.maxNbBroadPhaseOverlaps))
     testing.expectf(t, size_of(SceneLimits) == 32, "Wrong size for type SceneLimits, expected 32 got %v", size_of(SceneLimits))
 }
 
 @(test)
 test_layout_gDynamicsMemoryConfig :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(gDynamicsMemoryConfig, tempBufferCapacity) == 0, "Wrong offset for gDynamicsMemoryConfig.tempBufferCapacity, expected 0 got %v", offset_of(gDynamicsMemoryConfig, tempBufferCapacity))
+    testing.expectf(t, size_of(gDynamicsMemoryConfig{}.tempBufferCapacity) == 4, "Wrong size for gDynamicsMemoryConfig.tempBufferCapacity, expected 4 got %v", size_of(gDynamicsMemoryConfig{}.tempBufferCapacity))
     testing.expectf(t, offset_of(gDynamicsMemoryConfig, maxRigidContactCount) == 4, "Wrong offset for gDynamicsMemoryConfig.maxRigidContactCount, expected 4 got %v", offset_of(gDynamicsMemoryConfig, maxRigidContactCount))
+    testing.expectf(t, size_of(gDynamicsMemoryConfig{}.maxRigidContactCount) == 4, "Wrong size for gDynamicsMemoryConfig.maxRigidContactCount, expected 4 got %v", size_of(gDynamicsMemoryConfig{}.maxRigidContactCount))
     testing.expectf(t, offset_of(gDynamicsMemoryConfig, maxRigidPatchCount) == 8, "Wrong offset for gDynamicsMemoryConfig.maxRigidPatchCount, expected 8 got %v", offset_of(gDynamicsMemoryConfig, maxRigidPatchCount))
+    testing.expectf(t, size_of(gDynamicsMemoryConfig{}.maxRigidPatchCount) == 4, "Wrong size for gDynamicsMemoryConfig.maxRigidPatchCount, expected 4 got %v", size_of(gDynamicsMemoryConfig{}.maxRigidPatchCount))
     testing.expectf(t, offset_of(gDynamicsMemoryConfig, heapCapacity) == 12, "Wrong offset for gDynamicsMemoryConfig.heapCapacity, expected 12 got %v", offset_of(gDynamicsMemoryConfig, heapCapacity))
+    testing.expectf(t, size_of(gDynamicsMemoryConfig{}.heapCapacity) == 4, "Wrong size for gDynamicsMemoryConfig.heapCapacity, expected 4 got %v", size_of(gDynamicsMemoryConfig{}.heapCapacity))
     testing.expectf(t, offset_of(gDynamicsMemoryConfig, foundLostPairsCapacity) == 16, "Wrong offset for gDynamicsMemoryConfig.foundLostPairsCapacity, expected 16 got %v", offset_of(gDynamicsMemoryConfig, foundLostPairsCapacity))
+    testing.expectf(t, size_of(gDynamicsMemoryConfig{}.foundLostPairsCapacity) == 4, "Wrong size for gDynamicsMemoryConfig.foundLostPairsCapacity, expected 4 got %v", size_of(gDynamicsMemoryConfig{}.foundLostPairsCapacity))
     testing.expectf(t, offset_of(gDynamicsMemoryConfig, foundLostAggregatePairsCapacity) == 20, "Wrong offset for gDynamicsMemoryConfig.foundLostAggregatePairsCapacity, expected 20 got %v", offset_of(gDynamicsMemoryConfig, foundLostAggregatePairsCapacity))
+    testing.expectf(t, size_of(gDynamicsMemoryConfig{}.foundLostAggregatePairsCapacity) == 4, "Wrong size for gDynamicsMemoryConfig.foundLostAggregatePairsCapacity, expected 4 got %v", size_of(gDynamicsMemoryConfig{}.foundLostAggregatePairsCapacity))
     testing.expectf(t, offset_of(gDynamicsMemoryConfig, totalAggregatePairsCapacity) == 24, "Wrong offset for gDynamicsMemoryConfig.totalAggregatePairsCapacity, expected 24 got %v", offset_of(gDynamicsMemoryConfig, totalAggregatePairsCapacity))
+    testing.expectf(t, size_of(gDynamicsMemoryConfig{}.totalAggregatePairsCapacity) == 4, "Wrong size for gDynamicsMemoryConfig.totalAggregatePairsCapacity, expected 4 got %v", size_of(gDynamicsMemoryConfig{}.totalAggregatePairsCapacity))
     testing.expectf(t, offset_of(gDynamicsMemoryConfig, maxSoftBodyContacts) == 28, "Wrong offset for gDynamicsMemoryConfig.maxSoftBodyContacts, expected 28 got %v", offset_of(gDynamicsMemoryConfig, maxSoftBodyContacts))
+    testing.expectf(t, size_of(gDynamicsMemoryConfig{}.maxSoftBodyContacts) == 4, "Wrong size for gDynamicsMemoryConfig.maxSoftBodyContacts, expected 4 got %v", size_of(gDynamicsMemoryConfig{}.maxSoftBodyContacts))
     testing.expectf(t, offset_of(gDynamicsMemoryConfig, maxFemClothContacts) == 32, "Wrong offset for gDynamicsMemoryConfig.maxFemClothContacts, expected 32 got %v", offset_of(gDynamicsMemoryConfig, maxFemClothContacts))
+    testing.expectf(t, size_of(gDynamicsMemoryConfig{}.maxFemClothContacts) == 4, "Wrong size for gDynamicsMemoryConfig.maxFemClothContacts, expected 4 got %v", size_of(gDynamicsMemoryConfig{}.maxFemClothContacts))
     testing.expectf(t, offset_of(gDynamicsMemoryConfig, maxParticleContacts) == 36, "Wrong offset for gDynamicsMemoryConfig.maxParticleContacts, expected 36 got %v", offset_of(gDynamicsMemoryConfig, maxParticleContacts))
+    testing.expectf(t, size_of(gDynamicsMemoryConfig{}.maxParticleContacts) == 4, "Wrong size for gDynamicsMemoryConfig.maxParticleContacts, expected 4 got %v", size_of(gDynamicsMemoryConfig{}.maxParticleContacts))
     testing.expectf(t, offset_of(gDynamicsMemoryConfig, collisionStackSize) == 40, "Wrong offset for gDynamicsMemoryConfig.collisionStackSize, expected 40 got %v", offset_of(gDynamicsMemoryConfig, collisionStackSize))
+    testing.expectf(t, size_of(gDynamicsMemoryConfig{}.collisionStackSize) == 4, "Wrong size for gDynamicsMemoryConfig.collisionStackSize, expected 4 got %v", size_of(gDynamicsMemoryConfig{}.collisionStackSize))
     testing.expectf(t, offset_of(gDynamicsMemoryConfig, maxHairContacts) == 44, "Wrong offset for gDynamicsMemoryConfig.maxHairContacts, expected 44 got %v", offset_of(gDynamicsMemoryConfig, maxHairContacts))
+    testing.expectf(t, size_of(gDynamicsMemoryConfig{}.maxHairContacts) == 4, "Wrong size for gDynamicsMemoryConfig.maxHairContacts, expected 4 got %v", size_of(gDynamicsMemoryConfig{}.maxHairContacts))
     testing.expectf(t, size_of(gDynamicsMemoryConfig) == 48, "Wrong size for type gDynamicsMemoryConfig, expected 48 got %v", size_of(gDynamicsMemoryConfig))
 }
 
@@ -1701,113 +2320,205 @@ test_layout_gDynamicsMemoryConfig :: proc(t: ^testing.T) {
 test_layout_SceneDesc :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(SceneDesc, gravity) == 36, "Wrong offset for SceneDesc.gravity, expected 36 got %v", offset_of(SceneDesc, gravity))
+    testing.expectf(t, size_of(SceneDesc{}.gravity) == 12, "Wrong size for SceneDesc.gravity, expected 12 got %v", size_of(SceneDesc{}.gravity))
     testing.expectf(t, offset_of(SceneDesc, simulationEventCallback) == 48, "Wrong offset for SceneDesc.simulationEventCallback, expected 48 got %v", offset_of(SceneDesc, simulationEventCallback))
+    testing.expectf(t, size_of(SceneDesc{}.simulationEventCallback) == 8, "Wrong size for SceneDesc.simulationEventCallback, expected 8 got %v", size_of(SceneDesc{}.simulationEventCallback))
     testing.expectf(t, offset_of(SceneDesc, contactModifyCallback) == 56, "Wrong offset for SceneDesc.contactModifyCallback, expected 56 got %v", offset_of(SceneDesc, contactModifyCallback))
+    testing.expectf(t, size_of(SceneDesc{}.contactModifyCallback) == 8, "Wrong size for SceneDesc.contactModifyCallback, expected 8 got %v", size_of(SceneDesc{}.contactModifyCallback))
     testing.expectf(t, offset_of(SceneDesc, ccdContactModifyCallback) == 64, "Wrong offset for SceneDesc.ccdContactModifyCallback, expected 64 got %v", offset_of(SceneDesc, ccdContactModifyCallback))
+    testing.expectf(t, size_of(SceneDesc{}.ccdContactModifyCallback) == 8, "Wrong size for SceneDesc.ccdContactModifyCallback, expected 8 got %v", size_of(SceneDesc{}.ccdContactModifyCallback))
     testing.expectf(t, offset_of(SceneDesc, filterShaderData) == 72, "Wrong offset for SceneDesc.filterShaderData, expected 72 got %v", offset_of(SceneDesc, filterShaderData))
+    testing.expectf(t, size_of(SceneDesc{}.filterShaderData) == 8, "Wrong size for SceneDesc.filterShaderData, expected 8 got %v", size_of(SceneDesc{}.filterShaderData))
     testing.expectf(t, offset_of(SceneDesc, filterShaderDataSize) == 80, "Wrong offset for SceneDesc.filterShaderDataSize, expected 80 got %v", offset_of(SceneDesc, filterShaderDataSize))
+    testing.expectf(t, size_of(SceneDesc{}.filterShaderDataSize) == 4, "Wrong size for SceneDesc.filterShaderDataSize, expected 4 got %v", size_of(SceneDesc{}.filterShaderDataSize))
     testing.expectf(t, offset_of(SceneDesc, filterShader) == 88, "Wrong offset for SceneDesc.filterShader, expected 88 got %v", offset_of(SceneDesc, filterShader))
+    testing.expectf(t, size_of(SceneDesc{}.filterShader) == 8, "Wrong size for SceneDesc.filterShader, expected 8 got %v", size_of(SceneDesc{}.filterShader))
     testing.expectf(t, offset_of(SceneDesc, filterCallback) == 96, "Wrong offset for SceneDesc.filterCallback, expected 96 got %v", offset_of(SceneDesc, filterCallback))
+    testing.expectf(t, size_of(SceneDesc{}.filterCallback) == 8, "Wrong size for SceneDesc.filterCallback, expected 8 got %v", size_of(SceneDesc{}.filterCallback))
     testing.expectf(t, offset_of(SceneDesc, kineKineFilteringMode) == 104, "Wrong offset for SceneDesc.kineKineFilteringMode, expected 104 got %v", offset_of(SceneDesc, kineKineFilteringMode))
+    testing.expectf(t, size_of(SceneDesc{}.kineKineFilteringMode) == 4, "Wrong size for SceneDesc.kineKineFilteringMode, expected 4 got %v", size_of(SceneDesc{}.kineKineFilteringMode))
     testing.expectf(t, offset_of(SceneDesc, staticKineFilteringMode) == 108, "Wrong offset for SceneDesc.staticKineFilteringMode, expected 108 got %v", offset_of(SceneDesc, staticKineFilteringMode))
+    testing.expectf(t, size_of(SceneDesc{}.staticKineFilteringMode) == 4, "Wrong size for SceneDesc.staticKineFilteringMode, expected 4 got %v", size_of(SceneDesc{}.staticKineFilteringMode))
     testing.expectf(t, offset_of(SceneDesc, broadPhaseType) == 112, "Wrong offset for SceneDesc.broadPhaseType, expected 112 got %v", offset_of(SceneDesc, broadPhaseType))
+    testing.expectf(t, size_of(SceneDesc{}.broadPhaseType) == 4, "Wrong size for SceneDesc.broadPhaseType, expected 4 got %v", size_of(SceneDesc{}.broadPhaseType))
     testing.expectf(t, offset_of(SceneDesc, broadPhaseCallback) == 120, "Wrong offset for SceneDesc.broadPhaseCallback, expected 120 got %v", offset_of(SceneDesc, broadPhaseCallback))
+    testing.expectf(t, size_of(SceneDesc{}.broadPhaseCallback) == 8, "Wrong size for SceneDesc.broadPhaseCallback, expected 8 got %v", size_of(SceneDesc{}.broadPhaseCallback))
     testing.expectf(t, offset_of(SceneDesc, limits) == 128, "Wrong offset for SceneDesc.limits, expected 128 got %v", offset_of(SceneDesc, limits))
+    testing.expectf(t, size_of(SceneDesc{}.limits) == 32, "Wrong size for SceneDesc.limits, expected 32 got %v", size_of(SceneDesc{}.limits))
     testing.expectf(t, offset_of(SceneDesc, frictionType) == 160, "Wrong offset for SceneDesc.frictionType, expected 160 got %v", offset_of(SceneDesc, frictionType))
+    testing.expectf(t, size_of(SceneDesc{}.frictionType) == 4, "Wrong size for SceneDesc.frictionType, expected 4 got %v", size_of(SceneDesc{}.frictionType))
     testing.expectf(t, offset_of(SceneDesc, solverType) == 164, "Wrong offset for SceneDesc.solverType, expected 164 got %v", offset_of(SceneDesc, solverType))
+    testing.expectf(t, size_of(SceneDesc{}.solverType) == 4, "Wrong size for SceneDesc.solverType, expected 4 got %v", size_of(SceneDesc{}.solverType))
     testing.expectf(t, offset_of(SceneDesc, bounceThresholdVelocity) == 168, "Wrong offset for SceneDesc.bounceThresholdVelocity, expected 168 got %v", offset_of(SceneDesc, bounceThresholdVelocity))
+    testing.expectf(t, size_of(SceneDesc{}.bounceThresholdVelocity) == 4, "Wrong size for SceneDesc.bounceThresholdVelocity, expected 4 got %v", size_of(SceneDesc{}.bounceThresholdVelocity))
     testing.expectf(t, offset_of(SceneDesc, frictionOffsetThreshold) == 172, "Wrong offset for SceneDesc.frictionOffsetThreshold, expected 172 got %v", offset_of(SceneDesc, frictionOffsetThreshold))
+    testing.expectf(t, size_of(SceneDesc{}.frictionOffsetThreshold) == 4, "Wrong size for SceneDesc.frictionOffsetThreshold, expected 4 got %v", size_of(SceneDesc{}.frictionOffsetThreshold))
     testing.expectf(t, offset_of(SceneDesc, frictionCorrelationDistance) == 176, "Wrong offset for SceneDesc.frictionCorrelationDistance, expected 176 got %v", offset_of(SceneDesc, frictionCorrelationDistance))
+    testing.expectf(t, size_of(SceneDesc{}.frictionCorrelationDistance) == 4, "Wrong size for SceneDesc.frictionCorrelationDistance, expected 4 got %v", size_of(SceneDesc{}.frictionCorrelationDistance))
     testing.expectf(t, offset_of(SceneDesc, flags) == 180, "Wrong offset for SceneDesc.flags, expected 180 got %v", offset_of(SceneDesc, flags))
+    testing.expectf(t, size_of(SceneDesc{}.flags) == 4, "Wrong size for SceneDesc.flags, expected 4 got %v", size_of(SceneDesc{}.flags))
     testing.expectf(t, offset_of(SceneDesc, cpuDispatcher) == 184, "Wrong offset for SceneDesc.cpuDispatcher, expected 184 got %v", offset_of(SceneDesc, cpuDispatcher))
+    testing.expectf(t, size_of(SceneDesc{}.cpuDispatcher) == 8, "Wrong size for SceneDesc.cpuDispatcher, expected 8 got %v", size_of(SceneDesc{}.cpuDispatcher))
     testing.expectf(t, offset_of(SceneDesc, userData) == 200, "Wrong offset for SceneDesc.userData, expected 200 got %v", offset_of(SceneDesc, userData))
+    testing.expectf(t, size_of(SceneDesc{}.userData) == 8, "Wrong size for SceneDesc.userData, expected 8 got %v", size_of(SceneDesc{}.userData))
     testing.expectf(t, offset_of(SceneDesc, solverBatchSize) == 208, "Wrong offset for SceneDesc.solverBatchSize, expected 208 got %v", offset_of(SceneDesc, solverBatchSize))
+    testing.expectf(t, size_of(SceneDesc{}.solverBatchSize) == 4, "Wrong size for SceneDesc.solverBatchSize, expected 4 got %v", size_of(SceneDesc{}.solverBatchSize))
     testing.expectf(t, offset_of(SceneDesc, solverArticulationBatchSize) == 212, "Wrong offset for SceneDesc.solverArticulationBatchSize, expected 212 got %v", offset_of(SceneDesc, solverArticulationBatchSize))
+    testing.expectf(t, size_of(SceneDesc{}.solverArticulationBatchSize) == 4, "Wrong size for SceneDesc.solverArticulationBatchSize, expected 4 got %v", size_of(SceneDesc{}.solverArticulationBatchSize))
     testing.expectf(t, offset_of(SceneDesc, nbContactDataBlocks) == 216, "Wrong offset for SceneDesc.nbContactDataBlocks, expected 216 got %v", offset_of(SceneDesc, nbContactDataBlocks))
+    testing.expectf(t, size_of(SceneDesc{}.nbContactDataBlocks) == 4, "Wrong size for SceneDesc.nbContactDataBlocks, expected 4 got %v", size_of(SceneDesc{}.nbContactDataBlocks))
     testing.expectf(t, offset_of(SceneDesc, maxNbContactDataBlocks) == 220, "Wrong offset for SceneDesc.maxNbContactDataBlocks, expected 220 got %v", offset_of(SceneDesc, maxNbContactDataBlocks))
+    testing.expectf(t, size_of(SceneDesc{}.maxNbContactDataBlocks) == 4, "Wrong size for SceneDesc.maxNbContactDataBlocks, expected 4 got %v", size_of(SceneDesc{}.maxNbContactDataBlocks))
     testing.expectf(t, offset_of(SceneDesc, maxBiasCoefficient) == 224, "Wrong offset for SceneDesc.maxBiasCoefficient, expected 224 got %v", offset_of(SceneDesc, maxBiasCoefficient))
+    testing.expectf(t, size_of(SceneDesc{}.maxBiasCoefficient) == 4, "Wrong size for SceneDesc.maxBiasCoefficient, expected 4 got %v", size_of(SceneDesc{}.maxBiasCoefficient))
     testing.expectf(t, offset_of(SceneDesc, contactReportStreamBufferSize) == 228, "Wrong offset for SceneDesc.contactReportStreamBufferSize, expected 228 got %v", offset_of(SceneDesc, contactReportStreamBufferSize))
+    testing.expectf(t, size_of(SceneDesc{}.contactReportStreamBufferSize) == 4, "Wrong size for SceneDesc.contactReportStreamBufferSize, expected 4 got %v", size_of(SceneDesc{}.contactReportStreamBufferSize))
     testing.expectf(t, offset_of(SceneDesc, ccdMaxPasses) == 232, "Wrong offset for SceneDesc.ccdMaxPasses, expected 232 got %v", offset_of(SceneDesc, ccdMaxPasses))
+    testing.expectf(t, size_of(SceneDesc{}.ccdMaxPasses) == 4, "Wrong size for SceneDesc.ccdMaxPasses, expected 4 got %v", size_of(SceneDesc{}.ccdMaxPasses))
     testing.expectf(t, offset_of(SceneDesc, ccdThreshold) == 236, "Wrong offset for SceneDesc.ccdThreshold, expected 236 got %v", offset_of(SceneDesc, ccdThreshold))
+    testing.expectf(t, size_of(SceneDesc{}.ccdThreshold) == 4, "Wrong size for SceneDesc.ccdThreshold, expected 4 got %v", size_of(SceneDesc{}.ccdThreshold))
     testing.expectf(t, offset_of(SceneDesc, ccdMaxSeparation) == 240, "Wrong offset for SceneDesc.ccdMaxSeparation, expected 240 got %v", offset_of(SceneDesc, ccdMaxSeparation))
+    testing.expectf(t, size_of(SceneDesc{}.ccdMaxSeparation) == 4, "Wrong size for SceneDesc.ccdMaxSeparation, expected 4 got %v", size_of(SceneDesc{}.ccdMaxSeparation))
     testing.expectf(t, offset_of(SceneDesc, wakeCounterResetValue) == 244, "Wrong offset for SceneDesc.wakeCounterResetValue, expected 244 got %v", offset_of(SceneDesc, wakeCounterResetValue))
+    testing.expectf(t, size_of(SceneDesc{}.wakeCounterResetValue) == 4, "Wrong size for SceneDesc.wakeCounterResetValue, expected 4 got %v", size_of(SceneDesc{}.wakeCounterResetValue))
     testing.expectf(t, offset_of(SceneDesc, sanityBounds) == 248, "Wrong offset for SceneDesc.sanityBounds, expected 248 got %v", offset_of(SceneDesc, sanityBounds))
+    testing.expectf(t, size_of(SceneDesc{}.sanityBounds) == 24, "Wrong size for SceneDesc.sanityBounds, expected 24 got %v", size_of(SceneDesc{}.sanityBounds))
     testing.expectf(t, offset_of(SceneDesc, gpuDynamicsConfig) == 272, "Wrong offset for SceneDesc.gpuDynamicsConfig, expected 272 got %v", offset_of(SceneDesc, gpuDynamicsConfig))
+    testing.expectf(t, size_of(SceneDesc{}.gpuDynamicsConfig) == 48, "Wrong size for SceneDesc.gpuDynamicsConfig, expected 48 got %v", size_of(SceneDesc{}.gpuDynamicsConfig))
     testing.expectf(t, offset_of(SceneDesc, gpuMaxNumPartitions) == 320, "Wrong offset for SceneDesc.gpuMaxNumPartitions, expected 320 got %v", offset_of(SceneDesc, gpuMaxNumPartitions))
+    testing.expectf(t, size_of(SceneDesc{}.gpuMaxNumPartitions) == 4, "Wrong size for SceneDesc.gpuMaxNumPartitions, expected 4 got %v", size_of(SceneDesc{}.gpuMaxNumPartitions))
     testing.expectf(t, offset_of(SceneDesc, gpuMaxNumStaticPartitions) == 324, "Wrong offset for SceneDesc.gpuMaxNumStaticPartitions, expected 324 got %v", offset_of(SceneDesc, gpuMaxNumStaticPartitions))
+    testing.expectf(t, size_of(SceneDesc{}.gpuMaxNumStaticPartitions) == 4, "Wrong size for SceneDesc.gpuMaxNumStaticPartitions, expected 4 got %v", size_of(SceneDesc{}.gpuMaxNumStaticPartitions))
     testing.expectf(t, offset_of(SceneDesc, gpuComputeVersion) == 328, "Wrong offset for SceneDesc.gpuComputeVersion, expected 328 got %v", offset_of(SceneDesc, gpuComputeVersion))
+    testing.expectf(t, size_of(SceneDesc{}.gpuComputeVersion) == 4, "Wrong size for SceneDesc.gpuComputeVersion, expected 4 got %v", size_of(SceneDesc{}.gpuComputeVersion))
     testing.expectf(t, offset_of(SceneDesc, contactPairSlabSize) == 332, "Wrong offset for SceneDesc.contactPairSlabSize, expected 332 got %v", offset_of(SceneDesc, contactPairSlabSize))
+    testing.expectf(t, size_of(SceneDesc{}.contactPairSlabSize) == 4, "Wrong size for SceneDesc.contactPairSlabSize, expected 4 got %v", size_of(SceneDesc{}.contactPairSlabSize))
     testing.expectf(t, offset_of(SceneDesc, sceneQuerySystem) == 336, "Wrong offset for SceneDesc.sceneQuerySystem, expected 336 got %v", offset_of(SceneDesc, sceneQuerySystem))
+    testing.expectf(t, size_of(SceneDesc{}.sceneQuerySystem) == 8, "Wrong size for SceneDesc.sceneQuerySystem, expected 8 got %v", size_of(SceneDesc{}.sceneQuerySystem))
     testing.expectf(t, size_of(SceneDesc) == 352, "Wrong size for type SceneDesc, expected 352 got %v", size_of(SceneDesc))
 }
 
 @(test)
 test_layout_SimulationStatistics :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(SimulationStatistics, nbActiveConstraints) == 0, "Wrong offset for SimulationStatistics.nbActiveConstraints, expected 0 got %v", offset_of(SimulationStatistics, nbActiveConstraints))
+    testing.expectf(t, size_of(SimulationStatistics{}.nbActiveConstraints) == 4, "Wrong size for SimulationStatistics.nbActiveConstraints, expected 4 got %v", size_of(SimulationStatistics{}.nbActiveConstraints))
     testing.expectf(t, offset_of(SimulationStatistics, nbActiveDynamicBodies) == 4, "Wrong offset for SimulationStatistics.nbActiveDynamicBodies, expected 4 got %v", offset_of(SimulationStatistics, nbActiveDynamicBodies))
+    testing.expectf(t, size_of(SimulationStatistics{}.nbActiveDynamicBodies) == 4, "Wrong size for SimulationStatistics.nbActiveDynamicBodies, expected 4 got %v", size_of(SimulationStatistics{}.nbActiveDynamicBodies))
     testing.expectf(t, offset_of(SimulationStatistics, nbActiveKinematicBodies) == 8, "Wrong offset for SimulationStatistics.nbActiveKinematicBodies, expected 8 got %v", offset_of(SimulationStatistics, nbActiveKinematicBodies))
+    testing.expectf(t, size_of(SimulationStatistics{}.nbActiveKinematicBodies) == 4, "Wrong size for SimulationStatistics.nbActiveKinematicBodies, expected 4 got %v", size_of(SimulationStatistics{}.nbActiveKinematicBodies))
     testing.expectf(t, offset_of(SimulationStatistics, nbStaticBodies) == 12, "Wrong offset for SimulationStatistics.nbStaticBodies, expected 12 got %v", offset_of(SimulationStatistics, nbStaticBodies))
+    testing.expectf(t, size_of(SimulationStatistics{}.nbStaticBodies) == 4, "Wrong size for SimulationStatistics.nbStaticBodies, expected 4 got %v", size_of(SimulationStatistics{}.nbStaticBodies))
     testing.expectf(t, offset_of(SimulationStatistics, nbDynamicBodies) == 16, "Wrong offset for SimulationStatistics.nbDynamicBodies, expected 16 got %v", offset_of(SimulationStatistics, nbDynamicBodies))
+    testing.expectf(t, size_of(SimulationStatistics{}.nbDynamicBodies) == 4, "Wrong size for SimulationStatistics.nbDynamicBodies, expected 4 got %v", size_of(SimulationStatistics{}.nbDynamicBodies))
     testing.expectf(t, offset_of(SimulationStatistics, nbKinematicBodies) == 20, "Wrong offset for SimulationStatistics.nbKinematicBodies, expected 20 got %v", offset_of(SimulationStatistics, nbKinematicBodies))
+    testing.expectf(t, size_of(SimulationStatistics{}.nbKinematicBodies) == 4, "Wrong size for SimulationStatistics.nbKinematicBodies, expected 4 got %v", size_of(SimulationStatistics{}.nbKinematicBodies))
     testing.expectf(t, offset_of(SimulationStatistics, nbAggregates) == 68, "Wrong offset for SimulationStatistics.nbAggregates, expected 68 got %v", offset_of(SimulationStatistics, nbAggregates))
+    testing.expectf(t, size_of(SimulationStatistics{}.nbAggregates) == 4, "Wrong size for SimulationStatistics.nbAggregates, expected 4 got %v", size_of(SimulationStatistics{}.nbAggregates))
     testing.expectf(t, offset_of(SimulationStatistics, nbArticulations) == 72, "Wrong offset for SimulationStatistics.nbArticulations, expected 72 got %v", offset_of(SimulationStatistics, nbArticulations))
+    testing.expectf(t, size_of(SimulationStatistics{}.nbArticulations) == 4, "Wrong size for SimulationStatistics.nbArticulations, expected 4 got %v", size_of(SimulationStatistics{}.nbArticulations))
     testing.expectf(t, offset_of(SimulationStatistics, nbAxisSolverConstraints) == 76, "Wrong offset for SimulationStatistics.nbAxisSolverConstraints, expected 76 got %v", offset_of(SimulationStatistics, nbAxisSolverConstraints))
+    testing.expectf(t, size_of(SimulationStatistics{}.nbAxisSolverConstraints) == 4, "Wrong size for SimulationStatistics.nbAxisSolverConstraints, expected 4 got %v", size_of(SimulationStatistics{}.nbAxisSolverConstraints))
     testing.expectf(t, offset_of(SimulationStatistics, compressedContactSize) == 80, "Wrong offset for SimulationStatistics.compressedContactSize, expected 80 got %v", offset_of(SimulationStatistics, compressedContactSize))
+    testing.expectf(t, size_of(SimulationStatistics{}.compressedContactSize) == 4, "Wrong size for SimulationStatistics.compressedContactSize, expected 4 got %v", size_of(SimulationStatistics{}.compressedContactSize))
     testing.expectf(t, offset_of(SimulationStatistics, requiredContactConstraintMemory) == 84, "Wrong offset for SimulationStatistics.requiredContactConstraintMemory, expected 84 got %v", offset_of(SimulationStatistics, requiredContactConstraintMemory))
+    testing.expectf(t, size_of(SimulationStatistics{}.requiredContactConstraintMemory) == 4, "Wrong size for SimulationStatistics.requiredContactConstraintMemory, expected 4 got %v", size_of(SimulationStatistics{}.requiredContactConstraintMemory))
     testing.expectf(t, offset_of(SimulationStatistics, peakConstraintMemory) == 88, "Wrong offset for SimulationStatistics.peakConstraintMemory, expected 88 got %v", offset_of(SimulationStatistics, peakConstraintMemory))
+    testing.expectf(t, size_of(SimulationStatistics{}.peakConstraintMemory) == 4, "Wrong size for SimulationStatistics.peakConstraintMemory, expected 4 got %v", size_of(SimulationStatistics{}.peakConstraintMemory))
     testing.expectf(t, offset_of(SimulationStatistics, nbDiscreteContactPairsTotal) == 92, "Wrong offset for SimulationStatistics.nbDiscreteContactPairsTotal, expected 92 got %v", offset_of(SimulationStatistics, nbDiscreteContactPairsTotal))
+    testing.expectf(t, size_of(SimulationStatistics{}.nbDiscreteContactPairsTotal) == 4, "Wrong size for SimulationStatistics.nbDiscreteContactPairsTotal, expected 4 got %v", size_of(SimulationStatistics{}.nbDiscreteContactPairsTotal))
     testing.expectf(t, offset_of(SimulationStatistics, nbDiscreteContactPairsWithCacheHits) == 96, "Wrong offset for SimulationStatistics.nbDiscreteContactPairsWithCacheHits, expected 96 got %v", offset_of(SimulationStatistics, nbDiscreteContactPairsWithCacheHits))
+    testing.expectf(t, size_of(SimulationStatistics{}.nbDiscreteContactPairsWithCacheHits) == 4, "Wrong size for SimulationStatistics.nbDiscreteContactPairsWithCacheHits, expected 4 got %v", size_of(SimulationStatistics{}.nbDiscreteContactPairsWithCacheHits))
     testing.expectf(t, offset_of(SimulationStatistics, nbDiscreteContactPairsWithContacts) == 100, "Wrong offset for SimulationStatistics.nbDiscreteContactPairsWithContacts, expected 100 got %v", offset_of(SimulationStatistics, nbDiscreteContactPairsWithContacts))
+    testing.expectf(t, size_of(SimulationStatistics{}.nbDiscreteContactPairsWithContacts) == 4, "Wrong size for SimulationStatistics.nbDiscreteContactPairsWithContacts, expected 4 got %v", size_of(SimulationStatistics{}.nbDiscreteContactPairsWithContacts))
     testing.expectf(t, offset_of(SimulationStatistics, nbNewPairs) == 104, "Wrong offset for SimulationStatistics.nbNewPairs, expected 104 got %v", offset_of(SimulationStatistics, nbNewPairs))
+    testing.expectf(t, size_of(SimulationStatistics{}.nbNewPairs) == 4, "Wrong size for SimulationStatistics.nbNewPairs, expected 4 got %v", size_of(SimulationStatistics{}.nbNewPairs))
     testing.expectf(t, offset_of(SimulationStatistics, nbLostPairs) == 108, "Wrong offset for SimulationStatistics.nbLostPairs, expected 108 got %v", offset_of(SimulationStatistics, nbLostPairs))
+    testing.expectf(t, size_of(SimulationStatistics{}.nbLostPairs) == 4, "Wrong size for SimulationStatistics.nbLostPairs, expected 4 got %v", size_of(SimulationStatistics{}.nbLostPairs))
     testing.expectf(t, offset_of(SimulationStatistics, nbNewTouches) == 112, "Wrong offset for SimulationStatistics.nbNewTouches, expected 112 got %v", offset_of(SimulationStatistics, nbNewTouches))
+    testing.expectf(t, size_of(SimulationStatistics{}.nbNewTouches) == 4, "Wrong size for SimulationStatistics.nbNewTouches, expected 4 got %v", size_of(SimulationStatistics{}.nbNewTouches))
     testing.expectf(t, offset_of(SimulationStatistics, nbLostTouches) == 116, "Wrong offset for SimulationStatistics.nbLostTouches, expected 116 got %v", offset_of(SimulationStatistics, nbLostTouches))
+    testing.expectf(t, size_of(SimulationStatistics{}.nbLostTouches) == 4, "Wrong size for SimulationStatistics.nbLostTouches, expected 4 got %v", size_of(SimulationStatistics{}.nbLostTouches))
     testing.expectf(t, offset_of(SimulationStatistics, nbPartitions) == 120, "Wrong offset for SimulationStatistics.nbPartitions, expected 120 got %v", offset_of(SimulationStatistics, nbPartitions))
+    testing.expectf(t, size_of(SimulationStatistics{}.nbPartitions) == 4, "Wrong size for SimulationStatistics.nbPartitions, expected 4 got %v", size_of(SimulationStatistics{}.nbPartitions))
     testing.expectf(t, offset_of(SimulationStatistics, gpuMemParticles) == 128, "Wrong offset for SimulationStatistics.gpuMemParticles, expected 128 got %v", offset_of(SimulationStatistics, gpuMemParticles))
+    testing.expectf(t, size_of(SimulationStatistics{}.gpuMemParticles) == 8, "Wrong size for SimulationStatistics.gpuMemParticles, expected 8 got %v", size_of(SimulationStatistics{}.gpuMemParticles))
     testing.expectf(t, offset_of(SimulationStatistics, gpuMemSoftBodies) == 136, "Wrong offset for SimulationStatistics.gpuMemSoftBodies, expected 136 got %v", offset_of(SimulationStatistics, gpuMemSoftBodies))
+    testing.expectf(t, size_of(SimulationStatistics{}.gpuMemSoftBodies) == 8, "Wrong size for SimulationStatistics.gpuMemSoftBodies, expected 8 got %v", size_of(SimulationStatistics{}.gpuMemSoftBodies))
     testing.expectf(t, offset_of(SimulationStatistics, gpuMemFEMCloths) == 144, "Wrong offset for SimulationStatistics.gpuMemFEMCloths, expected 144 got %v", offset_of(SimulationStatistics, gpuMemFEMCloths))
+    testing.expectf(t, size_of(SimulationStatistics{}.gpuMemFEMCloths) == 8, "Wrong size for SimulationStatistics.gpuMemFEMCloths, expected 8 got %v", size_of(SimulationStatistics{}.gpuMemFEMCloths))
     testing.expectf(t, offset_of(SimulationStatistics, gpuMemHairSystems) == 152, "Wrong offset for SimulationStatistics.gpuMemHairSystems, expected 152 got %v", offset_of(SimulationStatistics, gpuMemHairSystems))
+    testing.expectf(t, size_of(SimulationStatistics{}.gpuMemHairSystems) == 8, "Wrong size for SimulationStatistics.gpuMemHairSystems, expected 8 got %v", size_of(SimulationStatistics{}.gpuMemHairSystems))
     testing.expectf(t, offset_of(SimulationStatistics, gpuMemHeap) == 160, "Wrong offset for SimulationStatistics.gpuMemHeap, expected 160 got %v", offset_of(SimulationStatistics, gpuMemHeap))
+    testing.expectf(t, size_of(SimulationStatistics{}.gpuMemHeap) == 8, "Wrong size for SimulationStatistics.gpuMemHeap, expected 8 got %v", size_of(SimulationStatistics{}.gpuMemHeap))
     testing.expectf(t, offset_of(SimulationStatistics, gpuMemHeapBroadPhase) == 168, "Wrong offset for SimulationStatistics.gpuMemHeapBroadPhase, expected 168 got %v", offset_of(SimulationStatistics, gpuMemHeapBroadPhase))
+    testing.expectf(t, size_of(SimulationStatistics{}.gpuMemHeapBroadPhase) == 8, "Wrong size for SimulationStatistics.gpuMemHeapBroadPhase, expected 8 got %v", size_of(SimulationStatistics{}.gpuMemHeapBroadPhase))
     testing.expectf(t, offset_of(SimulationStatistics, gpuMemHeapNarrowPhase) == 176, "Wrong offset for SimulationStatistics.gpuMemHeapNarrowPhase, expected 176 got %v", offset_of(SimulationStatistics, gpuMemHeapNarrowPhase))
+    testing.expectf(t, size_of(SimulationStatistics{}.gpuMemHeapNarrowPhase) == 8, "Wrong size for SimulationStatistics.gpuMemHeapNarrowPhase, expected 8 got %v", size_of(SimulationStatistics{}.gpuMemHeapNarrowPhase))
     testing.expectf(t, offset_of(SimulationStatistics, gpuMemHeapSolver) == 184, "Wrong offset for SimulationStatistics.gpuMemHeapSolver, expected 184 got %v", offset_of(SimulationStatistics, gpuMemHeapSolver))
+    testing.expectf(t, size_of(SimulationStatistics{}.gpuMemHeapSolver) == 8, "Wrong size for SimulationStatistics.gpuMemHeapSolver, expected 8 got %v", size_of(SimulationStatistics{}.gpuMemHeapSolver))
     testing.expectf(t, offset_of(SimulationStatistics, gpuMemHeapArticulation) == 192, "Wrong offset for SimulationStatistics.gpuMemHeapArticulation, expected 192 got %v", offset_of(SimulationStatistics, gpuMemHeapArticulation))
+    testing.expectf(t, size_of(SimulationStatistics{}.gpuMemHeapArticulation) == 8, "Wrong size for SimulationStatistics.gpuMemHeapArticulation, expected 8 got %v", size_of(SimulationStatistics{}.gpuMemHeapArticulation))
     testing.expectf(t, offset_of(SimulationStatistics, gpuMemHeapSimulation) == 200, "Wrong offset for SimulationStatistics.gpuMemHeapSimulation, expected 200 got %v", offset_of(SimulationStatistics, gpuMemHeapSimulation))
+    testing.expectf(t, size_of(SimulationStatistics{}.gpuMemHeapSimulation) == 8, "Wrong size for SimulationStatistics.gpuMemHeapSimulation, expected 8 got %v", size_of(SimulationStatistics{}.gpuMemHeapSimulation))
     testing.expectf(t, offset_of(SimulationStatistics, gpuMemHeapSimulationArticulation) == 208, "Wrong offset for SimulationStatistics.gpuMemHeapSimulationArticulation, expected 208 got %v", offset_of(SimulationStatistics, gpuMemHeapSimulationArticulation))
+    testing.expectf(t, size_of(SimulationStatistics{}.gpuMemHeapSimulationArticulation) == 8, "Wrong size for SimulationStatistics.gpuMemHeapSimulationArticulation, expected 8 got %v", size_of(SimulationStatistics{}.gpuMemHeapSimulationArticulation))
     testing.expectf(t, offset_of(SimulationStatistics, gpuMemHeapSimulationParticles) == 216, "Wrong offset for SimulationStatistics.gpuMemHeapSimulationParticles, expected 216 got %v", offset_of(SimulationStatistics, gpuMemHeapSimulationParticles))
+    testing.expectf(t, size_of(SimulationStatistics{}.gpuMemHeapSimulationParticles) == 8, "Wrong size for SimulationStatistics.gpuMemHeapSimulationParticles, expected 8 got %v", size_of(SimulationStatistics{}.gpuMemHeapSimulationParticles))
     testing.expectf(t, offset_of(SimulationStatistics, gpuMemHeapSimulationSoftBody) == 224, "Wrong offset for SimulationStatistics.gpuMemHeapSimulationSoftBody, expected 224 got %v", offset_of(SimulationStatistics, gpuMemHeapSimulationSoftBody))
+    testing.expectf(t, size_of(SimulationStatistics{}.gpuMemHeapSimulationSoftBody) == 8, "Wrong size for SimulationStatistics.gpuMemHeapSimulationSoftBody, expected 8 got %v", size_of(SimulationStatistics{}.gpuMemHeapSimulationSoftBody))
     testing.expectf(t, offset_of(SimulationStatistics, gpuMemHeapSimulationFEMCloth) == 232, "Wrong offset for SimulationStatistics.gpuMemHeapSimulationFEMCloth, expected 232 got %v", offset_of(SimulationStatistics, gpuMemHeapSimulationFEMCloth))
+    testing.expectf(t, size_of(SimulationStatistics{}.gpuMemHeapSimulationFEMCloth) == 8, "Wrong size for SimulationStatistics.gpuMemHeapSimulationFEMCloth, expected 8 got %v", size_of(SimulationStatistics{}.gpuMemHeapSimulationFEMCloth))
     testing.expectf(t, offset_of(SimulationStatistics, gpuMemHeapSimulationHairSystem) == 240, "Wrong offset for SimulationStatistics.gpuMemHeapSimulationHairSystem, expected 240 got %v", offset_of(SimulationStatistics, gpuMemHeapSimulationHairSystem))
+    testing.expectf(t, size_of(SimulationStatistics{}.gpuMemHeapSimulationHairSystem) == 8, "Wrong size for SimulationStatistics.gpuMemHeapSimulationHairSystem, expected 8 got %v", size_of(SimulationStatistics{}.gpuMemHeapSimulationHairSystem))
     testing.expectf(t, offset_of(SimulationStatistics, gpuMemHeapParticles) == 248, "Wrong offset for SimulationStatistics.gpuMemHeapParticles, expected 248 got %v", offset_of(SimulationStatistics, gpuMemHeapParticles))
+    testing.expectf(t, size_of(SimulationStatistics{}.gpuMemHeapParticles) == 8, "Wrong size for SimulationStatistics.gpuMemHeapParticles, expected 8 got %v", size_of(SimulationStatistics{}.gpuMemHeapParticles))
     testing.expectf(t, offset_of(SimulationStatistics, gpuMemHeapSoftBodies) == 256, "Wrong offset for SimulationStatistics.gpuMemHeapSoftBodies, expected 256 got %v", offset_of(SimulationStatistics, gpuMemHeapSoftBodies))
+    testing.expectf(t, size_of(SimulationStatistics{}.gpuMemHeapSoftBodies) == 8, "Wrong size for SimulationStatistics.gpuMemHeapSoftBodies, expected 8 got %v", size_of(SimulationStatistics{}.gpuMemHeapSoftBodies))
     testing.expectf(t, offset_of(SimulationStatistics, gpuMemHeapFEMCloths) == 264, "Wrong offset for SimulationStatistics.gpuMemHeapFEMCloths, expected 264 got %v", offset_of(SimulationStatistics, gpuMemHeapFEMCloths))
+    testing.expectf(t, size_of(SimulationStatistics{}.gpuMemHeapFEMCloths) == 8, "Wrong size for SimulationStatistics.gpuMemHeapFEMCloths, expected 8 got %v", size_of(SimulationStatistics{}.gpuMemHeapFEMCloths))
     testing.expectf(t, offset_of(SimulationStatistics, gpuMemHeapHairSystems) == 272, "Wrong offset for SimulationStatistics.gpuMemHeapHairSystems, expected 272 got %v", offset_of(SimulationStatistics, gpuMemHeapHairSystems))
+    testing.expectf(t, size_of(SimulationStatistics{}.gpuMemHeapHairSystems) == 8, "Wrong size for SimulationStatistics.gpuMemHeapHairSystems, expected 8 got %v", size_of(SimulationStatistics{}.gpuMemHeapHairSystems))
     testing.expectf(t, offset_of(SimulationStatistics, gpuMemHeapOther) == 280, "Wrong offset for SimulationStatistics.gpuMemHeapOther, expected 280 got %v", offset_of(SimulationStatistics, gpuMemHeapOther))
+    testing.expectf(t, size_of(SimulationStatistics{}.gpuMemHeapOther) == 8, "Wrong size for SimulationStatistics.gpuMemHeapOther, expected 8 got %v", size_of(SimulationStatistics{}.gpuMemHeapOther))
     testing.expectf(t, offset_of(SimulationStatistics, nbBroadPhaseAdds) == 288, "Wrong offset for SimulationStatistics.nbBroadPhaseAdds, expected 288 got %v", offset_of(SimulationStatistics, nbBroadPhaseAdds))
+    testing.expectf(t, size_of(SimulationStatistics{}.nbBroadPhaseAdds) == 4, "Wrong size for SimulationStatistics.nbBroadPhaseAdds, expected 4 got %v", size_of(SimulationStatistics{}.nbBroadPhaseAdds))
     testing.expectf(t, offset_of(SimulationStatistics, nbBroadPhaseRemoves) == 292, "Wrong offset for SimulationStatistics.nbBroadPhaseRemoves, expected 292 got %v", offset_of(SimulationStatistics, nbBroadPhaseRemoves))
+    testing.expectf(t, size_of(SimulationStatistics{}.nbBroadPhaseRemoves) == 4, "Wrong size for SimulationStatistics.nbBroadPhaseRemoves, expected 4 got %v", size_of(SimulationStatistics{}.nbBroadPhaseRemoves))
     testing.expectf(t, size_of(SimulationStatistics) == 2232, "Wrong size for type SimulationStatistics, expected 2232 got %v", size_of(SimulationStatistics))
 }
 
 @(test)
 test_layout_GpuBodyData :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(GpuBodyData, quat) == 0, "Wrong offset for GpuBodyData.quat, expected 0 got %v", offset_of(GpuBodyData, quat))
+    testing.expectf(t, size_of(GpuBodyData{}.quat) == 16, "Wrong size for GpuBodyData.quat, expected 16 got %v", size_of(GpuBodyData{}.quat))
     testing.expectf(t, offset_of(GpuBodyData, pos) == 16, "Wrong offset for GpuBodyData.pos, expected 16 got %v", offset_of(GpuBodyData, pos))
+    testing.expectf(t, size_of(GpuBodyData{}.pos) == 16, "Wrong size for GpuBodyData.pos, expected 16 got %v", size_of(GpuBodyData{}.pos))
     testing.expectf(t, offset_of(GpuBodyData, linVel) == 32, "Wrong offset for GpuBodyData.linVel, expected 32 got %v", offset_of(GpuBodyData, linVel))
+    testing.expectf(t, size_of(GpuBodyData{}.linVel) == 16, "Wrong size for GpuBodyData.linVel, expected 16 got %v", size_of(GpuBodyData{}.linVel))
     testing.expectf(t, offset_of(GpuBodyData, angVel) == 48, "Wrong offset for GpuBodyData.angVel, expected 48 got %v", offset_of(GpuBodyData, angVel))
+    testing.expectf(t, size_of(GpuBodyData{}.angVel) == 16, "Wrong size for GpuBodyData.angVel, expected 16 got %v", size_of(GpuBodyData{}.angVel))
     testing.expectf(t, size_of(GpuBodyData) == 64, "Wrong size for type GpuBodyData, expected 64 got %v", size_of(GpuBodyData))
 }
 
 @(test)
 test_layout_GpuActorPair :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(GpuActorPair, srcIndex) == 0, "Wrong offset for GpuActorPair.srcIndex, expected 0 got %v", offset_of(GpuActorPair, srcIndex))
+    testing.expectf(t, size_of(GpuActorPair{}.srcIndex) == 4, "Wrong size for GpuActorPair.srcIndex, expected 4 got %v", size_of(GpuActorPair{}.srcIndex))
     testing.expectf(t, offset_of(GpuActorPair, nodeIndex) == 8, "Wrong offset for GpuActorPair.nodeIndex, expected 8 got %v", offset_of(GpuActorPair, nodeIndex))
+    testing.expectf(t, size_of(GpuActorPair{}.nodeIndex) == 8, "Wrong size for GpuActorPair.nodeIndex, expected 8 got %v", size_of(GpuActorPair{}.nodeIndex))
     testing.expectf(t, size_of(GpuActorPair) == 16, "Wrong size for type GpuActorPair, expected 16 got %v", size_of(GpuActorPair))
 }
 
 @(test)
 test_layout_IndexDataPair :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(IndexDataPair, index) == 0, "Wrong offset for IndexDataPair.index, expected 0 got %v", offset_of(IndexDataPair, index))
+    testing.expectf(t, size_of(IndexDataPair{}.index) == 4, "Wrong size for IndexDataPair.index, expected 4 got %v", size_of(IndexDataPair{}.index))
     testing.expectf(t, offset_of(IndexDataPair, data) == 8, "Wrong offset for IndexDataPair.data, expected 8 got %v", offset_of(IndexDataPair, data))
+    testing.expectf(t, size_of(IndexDataPair{}.data) == 8, "Wrong size for IndexDataPair.data, expected 8 got %v", size_of(IndexDataPair{}.data))
     testing.expectf(t, size_of(IndexDataPair) == 16, "Wrong size for type IndexDataPair, expected 16 got %v", size_of(IndexDataPair))
 }
 
@@ -1820,7 +2531,10 @@ test_layout_PvdSceneClient :: proc(t: ^testing.T) {
 @(test)
 test_layout_DominanceGroupPair :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(DominanceGroupPair, dominance0) == 0, "Wrong offset for DominanceGroupPair.dominance0, expected 0 got %v", offset_of(DominanceGroupPair, dominance0))
+    testing.expectf(t, size_of(DominanceGroupPair{}.dominance0) == 1, "Wrong size for DominanceGroupPair.dominance0, expected 1 got %v", size_of(DominanceGroupPair{}.dominance0))
     testing.expectf(t, offset_of(DominanceGroupPair, dominance1) == 1, "Wrong offset for DominanceGroupPair.dominance1, expected 1 got %v", offset_of(DominanceGroupPair, dominance1))
+    testing.expectf(t, size_of(DominanceGroupPair{}.dominance1) == 1, "Wrong size for DominanceGroupPair.dominance1, expected 1 got %v", size_of(DominanceGroupPair{}.dominance1))
     testing.expectf(t, size_of(DominanceGroupPair) == 2, "Wrong size for type DominanceGroupPair, expected 2 got %v", size_of(DominanceGroupPair))
 }
 
@@ -1834,6 +2548,7 @@ test_layout_BroadPhaseCallback :: proc(t: ^testing.T) {
 test_layout_Scene :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(Scene, userData) == 8, "Wrong offset for Scene.userData, expected 8 got %v", offset_of(Scene, userData))
+    testing.expectf(t, size_of(Scene{}.userData) == 8, "Wrong size for Scene.userData, expected 8 got %v", size_of(Scene{}.userData))
     testing.expectf(t, size_of(Scene) == 16, "Wrong size for type Scene, expected 16 got %v", size_of(Scene))
 }
 
@@ -1852,6 +2567,8 @@ test_layout_SceneWriteLock :: proc(t: ^testing.T) {
 @(test)
 test_layout_ContactPairExtraDataItem :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(ContactPairExtraDataItem, type) == 0, "Wrong offset for ContactPairExtraDataItem.type, expected 0 got %v", offset_of(ContactPairExtraDataItem, type))
+    testing.expectf(t, size_of(ContactPairExtraDataItem{}.type) == 1, "Wrong size for ContactPairExtraDataItem.type, expected 1 got %v", size_of(ContactPairExtraDataItem{}.type))
     testing.expectf(t, size_of(ContactPairExtraDataItem) == 1, "Wrong size for type ContactPairExtraDataItem, expected 1 got %v", size_of(ContactPairExtraDataItem))
 }
 
@@ -1871,17 +2588,25 @@ test_layout_ContactPairPose :: proc(t: ^testing.T) {
 test_layout_ContactPairIndex :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(ContactPairIndex, index) == 2, "Wrong offset for ContactPairIndex.index, expected 2 got %v", offset_of(ContactPairIndex, index))
+    testing.expectf(t, size_of(ContactPairIndex{}.index) == 2, "Wrong size for ContactPairIndex.index, expected 2 got %v", size_of(ContactPairIndex{}.index))
     testing.expectf(t, size_of(ContactPairIndex) == 4, "Wrong size for type ContactPairIndex, expected 4 got %v", size_of(ContactPairIndex))
 }
 
 @(test)
 test_layout_ContactPairExtraDataIterator :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(ContactPairExtraDataIterator, currPtr) == 0, "Wrong offset for ContactPairExtraDataIterator.currPtr, expected 0 got %v", offset_of(ContactPairExtraDataIterator, currPtr))
+    testing.expectf(t, size_of(ContactPairExtraDataIterator{}.currPtr) == 8, "Wrong size for ContactPairExtraDataIterator.currPtr, expected 8 got %v", size_of(ContactPairExtraDataIterator{}.currPtr))
     testing.expectf(t, offset_of(ContactPairExtraDataIterator, endPtr) == 8, "Wrong offset for ContactPairExtraDataIterator.endPtr, expected 8 got %v", offset_of(ContactPairExtraDataIterator, endPtr))
+    testing.expectf(t, size_of(ContactPairExtraDataIterator{}.endPtr) == 8, "Wrong size for ContactPairExtraDataIterator.endPtr, expected 8 got %v", size_of(ContactPairExtraDataIterator{}.endPtr))
     testing.expectf(t, offset_of(ContactPairExtraDataIterator, preSolverVelocity) == 16, "Wrong offset for ContactPairExtraDataIterator.preSolverVelocity, expected 16 got %v", offset_of(ContactPairExtraDataIterator, preSolverVelocity))
+    testing.expectf(t, size_of(ContactPairExtraDataIterator{}.preSolverVelocity) == 8, "Wrong size for ContactPairExtraDataIterator.preSolverVelocity, expected 8 got %v", size_of(ContactPairExtraDataIterator{}.preSolverVelocity))
     testing.expectf(t, offset_of(ContactPairExtraDataIterator, postSolverVelocity) == 24, "Wrong offset for ContactPairExtraDataIterator.postSolverVelocity, expected 24 got %v", offset_of(ContactPairExtraDataIterator, postSolverVelocity))
+    testing.expectf(t, size_of(ContactPairExtraDataIterator{}.postSolverVelocity) == 8, "Wrong size for ContactPairExtraDataIterator.postSolverVelocity, expected 8 got %v", size_of(ContactPairExtraDataIterator{}.postSolverVelocity))
     testing.expectf(t, offset_of(ContactPairExtraDataIterator, eventPose) == 32, "Wrong offset for ContactPairExtraDataIterator.eventPose, expected 32 got %v", offset_of(ContactPairExtraDataIterator, eventPose))
+    testing.expectf(t, size_of(ContactPairExtraDataIterator{}.eventPose) == 8, "Wrong size for ContactPairExtraDataIterator.eventPose, expected 8 got %v", size_of(ContactPairExtraDataIterator{}.eventPose))
     testing.expectf(t, offset_of(ContactPairExtraDataIterator, contactPairIndex) == 40, "Wrong offset for ContactPairExtraDataIterator.contactPairIndex, expected 40 got %v", offset_of(ContactPairExtraDataIterator, contactPairIndex))
+    testing.expectf(t, size_of(ContactPairExtraDataIterator{}.contactPairIndex) == 4, "Wrong size for ContactPairExtraDataIterator.contactPairIndex, expected 4 got %v", size_of(ContactPairExtraDataIterator{}.contactPairIndex))
     testing.expectf(t, size_of(ContactPairExtraDataIterator) == 48, "Wrong size for type ContactPairExtraDataIterator, expected 48 got %v", size_of(ContactPairExtraDataIterator))
 }
 
@@ -1889,21 +2614,33 @@ test_layout_ContactPairExtraDataIterator :: proc(t: ^testing.T) {
 test_layout_ContactPairHeader :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(ContactPairHeader, extraDataStream) == 16, "Wrong offset for ContactPairHeader.extraDataStream, expected 16 got %v", offset_of(ContactPairHeader, extraDataStream))
+    testing.expectf(t, size_of(ContactPairHeader{}.extraDataStream) == 8, "Wrong size for ContactPairHeader.extraDataStream, expected 8 got %v", size_of(ContactPairHeader{}.extraDataStream))
     testing.expectf(t, offset_of(ContactPairHeader, extraDataStreamSize) == 24, "Wrong offset for ContactPairHeader.extraDataStreamSize, expected 24 got %v", offset_of(ContactPairHeader, extraDataStreamSize))
+    testing.expectf(t, size_of(ContactPairHeader{}.extraDataStreamSize) == 2, "Wrong size for ContactPairHeader.extraDataStreamSize, expected 2 got %v", size_of(ContactPairHeader{}.extraDataStreamSize))
     testing.expectf(t, offset_of(ContactPairHeader, flags) == 26, "Wrong offset for ContactPairHeader.flags, expected 26 got %v", offset_of(ContactPairHeader, flags))
+    testing.expectf(t, size_of(ContactPairHeader{}.flags) == 2, "Wrong size for ContactPairHeader.flags, expected 2 got %v", size_of(ContactPairHeader{}.flags))
     testing.expectf(t, offset_of(ContactPairHeader, pairs) == 32, "Wrong offset for ContactPairHeader.pairs, expected 32 got %v", offset_of(ContactPairHeader, pairs))
+    testing.expectf(t, size_of(ContactPairHeader{}.pairs) == 8, "Wrong size for ContactPairHeader.pairs, expected 8 got %v", size_of(ContactPairHeader{}.pairs))
     testing.expectf(t, offset_of(ContactPairHeader, nbPairs) == 40, "Wrong offset for ContactPairHeader.nbPairs, expected 40 got %v", offset_of(ContactPairHeader, nbPairs))
+    testing.expectf(t, size_of(ContactPairHeader{}.nbPairs) == 4, "Wrong size for ContactPairHeader.nbPairs, expected 4 got %v", size_of(ContactPairHeader{}.nbPairs))
     testing.expectf(t, size_of(ContactPairHeader) == 48, "Wrong size for type ContactPairHeader, expected 48 got %v", size_of(ContactPairHeader))
 }
 
 @(test)
 test_layout_ContactPairPoint :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(ContactPairPoint, position) == 0, "Wrong offset for ContactPairPoint.position, expected 0 got %v", offset_of(ContactPairPoint, position))
+    testing.expectf(t, size_of(ContactPairPoint{}.position) == 12, "Wrong size for ContactPairPoint.position, expected 12 got %v", size_of(ContactPairPoint{}.position))
     testing.expectf(t, offset_of(ContactPairPoint, separation) == 12, "Wrong offset for ContactPairPoint.separation, expected 12 got %v", offset_of(ContactPairPoint, separation))
+    testing.expectf(t, size_of(ContactPairPoint{}.separation) == 4, "Wrong size for ContactPairPoint.separation, expected 4 got %v", size_of(ContactPairPoint{}.separation))
     testing.expectf(t, offset_of(ContactPairPoint, normal) == 16, "Wrong offset for ContactPairPoint.normal, expected 16 got %v", offset_of(ContactPairPoint, normal))
+    testing.expectf(t, size_of(ContactPairPoint{}.normal) == 12, "Wrong size for ContactPairPoint.normal, expected 12 got %v", size_of(ContactPairPoint{}.normal))
     testing.expectf(t, offset_of(ContactPairPoint, internalFaceIndex0) == 28, "Wrong offset for ContactPairPoint.internalFaceIndex0, expected 28 got %v", offset_of(ContactPairPoint, internalFaceIndex0))
+    testing.expectf(t, size_of(ContactPairPoint{}.internalFaceIndex0) == 4, "Wrong size for ContactPairPoint.internalFaceIndex0, expected 4 got %v", size_of(ContactPairPoint{}.internalFaceIndex0))
     testing.expectf(t, offset_of(ContactPairPoint, impulse) == 32, "Wrong offset for ContactPairPoint.impulse, expected 32 got %v", offset_of(ContactPairPoint, impulse))
+    testing.expectf(t, size_of(ContactPairPoint{}.impulse) == 12, "Wrong size for ContactPairPoint.impulse, expected 12 got %v", size_of(ContactPairPoint{}.impulse))
     testing.expectf(t, offset_of(ContactPairPoint, internalFaceIndex1) == 44, "Wrong offset for ContactPairPoint.internalFaceIndex1, expected 44 got %v", offset_of(ContactPairPoint, internalFaceIndex1))
+    testing.expectf(t, size_of(ContactPairPoint{}.internalFaceIndex1) == 4, "Wrong size for ContactPairPoint.internalFaceIndex1, expected 4 got %v", size_of(ContactPairPoint{}.internalFaceIndex1))
     testing.expectf(t, size_of(ContactPairPoint) == 48, "Wrong size for type ContactPairPoint, expected 48 got %v", size_of(ContactPairPoint))
 }
 
@@ -1911,33 +2648,53 @@ test_layout_ContactPairPoint :: proc(t: ^testing.T) {
 test_layout_ContactPair :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(ContactPair, contactPatches) == 16, "Wrong offset for ContactPair.contactPatches, expected 16 got %v", offset_of(ContactPair, contactPatches))
+    testing.expectf(t, size_of(ContactPair{}.contactPatches) == 8, "Wrong size for ContactPair.contactPatches, expected 8 got %v", size_of(ContactPair{}.contactPatches))
     testing.expectf(t, offset_of(ContactPair, contactPoints) == 24, "Wrong offset for ContactPair.contactPoints, expected 24 got %v", offset_of(ContactPair, contactPoints))
+    testing.expectf(t, size_of(ContactPair{}.contactPoints) == 8, "Wrong size for ContactPair.contactPoints, expected 8 got %v", size_of(ContactPair{}.contactPoints))
     testing.expectf(t, offset_of(ContactPair, contactImpulses) == 32, "Wrong offset for ContactPair.contactImpulses, expected 32 got %v", offset_of(ContactPair, contactImpulses))
+    testing.expectf(t, size_of(ContactPair{}.contactImpulses) == 8, "Wrong size for ContactPair.contactImpulses, expected 8 got %v", size_of(ContactPair{}.contactImpulses))
     testing.expectf(t, offset_of(ContactPair, requiredBufferSize) == 40, "Wrong offset for ContactPair.requiredBufferSize, expected 40 got %v", offset_of(ContactPair, requiredBufferSize))
+    testing.expectf(t, size_of(ContactPair{}.requiredBufferSize) == 4, "Wrong size for ContactPair.requiredBufferSize, expected 4 got %v", size_of(ContactPair{}.requiredBufferSize))
     testing.expectf(t, offset_of(ContactPair, contactCount) == 44, "Wrong offset for ContactPair.contactCount, expected 44 got %v", offset_of(ContactPair, contactCount))
+    testing.expectf(t, size_of(ContactPair{}.contactCount) == 1, "Wrong size for ContactPair.contactCount, expected 1 got %v", size_of(ContactPair{}.contactCount))
     testing.expectf(t, offset_of(ContactPair, patchCount) == 45, "Wrong offset for ContactPair.patchCount, expected 45 got %v", offset_of(ContactPair, patchCount))
+    testing.expectf(t, size_of(ContactPair{}.patchCount) == 1, "Wrong size for ContactPair.patchCount, expected 1 got %v", size_of(ContactPair{}.patchCount))
     testing.expectf(t, offset_of(ContactPair, contactStreamSize) == 46, "Wrong offset for ContactPair.contactStreamSize, expected 46 got %v", offset_of(ContactPair, contactStreamSize))
+    testing.expectf(t, size_of(ContactPair{}.contactStreamSize) == 2, "Wrong size for ContactPair.contactStreamSize, expected 2 got %v", size_of(ContactPair{}.contactStreamSize))
     testing.expectf(t, offset_of(ContactPair, flags) == 48, "Wrong offset for ContactPair.flags, expected 48 got %v", offset_of(ContactPair, flags))
+    testing.expectf(t, size_of(ContactPair{}.flags) == 2, "Wrong size for ContactPair.flags, expected 2 got %v", size_of(ContactPair{}.flags))
     testing.expectf(t, offset_of(ContactPair, events) == 50, "Wrong offset for ContactPair.events, expected 50 got %v", offset_of(ContactPair, events))
+    testing.expectf(t, size_of(ContactPair{}.events) == 2, "Wrong size for ContactPair.events, expected 2 got %v", size_of(ContactPair{}.events))
     testing.expectf(t, size_of(ContactPair) == 64, "Wrong size for type ContactPair, expected 64 got %v", size_of(ContactPair))
 }
 
 @(test)
 test_layout_TriggerPair :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(TriggerPair, triggerShape) == 0, "Wrong offset for TriggerPair.triggerShape, expected 0 got %v", offset_of(TriggerPair, triggerShape))
+    testing.expectf(t, size_of(TriggerPair{}.triggerShape) == 8, "Wrong size for TriggerPair.triggerShape, expected 8 got %v", size_of(TriggerPair{}.triggerShape))
     testing.expectf(t, offset_of(TriggerPair, triggerActor) == 8, "Wrong offset for TriggerPair.triggerActor, expected 8 got %v", offset_of(TriggerPair, triggerActor))
+    testing.expectf(t, size_of(TriggerPair{}.triggerActor) == 8, "Wrong size for TriggerPair.triggerActor, expected 8 got %v", size_of(TriggerPair{}.triggerActor))
     testing.expectf(t, offset_of(TriggerPair, otherShape) == 16, "Wrong offset for TriggerPair.otherShape, expected 16 got %v", offset_of(TriggerPair, otherShape))
+    testing.expectf(t, size_of(TriggerPair{}.otherShape) == 8, "Wrong size for TriggerPair.otherShape, expected 8 got %v", size_of(TriggerPair{}.otherShape))
     testing.expectf(t, offset_of(TriggerPair, otherActor) == 24, "Wrong offset for TriggerPair.otherActor, expected 24 got %v", offset_of(TriggerPair, otherActor))
+    testing.expectf(t, size_of(TriggerPair{}.otherActor) == 8, "Wrong size for TriggerPair.otherActor, expected 8 got %v", size_of(TriggerPair{}.otherActor))
     testing.expectf(t, offset_of(TriggerPair, status) == 32, "Wrong offset for TriggerPair.status, expected 32 got %v", offset_of(TriggerPair, status))
+    testing.expectf(t, size_of(TriggerPair{}.status) == 4, "Wrong size for TriggerPair.status, expected 4 got %v", size_of(TriggerPair{}.status))
     testing.expectf(t, offset_of(TriggerPair, flags) == 36, "Wrong offset for TriggerPair.flags, expected 36 got %v", offset_of(TriggerPair, flags))
+    testing.expectf(t, size_of(TriggerPair{}.flags) == 1, "Wrong size for TriggerPair.flags, expected 1 got %v", size_of(TriggerPair{}.flags))
     testing.expectf(t, size_of(TriggerPair) == 40, "Wrong size for type TriggerPair, expected 40 got %v", size_of(TriggerPair))
 }
 
 @(test)
 test_layout_ConstraintInfo :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(ConstraintInfo, constraint) == 0, "Wrong offset for ConstraintInfo.constraint, expected 0 got %v", offset_of(ConstraintInfo, constraint))
+    testing.expectf(t, size_of(ConstraintInfo{}.constraint) == 8, "Wrong size for ConstraintInfo.constraint, expected 8 got %v", size_of(ConstraintInfo{}.constraint))
     testing.expectf(t, offset_of(ConstraintInfo, externalReference) == 8, "Wrong offset for ConstraintInfo.externalReference, expected 8 got %v", offset_of(ConstraintInfo, externalReference))
+    testing.expectf(t, size_of(ConstraintInfo{}.externalReference) == 8, "Wrong size for ConstraintInfo.externalReference, expected 8 got %v", size_of(ConstraintInfo{}.externalReference))
     testing.expectf(t, offset_of(ConstraintInfo, type) == 16, "Wrong offset for ConstraintInfo.type, expected 16 got %v", offset_of(ConstraintInfo, type))
+    testing.expectf(t, size_of(ConstraintInfo{}.type) == 4, "Wrong size for ConstraintInfo.type, expected 4 got %v", size_of(ConstraintInfo{}.type))
     testing.expectf(t, size_of(ConstraintInfo) == 24, "Wrong size for type ConstraintInfo, expected 24 got %v", size_of(ConstraintInfo))
 }
 
@@ -1950,11 +2707,18 @@ test_layout_SimulationEventCallback :: proc(t: ^testing.T) {
 @(test)
 test_layout_FEMParameters :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(FEMParameters, velocityDamping) == 0, "Wrong offset for FEMParameters.velocityDamping, expected 0 got %v", offset_of(FEMParameters, velocityDamping))
+    testing.expectf(t, size_of(FEMParameters{}.velocityDamping) == 4, "Wrong size for FEMParameters.velocityDamping, expected 4 got %v", size_of(FEMParameters{}.velocityDamping))
     testing.expectf(t, offset_of(FEMParameters, settlingThreshold) == 4, "Wrong offset for FEMParameters.settlingThreshold, expected 4 got %v", offset_of(FEMParameters, settlingThreshold))
+    testing.expectf(t, size_of(FEMParameters{}.settlingThreshold) == 4, "Wrong size for FEMParameters.settlingThreshold, expected 4 got %v", size_of(FEMParameters{}.settlingThreshold))
     testing.expectf(t, offset_of(FEMParameters, sleepThreshold) == 8, "Wrong offset for FEMParameters.sleepThreshold, expected 8 got %v", offset_of(FEMParameters, sleepThreshold))
+    testing.expectf(t, size_of(FEMParameters{}.sleepThreshold) == 4, "Wrong size for FEMParameters.sleepThreshold, expected 4 got %v", size_of(FEMParameters{}.sleepThreshold))
     testing.expectf(t, offset_of(FEMParameters, sleepDamping) == 12, "Wrong offset for FEMParameters.sleepDamping, expected 12 got %v", offset_of(FEMParameters, sleepDamping))
+    testing.expectf(t, size_of(FEMParameters{}.sleepDamping) == 4, "Wrong size for FEMParameters.sleepDamping, expected 4 got %v", size_of(FEMParameters{}.sleepDamping))
     testing.expectf(t, offset_of(FEMParameters, selfCollisionFilterDistance) == 16, "Wrong offset for FEMParameters.selfCollisionFilterDistance, expected 16 got %v", offset_of(FEMParameters, selfCollisionFilterDistance))
+    testing.expectf(t, size_of(FEMParameters{}.selfCollisionFilterDistance) == 4, "Wrong size for FEMParameters.selfCollisionFilterDistance, expected 4 got %v", size_of(FEMParameters{}.selfCollisionFilterDistance))
     testing.expectf(t, offset_of(FEMParameters, selfCollisionStressTolerance) == 20, "Wrong offset for FEMParameters.selfCollisionStressTolerance, expected 20 got %v", offset_of(FEMParameters, selfCollisionStressTolerance))
+    testing.expectf(t, size_of(FEMParameters{}.selfCollisionStressTolerance) == 4, "Wrong size for FEMParameters.selfCollisionStressTolerance, expected 4 got %v", size_of(FEMParameters{}.selfCollisionStressTolerance))
     testing.expectf(t, size_of(FEMParameters) == 24, "Wrong size for type FEMParameters, expected 24 got %v", size_of(FEMParameters))
 }
 
@@ -1967,8 +2731,12 @@ test_layout_PruningStructure :: proc(t: ^testing.T) {
 @(test)
 test_layout_ExtendedVec3 :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(ExtendedVec3, x) == 0, "Wrong offset for ExtendedVec3.x, expected 0 got %v", offset_of(ExtendedVec3, x))
+    testing.expectf(t, size_of(ExtendedVec3{}.x) == 8, "Wrong size for ExtendedVec3.x, expected 8 got %v", size_of(ExtendedVec3{}.x))
     testing.expectf(t, offset_of(ExtendedVec3, y) == 8, "Wrong offset for ExtendedVec3.y, expected 8 got %v", offset_of(ExtendedVec3, y))
+    testing.expectf(t, size_of(ExtendedVec3{}.y) == 8, "Wrong size for ExtendedVec3.y, expected 8 got %v", size_of(ExtendedVec3{}.y))
     testing.expectf(t, offset_of(ExtendedVec3, z) == 16, "Wrong offset for ExtendedVec3.z, expected 16 got %v", offset_of(ExtendedVec3, z))
+    testing.expectf(t, size_of(ExtendedVec3{}.z) == 8, "Wrong size for ExtendedVec3.z, expected 8 got %v", size_of(ExtendedVec3{}.z))
     testing.expectf(t, size_of(ExtendedVec3) == 24, "Wrong size for type ExtendedVec3, expected 24 got %v", size_of(ExtendedVec3))
 }
 
@@ -1976,8 +2744,11 @@ test_layout_ExtendedVec3 :: proc(t: ^testing.T) {
 test_layout_Obstacle :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(Obstacle, mUserData) == 8, "Wrong offset for Obstacle.mUserData, expected 8 got %v", offset_of(Obstacle, mUserData))
+    testing.expectf(t, size_of(Obstacle{}.mUserData) == 8, "Wrong size for Obstacle.mUserData, expected 8 got %v", size_of(Obstacle{}.mUserData))
     testing.expectf(t, offset_of(Obstacle, mPos) == 16, "Wrong offset for Obstacle.mPos, expected 16 got %v", offset_of(Obstacle, mPos))
+    testing.expectf(t, size_of(Obstacle{}.mPos) == 24, "Wrong size for Obstacle.mPos, expected 24 got %v", size_of(Obstacle{}.mPos))
     testing.expectf(t, offset_of(Obstacle, mRot) == 40, "Wrong offset for Obstacle.mRot, expected 40 got %v", offset_of(Obstacle, mRot))
+    testing.expectf(t, size_of(Obstacle{}.mRot) == 16, "Wrong size for Obstacle.mRot, expected 16 got %v", size_of(Obstacle{}.mRot))
     testing.expectf(t, size_of(Obstacle) == 56, "Wrong size for type Obstacle, expected 56 got %v", size_of(Obstacle))
 }
 
@@ -1985,6 +2756,7 @@ test_layout_Obstacle :: proc(t: ^testing.T) {
 test_layout_BoxObstacle :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(BoxObstacle, mHalfExtents) == 56, "Wrong offset for BoxObstacle.mHalfExtents, expected 56 got %v", offset_of(BoxObstacle, mHalfExtents))
+    testing.expectf(t, size_of(BoxObstacle{}.mHalfExtents) == 12, "Wrong size for BoxObstacle.mHalfExtents, expected 12 got %v", size_of(BoxObstacle{}.mHalfExtents))
     testing.expectf(t, size_of(BoxObstacle) == 72, "Wrong size for type BoxObstacle, expected 72 got %v", size_of(BoxObstacle))
 }
 
@@ -1992,7 +2764,9 @@ test_layout_BoxObstacle :: proc(t: ^testing.T) {
 test_layout_CapsuleObstacle :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(CapsuleObstacle, mHalfHeight) == 56, "Wrong offset for CapsuleObstacle.mHalfHeight, expected 56 got %v", offset_of(CapsuleObstacle, mHalfHeight))
+    testing.expectf(t, size_of(CapsuleObstacle{}.mHalfHeight) == 4, "Wrong size for CapsuleObstacle.mHalfHeight, expected 4 got %v", size_of(CapsuleObstacle{}.mHalfHeight))
     testing.expectf(t, offset_of(CapsuleObstacle, mRadius) == 60, "Wrong offset for CapsuleObstacle.mRadius, expected 60 got %v", offset_of(CapsuleObstacle, mRadius))
+    testing.expectf(t, size_of(CapsuleObstacle{}.mRadius) == 4, "Wrong size for CapsuleObstacle.mRadius, expected 4 got %v", size_of(CapsuleObstacle{}.mRadius))
     testing.expectf(t, size_of(CapsuleObstacle) == 64, "Wrong size for type CapsuleObstacle, expected 64 got %v", size_of(CapsuleObstacle))
 }
 
@@ -2005,32 +2779,52 @@ test_layout_ObstacleContext :: proc(t: ^testing.T) {
 @(test)
 test_layout_ControllerState :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(ControllerState, deltaXP) == 0, "Wrong offset for ControllerState.deltaXP, expected 0 got %v", offset_of(ControllerState, deltaXP))
+    testing.expectf(t, size_of(ControllerState{}.deltaXP) == 12, "Wrong size for ControllerState.deltaXP, expected 12 got %v", size_of(ControllerState{}.deltaXP))
     testing.expectf(t, offset_of(ControllerState, touchedShape) == 16, "Wrong offset for ControllerState.touchedShape, expected 16 got %v", offset_of(ControllerState, touchedShape))
+    testing.expectf(t, size_of(ControllerState{}.touchedShape) == 8, "Wrong size for ControllerState.touchedShape, expected 8 got %v", size_of(ControllerState{}.touchedShape))
     testing.expectf(t, offset_of(ControllerState, touchedActor) == 24, "Wrong offset for ControllerState.touchedActor, expected 24 got %v", offset_of(ControllerState, touchedActor))
+    testing.expectf(t, size_of(ControllerState{}.touchedActor) == 8, "Wrong size for ControllerState.touchedActor, expected 8 got %v", size_of(ControllerState{}.touchedActor))
     testing.expectf(t, offset_of(ControllerState, touchedObstacleHandle) == 32, "Wrong offset for ControllerState.touchedObstacleHandle, expected 32 got %v", offset_of(ControllerState, touchedObstacleHandle))
+    testing.expectf(t, size_of(ControllerState{}.touchedObstacleHandle) == 4, "Wrong size for ControllerState.touchedObstacleHandle, expected 4 got %v", size_of(ControllerState{}.touchedObstacleHandle))
     testing.expectf(t, offset_of(ControllerState, collisionFlags) == 36, "Wrong offset for ControllerState.collisionFlags, expected 36 got %v", offset_of(ControllerState, collisionFlags))
+    testing.expectf(t, size_of(ControllerState{}.collisionFlags) == 4, "Wrong size for ControllerState.collisionFlags, expected 4 got %v", size_of(ControllerState{}.collisionFlags))
     testing.expectf(t, offset_of(ControllerState, standOnAnotherCCT) == 40, "Wrong offset for ControllerState.standOnAnotherCCT, expected 40 got %v", offset_of(ControllerState, standOnAnotherCCT))
+    testing.expectf(t, size_of(ControllerState{}.standOnAnotherCCT) == 1, "Wrong size for ControllerState.standOnAnotherCCT, expected 1 got %v", size_of(ControllerState{}.standOnAnotherCCT))
     testing.expectf(t, offset_of(ControllerState, standOnObstacle) == 41, "Wrong offset for ControllerState.standOnObstacle, expected 41 got %v", offset_of(ControllerState, standOnObstacle))
+    testing.expectf(t, size_of(ControllerState{}.standOnObstacle) == 1, "Wrong size for ControllerState.standOnObstacle, expected 1 got %v", size_of(ControllerState{}.standOnObstacle))
     testing.expectf(t, offset_of(ControllerState, isMovingUp) == 42, "Wrong offset for ControllerState.isMovingUp, expected 42 got %v", offset_of(ControllerState, isMovingUp))
+    testing.expectf(t, size_of(ControllerState{}.isMovingUp) == 1, "Wrong size for ControllerState.isMovingUp, expected 1 got %v", size_of(ControllerState{}.isMovingUp))
     testing.expectf(t, size_of(ControllerState) == 48, "Wrong size for type ControllerState, expected 48 got %v", size_of(ControllerState))
 }
 
 @(test)
 test_layout_ControllerStats :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(ControllerStats, nbIterations) == 0, "Wrong offset for ControllerStats.nbIterations, expected 0 got %v", offset_of(ControllerStats, nbIterations))
+    testing.expectf(t, size_of(ControllerStats{}.nbIterations) == 2, "Wrong size for ControllerStats.nbIterations, expected 2 got %v", size_of(ControllerStats{}.nbIterations))
     testing.expectf(t, offset_of(ControllerStats, nbFullUpdates) == 2, "Wrong offset for ControllerStats.nbFullUpdates, expected 2 got %v", offset_of(ControllerStats, nbFullUpdates))
+    testing.expectf(t, size_of(ControllerStats{}.nbFullUpdates) == 2, "Wrong size for ControllerStats.nbFullUpdates, expected 2 got %v", size_of(ControllerStats{}.nbFullUpdates))
     testing.expectf(t, offset_of(ControllerStats, nbPartialUpdates) == 4, "Wrong offset for ControllerStats.nbPartialUpdates, expected 4 got %v", offset_of(ControllerStats, nbPartialUpdates))
+    testing.expectf(t, size_of(ControllerStats{}.nbPartialUpdates) == 2, "Wrong size for ControllerStats.nbPartialUpdates, expected 2 got %v", size_of(ControllerStats{}.nbPartialUpdates))
     testing.expectf(t, offset_of(ControllerStats, nbTessellation) == 6, "Wrong offset for ControllerStats.nbTessellation, expected 6 got %v", offset_of(ControllerStats, nbTessellation))
+    testing.expectf(t, size_of(ControllerStats{}.nbTessellation) == 2, "Wrong size for ControllerStats.nbTessellation, expected 2 got %v", size_of(ControllerStats{}.nbTessellation))
     testing.expectf(t, size_of(ControllerStats) == 8, "Wrong size for type ControllerStats, expected 8 got %v", size_of(ControllerStats))
 }
 
 @(test)
 test_layout_ControllerHit :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(ControllerHit, controller) == 0, "Wrong offset for ControllerHit.controller, expected 0 got %v", offset_of(ControllerHit, controller))
+    testing.expectf(t, size_of(ControllerHit{}.controller) == 8, "Wrong size for ControllerHit.controller, expected 8 got %v", size_of(ControllerHit{}.controller))
     testing.expectf(t, offset_of(ControllerHit, worldPos) == 8, "Wrong offset for ControllerHit.worldPos, expected 8 got %v", offset_of(ControllerHit, worldPos))
+    testing.expectf(t, size_of(ControllerHit{}.worldPos) == 24, "Wrong size for ControllerHit.worldPos, expected 24 got %v", size_of(ControllerHit{}.worldPos))
     testing.expectf(t, offset_of(ControllerHit, worldNormal) == 32, "Wrong offset for ControllerHit.worldNormal, expected 32 got %v", offset_of(ControllerHit, worldNormal))
+    testing.expectf(t, size_of(ControllerHit{}.worldNormal) == 12, "Wrong size for ControllerHit.worldNormal, expected 12 got %v", size_of(ControllerHit{}.worldNormal))
     testing.expectf(t, offset_of(ControllerHit, dir) == 44, "Wrong offset for ControllerHit.dir, expected 44 got %v", offset_of(ControllerHit, dir))
+    testing.expectf(t, size_of(ControllerHit{}.dir) == 12, "Wrong size for ControllerHit.dir, expected 12 got %v", size_of(ControllerHit{}.dir))
     testing.expectf(t, offset_of(ControllerHit, length) == 56, "Wrong offset for ControllerHit.length, expected 56 got %v", offset_of(ControllerHit, length))
+    testing.expectf(t, size_of(ControllerHit{}.length) == 4, "Wrong size for ControllerHit.length, expected 4 got %v", size_of(ControllerHit{}.length))
     testing.expectf(t, size_of(ControllerHit) == 64, "Wrong size for type ControllerHit, expected 64 got %v", size_of(ControllerHit))
 }
 
@@ -2038,8 +2832,11 @@ test_layout_ControllerHit :: proc(t: ^testing.T) {
 test_layout_ControllerShapeHit :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(ControllerShapeHit, shape) == 64, "Wrong offset for ControllerShapeHit.shape, expected 64 got %v", offset_of(ControllerShapeHit, shape))
+    testing.expectf(t, size_of(ControllerShapeHit{}.shape) == 8, "Wrong size for ControllerShapeHit.shape, expected 8 got %v", size_of(ControllerShapeHit{}.shape))
     testing.expectf(t, offset_of(ControllerShapeHit, actor) == 72, "Wrong offset for ControllerShapeHit.actor, expected 72 got %v", offset_of(ControllerShapeHit, actor))
+    testing.expectf(t, size_of(ControllerShapeHit{}.actor) == 8, "Wrong size for ControllerShapeHit.actor, expected 8 got %v", size_of(ControllerShapeHit{}.actor))
     testing.expectf(t, offset_of(ControllerShapeHit, triangleIndex) == 80, "Wrong offset for ControllerShapeHit.triangleIndex, expected 80 got %v", offset_of(ControllerShapeHit, triangleIndex))
+    testing.expectf(t, size_of(ControllerShapeHit{}.triangleIndex) == 4, "Wrong size for ControllerShapeHit.triangleIndex, expected 4 got %v", size_of(ControllerShapeHit{}.triangleIndex))
     testing.expectf(t, size_of(ControllerShapeHit) == 88, "Wrong size for type ControllerShapeHit, expected 88 got %v", size_of(ControllerShapeHit))
 }
 
@@ -2047,6 +2844,7 @@ test_layout_ControllerShapeHit :: proc(t: ^testing.T) {
 test_layout_ControllersHit :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(ControllersHit, other) == 64, "Wrong offset for ControllersHit.other, expected 64 got %v", offset_of(ControllersHit, other))
+    testing.expectf(t, size_of(ControllersHit{}.other) == 8, "Wrong size for ControllersHit.other, expected 8 got %v", size_of(ControllersHit{}.other))
     testing.expectf(t, size_of(ControllersHit) == 72, "Wrong size for type ControllersHit, expected 72 got %v", size_of(ControllersHit))
 }
 
@@ -2054,6 +2852,7 @@ test_layout_ControllersHit :: proc(t: ^testing.T) {
 test_layout_ControllerObstacleHit :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(ControllerObstacleHit, userData) == 64, "Wrong offset for ControllerObstacleHit.userData, expected 64 got %v", offset_of(ControllerObstacleHit, userData))
+    testing.expectf(t, size_of(ControllerObstacleHit{}.userData) == 8, "Wrong size for ControllerObstacleHit.userData, expected 8 got %v", size_of(ControllerObstacleHit{}.userData))
     testing.expectf(t, size_of(ControllerObstacleHit) == 72, "Wrong size for type ControllerObstacleHit, expected 72 got %v", size_of(ControllerObstacleHit))
 }
 
@@ -2072,9 +2871,14 @@ test_layout_ControllerFilterCallback :: proc(t: ^testing.T) {
 @(test)
 test_layout_ControllerFilters :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(ControllerFilters, mFilterData) == 0, "Wrong offset for ControllerFilters.mFilterData, expected 0 got %v", offset_of(ControllerFilters, mFilterData))
+    testing.expectf(t, size_of(ControllerFilters{}.mFilterData) == 8, "Wrong size for ControllerFilters.mFilterData, expected 8 got %v", size_of(ControllerFilters{}.mFilterData))
     testing.expectf(t, offset_of(ControllerFilters, mFilterCallback) == 8, "Wrong offset for ControllerFilters.mFilterCallback, expected 8 got %v", offset_of(ControllerFilters, mFilterCallback))
+    testing.expectf(t, size_of(ControllerFilters{}.mFilterCallback) == 8, "Wrong size for ControllerFilters.mFilterCallback, expected 8 got %v", size_of(ControllerFilters{}.mFilterCallback))
     testing.expectf(t, offset_of(ControllerFilters, mFilterFlags) == 16, "Wrong offset for ControllerFilters.mFilterFlags, expected 16 got %v", offset_of(ControllerFilters, mFilterFlags))
+    testing.expectf(t, size_of(ControllerFilters{}.mFilterFlags) == 2, "Wrong size for ControllerFilters.mFilterFlags, expected 2 got %v", size_of(ControllerFilters{}.mFilterFlags))
     testing.expectf(t, offset_of(ControllerFilters, mCCTFilterCallback) == 24, "Wrong offset for ControllerFilters.mCCTFilterCallback, expected 24 got %v", offset_of(ControllerFilters, mCCTFilterCallback))
+    testing.expectf(t, size_of(ControllerFilters{}.mCCTFilterCallback) == 8, "Wrong size for ControllerFilters.mCCTFilterCallback, expected 8 got %v", size_of(ControllerFilters{}.mCCTFilterCallback))
     testing.expectf(t, size_of(ControllerFilters) == 32, "Wrong size for type ControllerFilters, expected 32 got %v", size_of(ControllerFilters))
 }
 
@@ -2082,22 +2886,39 @@ test_layout_ControllerFilters :: proc(t: ^testing.T) {
 test_layout_ControllerDesc :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(ControllerDesc, position) == 8, "Wrong offset for ControllerDesc.position, expected 8 got %v", offset_of(ControllerDesc, position))
+    testing.expectf(t, size_of(ControllerDesc{}.position) == 24, "Wrong size for ControllerDesc.position, expected 24 got %v", size_of(ControllerDesc{}.position))
     testing.expectf(t, offset_of(ControllerDesc, upDirection) == 32, "Wrong offset for ControllerDesc.upDirection, expected 32 got %v", offset_of(ControllerDesc, upDirection))
+    testing.expectf(t, size_of(ControllerDesc{}.upDirection) == 12, "Wrong size for ControllerDesc.upDirection, expected 12 got %v", size_of(ControllerDesc{}.upDirection))
     testing.expectf(t, offset_of(ControllerDesc, slopeLimit) == 44, "Wrong offset for ControllerDesc.slopeLimit, expected 44 got %v", offset_of(ControllerDesc, slopeLimit))
+    testing.expectf(t, size_of(ControllerDesc{}.slopeLimit) == 4, "Wrong size for ControllerDesc.slopeLimit, expected 4 got %v", size_of(ControllerDesc{}.slopeLimit))
     testing.expectf(t, offset_of(ControllerDesc, invisibleWallHeight) == 48, "Wrong offset for ControllerDesc.invisibleWallHeight, expected 48 got %v", offset_of(ControllerDesc, invisibleWallHeight))
+    testing.expectf(t, size_of(ControllerDesc{}.invisibleWallHeight) == 4, "Wrong size for ControllerDesc.invisibleWallHeight, expected 4 got %v", size_of(ControllerDesc{}.invisibleWallHeight))
     testing.expectf(t, offset_of(ControllerDesc, maxJumpHeight) == 52, "Wrong offset for ControllerDesc.maxJumpHeight, expected 52 got %v", offset_of(ControllerDesc, maxJumpHeight))
+    testing.expectf(t, size_of(ControllerDesc{}.maxJumpHeight) == 4, "Wrong size for ControllerDesc.maxJumpHeight, expected 4 got %v", size_of(ControllerDesc{}.maxJumpHeight))
     testing.expectf(t, offset_of(ControllerDesc, contactOffset) == 56, "Wrong offset for ControllerDesc.contactOffset, expected 56 got %v", offset_of(ControllerDesc, contactOffset))
+    testing.expectf(t, size_of(ControllerDesc{}.contactOffset) == 4, "Wrong size for ControllerDesc.contactOffset, expected 4 got %v", size_of(ControllerDesc{}.contactOffset))
     testing.expectf(t, offset_of(ControllerDesc, stepOffset) == 60, "Wrong offset for ControllerDesc.stepOffset, expected 60 got %v", offset_of(ControllerDesc, stepOffset))
+    testing.expectf(t, size_of(ControllerDesc{}.stepOffset) == 4, "Wrong size for ControllerDesc.stepOffset, expected 4 got %v", size_of(ControllerDesc{}.stepOffset))
     testing.expectf(t, offset_of(ControllerDesc, density) == 64, "Wrong offset for ControllerDesc.density, expected 64 got %v", offset_of(ControllerDesc, density))
+    testing.expectf(t, size_of(ControllerDesc{}.density) == 4, "Wrong size for ControllerDesc.density, expected 4 got %v", size_of(ControllerDesc{}.density))
     testing.expectf(t, offset_of(ControllerDesc, scaleCoeff) == 68, "Wrong offset for ControllerDesc.scaleCoeff, expected 68 got %v", offset_of(ControllerDesc, scaleCoeff))
+    testing.expectf(t, size_of(ControllerDesc{}.scaleCoeff) == 4, "Wrong size for ControllerDesc.scaleCoeff, expected 4 got %v", size_of(ControllerDesc{}.scaleCoeff))
     testing.expectf(t, offset_of(ControllerDesc, volumeGrowth) == 72, "Wrong offset for ControllerDesc.volumeGrowth, expected 72 got %v", offset_of(ControllerDesc, volumeGrowth))
+    testing.expectf(t, size_of(ControllerDesc{}.volumeGrowth) == 4, "Wrong size for ControllerDesc.volumeGrowth, expected 4 got %v", size_of(ControllerDesc{}.volumeGrowth))
     testing.expectf(t, offset_of(ControllerDesc, reportCallback) == 80, "Wrong offset for ControllerDesc.reportCallback, expected 80 got %v", offset_of(ControllerDesc, reportCallback))
+    testing.expectf(t, size_of(ControllerDesc{}.reportCallback) == 8, "Wrong size for ControllerDesc.reportCallback, expected 8 got %v", size_of(ControllerDesc{}.reportCallback))
     testing.expectf(t, offset_of(ControllerDesc, behaviorCallback) == 88, "Wrong offset for ControllerDesc.behaviorCallback, expected 88 got %v", offset_of(ControllerDesc, behaviorCallback))
+    testing.expectf(t, size_of(ControllerDesc{}.behaviorCallback) == 8, "Wrong size for ControllerDesc.behaviorCallback, expected 8 got %v", size_of(ControllerDesc{}.behaviorCallback))
     testing.expectf(t, offset_of(ControllerDesc, nonWalkableMode) == 96, "Wrong offset for ControllerDesc.nonWalkableMode, expected 96 got %v", offset_of(ControllerDesc, nonWalkableMode))
+    testing.expectf(t, size_of(ControllerDesc{}.nonWalkableMode) == 4, "Wrong size for ControllerDesc.nonWalkableMode, expected 4 got %v", size_of(ControllerDesc{}.nonWalkableMode))
     testing.expectf(t, offset_of(ControllerDesc, material) == 104, "Wrong offset for ControllerDesc.material, expected 104 got %v", offset_of(ControllerDesc, material))
+    testing.expectf(t, size_of(ControllerDesc{}.material) == 8, "Wrong size for ControllerDesc.material, expected 8 got %v", size_of(ControllerDesc{}.material))
     testing.expectf(t, offset_of(ControllerDesc, registerDeletionListener) == 112, "Wrong offset for ControllerDesc.registerDeletionListener, expected 112 got %v", offset_of(ControllerDesc, registerDeletionListener))
+    testing.expectf(t, size_of(ControllerDesc{}.registerDeletionListener) == 1, "Wrong size for ControllerDesc.registerDeletionListener, expected 1 got %v", size_of(ControllerDesc{}.registerDeletionListener))
     testing.expectf(t, offset_of(ControllerDesc, clientID) == 113, "Wrong offset for ControllerDesc.clientID, expected 113 got %v", offset_of(ControllerDesc, clientID))
+    testing.expectf(t, size_of(ControllerDesc{}.clientID) == 1, "Wrong size for ControllerDesc.clientID, expected 1 got %v", size_of(ControllerDesc{}.clientID))
     testing.expectf(t, offset_of(ControllerDesc, userData) == 120, "Wrong offset for ControllerDesc.userData, expected 120 got %v", offset_of(ControllerDesc, userData))
+    testing.expectf(t, size_of(ControllerDesc{}.userData) == 8, "Wrong size for ControllerDesc.userData, expected 8 got %v", size_of(ControllerDesc{}.userData))
     testing.expectf(t, size_of(ControllerDesc) == 132, "Wrong size for type ControllerDesc, expected 132 got %v", size_of(ControllerDesc))
 }
 
@@ -2111,8 +2932,11 @@ test_layout_Controller :: proc(t: ^testing.T) {
 test_layout_BoxControllerDesc :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(BoxControllerDesc, halfHeight) == 136, "Wrong offset for BoxControllerDesc.halfHeight, expected 136 got %v", offset_of(BoxControllerDesc, halfHeight))
+    testing.expectf(t, size_of(BoxControllerDesc{}.halfHeight) == 4, "Wrong size for BoxControllerDesc.halfHeight, expected 4 got %v", size_of(BoxControllerDesc{}.halfHeight))
     testing.expectf(t, offset_of(BoxControllerDesc, halfSideExtent) == 140, "Wrong offset for BoxControllerDesc.halfSideExtent, expected 140 got %v", offset_of(BoxControllerDesc, halfSideExtent))
+    testing.expectf(t, size_of(BoxControllerDesc{}.halfSideExtent) == 4, "Wrong size for BoxControllerDesc.halfSideExtent, expected 4 got %v", size_of(BoxControllerDesc{}.halfSideExtent))
     testing.expectf(t, offset_of(BoxControllerDesc, halfForwardExtent) == 144, "Wrong offset for BoxControllerDesc.halfForwardExtent, expected 144 got %v", offset_of(BoxControllerDesc, halfForwardExtent))
+    testing.expectf(t, size_of(BoxControllerDesc{}.halfForwardExtent) == 4, "Wrong size for BoxControllerDesc.halfForwardExtent, expected 4 got %v", size_of(BoxControllerDesc{}.halfForwardExtent))
     testing.expectf(t, size_of(BoxControllerDesc) == 152, "Wrong size for type BoxControllerDesc, expected 152 got %v", size_of(BoxControllerDesc))
 }
 
@@ -2126,8 +2950,11 @@ test_layout_BoxController :: proc(t: ^testing.T) {
 test_layout_CapsuleControllerDesc :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(CapsuleControllerDesc, radius) == 136, "Wrong offset for CapsuleControllerDesc.radius, expected 136 got %v", offset_of(CapsuleControllerDesc, radius))
+    testing.expectf(t, size_of(CapsuleControllerDesc{}.radius) == 4, "Wrong size for CapsuleControllerDesc.radius, expected 4 got %v", size_of(CapsuleControllerDesc{}.radius))
     testing.expectf(t, offset_of(CapsuleControllerDesc, height) == 140, "Wrong offset for CapsuleControllerDesc.height, expected 140 got %v", offset_of(CapsuleControllerDesc, height))
+    testing.expectf(t, size_of(CapsuleControllerDesc{}.height) == 4, "Wrong size for CapsuleControllerDesc.height, expected 4 got %v", size_of(CapsuleControllerDesc{}.height))
     testing.expectf(t, offset_of(CapsuleControllerDesc, climbingMode) == 144, "Wrong offset for CapsuleControllerDesc.climbingMode, expected 144 got %v", offset_of(CapsuleControllerDesc, climbingMode))
+    testing.expectf(t, size_of(CapsuleControllerDesc{}.climbingMode) == 4, "Wrong size for CapsuleControllerDesc.climbingMode, expected 4 got %v", size_of(CapsuleControllerDesc{}.climbingMode))
     testing.expectf(t, size_of(CapsuleControllerDesc) == 152, "Wrong size for type CapsuleControllerDesc, expected 152 got %v", size_of(CapsuleControllerDesc))
 }
 
@@ -2152,40 +2979,68 @@ test_layout_ControllerManager :: proc(t: ^testing.T) {
 @(test)
 test_layout_Dim3 :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(Dim3, x) == 0, "Wrong offset for Dim3.x, expected 0 got %v", offset_of(Dim3, x))
+    testing.expectf(t, size_of(Dim3{}.x) == 4, "Wrong size for Dim3.x, expected 4 got %v", size_of(Dim3{}.x))
     testing.expectf(t, offset_of(Dim3, y) == 4, "Wrong offset for Dim3.y, expected 4 got %v", offset_of(Dim3, y))
+    testing.expectf(t, size_of(Dim3{}.y) == 4, "Wrong size for Dim3.y, expected 4 got %v", size_of(Dim3{}.y))
     testing.expectf(t, offset_of(Dim3, z) == 8, "Wrong offset for Dim3.z, expected 8 got %v", offset_of(Dim3, z))
+    testing.expectf(t, size_of(Dim3{}.z) == 4, "Wrong size for Dim3.z, expected 4 got %v", size_of(Dim3{}.z))
     testing.expectf(t, size_of(Dim3) == 12, "Wrong size for type Dim3, expected 12 got %v", size_of(Dim3))
 }
 
 @(test)
 test_layout_SDFDesc :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(SDFDesc, sdf) == 0, "Wrong offset for SDFDesc.sdf, expected 0 got %v", offset_of(SDFDesc, sdf))
+    testing.expectf(t, size_of(SDFDesc{}.sdf) == 24, "Wrong size for SDFDesc.sdf, expected 24 got %v", size_of(SDFDesc{}.sdf))
     testing.expectf(t, offset_of(SDFDesc, dims) == 24, "Wrong offset for SDFDesc.dims, expected 24 got %v", offset_of(SDFDesc, dims))
+    testing.expectf(t, size_of(SDFDesc{}.dims) == 12, "Wrong size for SDFDesc.dims, expected 12 got %v", size_of(SDFDesc{}.dims))
     testing.expectf(t, offset_of(SDFDesc, meshLower) == 36, "Wrong offset for SDFDesc.meshLower, expected 36 got %v", offset_of(SDFDesc, meshLower))
+    testing.expectf(t, size_of(SDFDesc{}.meshLower) == 12, "Wrong size for SDFDesc.meshLower, expected 12 got %v", size_of(SDFDesc{}.meshLower))
     testing.expectf(t, offset_of(SDFDesc, spacing) == 48, "Wrong offset for SDFDesc.spacing, expected 48 got %v", offset_of(SDFDesc, spacing))
+    testing.expectf(t, size_of(SDFDesc{}.spacing) == 4, "Wrong size for SDFDesc.spacing, expected 4 got %v", size_of(SDFDesc{}.spacing))
     testing.expectf(t, offset_of(SDFDesc, subgridSize) == 52, "Wrong offset for SDFDesc.subgridSize, expected 52 got %v", offset_of(SDFDesc, subgridSize))
+    testing.expectf(t, size_of(SDFDesc{}.subgridSize) == 4, "Wrong size for SDFDesc.subgridSize, expected 4 got %v", size_of(SDFDesc{}.subgridSize))
     testing.expectf(t, offset_of(SDFDesc, bitsPerSubgridPixel) == 56, "Wrong offset for SDFDesc.bitsPerSubgridPixel, expected 56 got %v", offset_of(SDFDesc, bitsPerSubgridPixel))
+    testing.expectf(t, size_of(SDFDesc{}.bitsPerSubgridPixel) == 4, "Wrong size for SDFDesc.bitsPerSubgridPixel, expected 4 got %v", size_of(SDFDesc{}.bitsPerSubgridPixel))
     testing.expectf(t, offset_of(SDFDesc, sdfSubgrids3DTexBlockDim) == 60, "Wrong offset for SDFDesc.sdfSubgrids3DTexBlockDim, expected 60 got %v", offset_of(SDFDesc, sdfSubgrids3DTexBlockDim))
+    testing.expectf(t, size_of(SDFDesc{}.sdfSubgrids3DTexBlockDim) == 12, "Wrong size for SDFDesc.sdfSubgrids3DTexBlockDim, expected 12 got %v", size_of(SDFDesc{}.sdfSubgrids3DTexBlockDim))
     testing.expectf(t, offset_of(SDFDesc, sdfSubgrids) == 72, "Wrong offset for SDFDesc.sdfSubgrids, expected 72 got %v", offset_of(SDFDesc, sdfSubgrids))
+    testing.expectf(t, size_of(SDFDesc{}.sdfSubgrids) == 24, "Wrong size for SDFDesc.sdfSubgrids, expected 24 got %v", size_of(SDFDesc{}.sdfSubgrids))
     testing.expectf(t, offset_of(SDFDesc, sdfStartSlots) == 96, "Wrong offset for SDFDesc.sdfStartSlots, expected 96 got %v", offset_of(SDFDesc, sdfStartSlots))
+    testing.expectf(t, size_of(SDFDesc{}.sdfStartSlots) == 24, "Wrong size for SDFDesc.sdfStartSlots, expected 24 got %v", size_of(SDFDesc{}.sdfStartSlots))
     testing.expectf(t, offset_of(SDFDesc, subgridsMinSdfValue) == 120, "Wrong offset for SDFDesc.subgridsMinSdfValue, expected 120 got %v", offset_of(SDFDesc, subgridsMinSdfValue))
+    testing.expectf(t, size_of(SDFDesc{}.subgridsMinSdfValue) == 4, "Wrong size for SDFDesc.subgridsMinSdfValue, expected 4 got %v", size_of(SDFDesc{}.subgridsMinSdfValue))
     testing.expectf(t, offset_of(SDFDesc, subgridsMaxSdfValue) == 124, "Wrong offset for SDFDesc.subgridsMaxSdfValue, expected 124 got %v", offset_of(SDFDesc, subgridsMaxSdfValue))
+    testing.expectf(t, size_of(SDFDesc{}.subgridsMaxSdfValue) == 4, "Wrong size for SDFDesc.subgridsMaxSdfValue, expected 4 got %v", size_of(SDFDesc{}.subgridsMaxSdfValue))
     testing.expectf(t, offset_of(SDFDesc, sdfBounds) == 128, "Wrong offset for SDFDesc.sdfBounds, expected 128 got %v", offset_of(SDFDesc, sdfBounds))
+    testing.expectf(t, size_of(SDFDesc{}.sdfBounds) == 24, "Wrong size for SDFDesc.sdfBounds, expected 24 got %v", size_of(SDFDesc{}.sdfBounds))
     testing.expectf(t, offset_of(SDFDesc, narrowBandThicknessRelativeToSdfBoundsDiagonal) == 152, "Wrong offset for SDFDesc.narrowBandThicknessRelativeToSdfBoundsDiagonal, expected 152 got %v", offset_of(SDFDesc, narrowBandThicknessRelativeToSdfBoundsDiagonal))
+    testing.expectf(t, size_of(SDFDesc{}.narrowBandThicknessRelativeToSdfBoundsDiagonal) == 4, "Wrong size for SDFDesc.narrowBandThicknessRelativeToSdfBoundsDiagonal, expected 4 got %v", size_of(SDFDesc{}.narrowBandThicknessRelativeToSdfBoundsDiagonal))
     testing.expectf(t, offset_of(SDFDesc, numThreadsForSdfConstruction) == 156, "Wrong offset for SDFDesc.numThreadsForSdfConstruction, expected 156 got %v", offset_of(SDFDesc, numThreadsForSdfConstruction))
+    testing.expectf(t, size_of(SDFDesc{}.numThreadsForSdfConstruction) == 4, "Wrong size for SDFDesc.numThreadsForSdfConstruction, expected 4 got %v", size_of(SDFDesc{}.numThreadsForSdfConstruction))
     testing.expectf(t, size_of(SDFDesc) == 160, "Wrong size for type SDFDesc, expected 160 got %v", size_of(SDFDesc))
 }
 
 @(test)
 test_layout_ConvexMeshDesc :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(ConvexMeshDesc, points) == 0, "Wrong offset for ConvexMeshDesc.points, expected 0 got %v", offset_of(ConvexMeshDesc, points))
+    testing.expectf(t, size_of(ConvexMeshDesc{}.points) == 24, "Wrong size for ConvexMeshDesc.points, expected 24 got %v", size_of(ConvexMeshDesc{}.points))
     testing.expectf(t, offset_of(ConvexMeshDesc, polygons) == 24, "Wrong offset for ConvexMeshDesc.polygons, expected 24 got %v", offset_of(ConvexMeshDesc, polygons))
+    testing.expectf(t, size_of(ConvexMeshDesc{}.polygons) == 24, "Wrong size for ConvexMeshDesc.polygons, expected 24 got %v", size_of(ConvexMeshDesc{}.polygons))
     testing.expectf(t, offset_of(ConvexMeshDesc, indices) == 48, "Wrong offset for ConvexMeshDesc.indices, expected 48 got %v", offset_of(ConvexMeshDesc, indices))
+    testing.expectf(t, size_of(ConvexMeshDesc{}.indices) == 24, "Wrong size for ConvexMeshDesc.indices, expected 24 got %v", size_of(ConvexMeshDesc{}.indices))
     testing.expectf(t, offset_of(ConvexMeshDesc, flags) == 72, "Wrong offset for ConvexMeshDesc.flags, expected 72 got %v", offset_of(ConvexMeshDesc, flags))
+    testing.expectf(t, size_of(ConvexMeshDesc{}.flags) == 2, "Wrong size for ConvexMeshDesc.flags, expected 2 got %v", size_of(ConvexMeshDesc{}.flags))
     testing.expectf(t, offset_of(ConvexMeshDesc, vertexLimit) == 74, "Wrong offset for ConvexMeshDesc.vertexLimit, expected 74 got %v", offset_of(ConvexMeshDesc, vertexLimit))
+    testing.expectf(t, size_of(ConvexMeshDesc{}.vertexLimit) == 2, "Wrong size for ConvexMeshDesc.vertexLimit, expected 2 got %v", size_of(ConvexMeshDesc{}.vertexLimit))
     testing.expectf(t, offset_of(ConvexMeshDesc, polygonLimit) == 76, "Wrong offset for ConvexMeshDesc.polygonLimit, expected 76 got %v", offset_of(ConvexMeshDesc, polygonLimit))
+    testing.expectf(t, size_of(ConvexMeshDesc{}.polygonLimit) == 2, "Wrong size for ConvexMeshDesc.polygonLimit, expected 2 got %v", size_of(ConvexMeshDesc{}.polygonLimit))
     testing.expectf(t, offset_of(ConvexMeshDesc, quantizedCount) == 78, "Wrong offset for ConvexMeshDesc.quantizedCount, expected 78 got %v", offset_of(ConvexMeshDesc, quantizedCount))
+    testing.expectf(t, size_of(ConvexMeshDesc{}.quantizedCount) == 2, "Wrong size for ConvexMeshDesc.quantizedCount, expected 2 got %v", size_of(ConvexMeshDesc{}.quantizedCount))
     testing.expectf(t, offset_of(ConvexMeshDesc, sdfDesc) == 80, "Wrong offset for ConvexMeshDesc.sdfDesc, expected 80 got %v", offset_of(ConvexMeshDesc, sdfDesc))
+    testing.expectf(t, size_of(ConvexMeshDesc{}.sdfDesc) == 8, "Wrong size for ConvexMeshDesc.sdfDesc, expected 8 got %v", size_of(ConvexMeshDesc{}.sdfDesc))
     testing.expectf(t, size_of(ConvexMeshDesc) == 88, "Wrong size for type ConvexMeshDesc, expected 88 got %v", size_of(ConvexMeshDesc))
 }
 
@@ -2193,6 +3048,7 @@ test_layout_ConvexMeshDesc :: proc(t: ^testing.T) {
 test_layout_TriangleMeshDesc :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(TriangleMeshDesc, sdfDesc) == 72, "Wrong offset for TriangleMeshDesc.sdfDesc, expected 72 got %v", offset_of(TriangleMeshDesc, sdfDesc))
+    testing.expectf(t, size_of(TriangleMeshDesc{}.sdfDesc) == 8, "Wrong size for TriangleMeshDesc.sdfDesc, expected 8 got %v", size_of(TriangleMeshDesc{}.sdfDesc))
     testing.expectf(t, size_of(TriangleMeshDesc) == 80, "Wrong size for type TriangleMeshDesc, expected 80 got %v", size_of(TriangleMeshDesc))
 }
 
@@ -2200,23 +3056,33 @@ test_layout_TriangleMeshDesc :: proc(t: ^testing.T) {
 test_layout_TetrahedronMeshDesc :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(TetrahedronMeshDesc, points) == 16, "Wrong offset for TetrahedronMeshDesc.points, expected 16 got %v", offset_of(TetrahedronMeshDesc, points))
+    testing.expectf(t, size_of(TetrahedronMeshDesc{}.points) == 24, "Wrong size for TetrahedronMeshDesc.points, expected 24 got %v", size_of(TetrahedronMeshDesc{}.points))
     testing.expectf(t, offset_of(TetrahedronMeshDesc, tetrahedrons) == 40, "Wrong offset for TetrahedronMeshDesc.tetrahedrons, expected 40 got %v", offset_of(TetrahedronMeshDesc, tetrahedrons))
+    testing.expectf(t, size_of(TetrahedronMeshDesc{}.tetrahedrons) == 24, "Wrong size for TetrahedronMeshDesc.tetrahedrons, expected 24 got %v", size_of(TetrahedronMeshDesc{}.tetrahedrons))
     testing.expectf(t, offset_of(TetrahedronMeshDesc, flags) == 64, "Wrong offset for TetrahedronMeshDesc.flags, expected 64 got %v", offset_of(TetrahedronMeshDesc, flags))
+    testing.expectf(t, size_of(TetrahedronMeshDesc{}.flags) == 2, "Wrong size for TetrahedronMeshDesc.flags, expected 2 got %v", size_of(TetrahedronMeshDesc{}.flags))
     testing.expectf(t, offset_of(TetrahedronMeshDesc, tetsPerElement) == 66, "Wrong offset for TetrahedronMeshDesc.tetsPerElement, expected 66 got %v", offset_of(TetrahedronMeshDesc, tetsPerElement))
+    testing.expectf(t, size_of(TetrahedronMeshDesc{}.tetsPerElement) == 2, "Wrong size for TetrahedronMeshDesc.tetsPerElement, expected 2 got %v", size_of(TetrahedronMeshDesc{}.tetsPerElement))
     testing.expectf(t, size_of(TetrahedronMeshDesc) == 72, "Wrong size for type TetrahedronMeshDesc, expected 72 got %v", size_of(TetrahedronMeshDesc))
 }
 
 @(test)
 test_layout_SoftBodySimulationDataDesc :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(SoftBodySimulationDataDesc, vertexToTet) == 0, "Wrong offset for SoftBodySimulationDataDesc.vertexToTet, expected 0 got %v", offset_of(SoftBodySimulationDataDesc, vertexToTet))
+    testing.expectf(t, size_of(SoftBodySimulationDataDesc{}.vertexToTet) == 24, "Wrong size for SoftBodySimulationDataDesc.vertexToTet, expected 24 got %v", size_of(SoftBodySimulationDataDesc{}.vertexToTet))
     testing.expectf(t, size_of(SoftBodySimulationDataDesc) == 24, "Wrong size for type SoftBodySimulationDataDesc, expected 24 got %v", size_of(SoftBodySimulationDataDesc))
 }
 
 @(test)
 test_layout_BVH34MidphaseDesc :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(BVH34MidphaseDesc, numPrimsPerLeaf) == 0, "Wrong offset for BVH34MidphaseDesc.numPrimsPerLeaf, expected 0 got %v", offset_of(BVH34MidphaseDesc, numPrimsPerLeaf))
+    testing.expectf(t, size_of(BVH34MidphaseDesc{}.numPrimsPerLeaf) == 4, "Wrong size for BVH34MidphaseDesc.numPrimsPerLeaf, expected 4 got %v", size_of(BVH34MidphaseDesc{}.numPrimsPerLeaf))
     testing.expectf(t, offset_of(BVH34MidphaseDesc, buildStrategy) == 4, "Wrong offset for BVH34MidphaseDesc.buildStrategy, expected 4 got %v", offset_of(BVH34MidphaseDesc, buildStrategy))
+    testing.expectf(t, size_of(BVH34MidphaseDesc{}.buildStrategy) == 4, "Wrong size for BVH34MidphaseDesc.buildStrategy, expected 4 got %v", size_of(BVH34MidphaseDesc{}.buildStrategy))
     testing.expectf(t, offset_of(BVH34MidphaseDesc, quantized) == 8, "Wrong offset for BVH34MidphaseDesc.quantized, expected 8 got %v", offset_of(BVH34MidphaseDesc, quantized))
+    testing.expectf(t, size_of(BVH34MidphaseDesc{}.quantized) == 1, "Wrong size for BVH34MidphaseDesc.quantized, expected 1 got %v", size_of(BVH34MidphaseDesc{}.quantized))
     testing.expectf(t, size_of(BVH34MidphaseDesc) == 12, "Wrong size for type BVH34MidphaseDesc, expected 12 got %v", size_of(BVH34MidphaseDesc))
 }
 
@@ -2229,26 +3095,44 @@ test_layout_MidphaseDesc :: proc(t: ^testing.T) {
 @(test)
 test_layout_BVHDesc :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(BVHDesc, bounds) == 0, "Wrong offset for BVHDesc.bounds, expected 0 got %v", offset_of(BVHDesc, bounds))
+    testing.expectf(t, size_of(BVHDesc{}.bounds) == 24, "Wrong size for BVHDesc.bounds, expected 24 got %v", size_of(BVHDesc{}.bounds))
     testing.expectf(t, offset_of(BVHDesc, enlargement) == 24, "Wrong offset for BVHDesc.enlargement, expected 24 got %v", offset_of(BVHDesc, enlargement))
+    testing.expectf(t, size_of(BVHDesc{}.enlargement) == 4, "Wrong size for BVHDesc.enlargement, expected 4 got %v", size_of(BVHDesc{}.enlargement))
     testing.expectf(t, offset_of(BVHDesc, numPrimsPerLeaf) == 28, "Wrong offset for BVHDesc.numPrimsPerLeaf, expected 28 got %v", offset_of(BVHDesc, numPrimsPerLeaf))
+    testing.expectf(t, size_of(BVHDesc{}.numPrimsPerLeaf) == 4, "Wrong size for BVHDesc.numPrimsPerLeaf, expected 4 got %v", size_of(BVHDesc{}.numPrimsPerLeaf))
     testing.expectf(t, offset_of(BVHDesc, buildStrategy) == 32, "Wrong offset for BVHDesc.buildStrategy, expected 32 got %v", offset_of(BVHDesc, buildStrategy))
+    testing.expectf(t, size_of(BVHDesc{}.buildStrategy) == 4, "Wrong size for BVHDesc.buildStrategy, expected 4 got %v", size_of(BVHDesc{}.buildStrategy))
     testing.expectf(t, size_of(BVHDesc) == 40, "Wrong size for type BVHDesc, expected 40 got %v", size_of(BVHDesc))
 }
 
 @(test)
 test_layout_CookingParams :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(CookingParams, areaTestEpsilon) == 0, "Wrong offset for CookingParams.areaTestEpsilon, expected 0 got %v", offset_of(CookingParams, areaTestEpsilon))
+    testing.expectf(t, size_of(CookingParams{}.areaTestEpsilon) == 4, "Wrong size for CookingParams.areaTestEpsilon, expected 4 got %v", size_of(CookingParams{}.areaTestEpsilon))
     testing.expectf(t, offset_of(CookingParams, planeTolerance) == 4, "Wrong offset for CookingParams.planeTolerance, expected 4 got %v", offset_of(CookingParams, planeTolerance))
+    testing.expectf(t, size_of(CookingParams{}.planeTolerance) == 4, "Wrong size for CookingParams.planeTolerance, expected 4 got %v", size_of(CookingParams{}.planeTolerance))
     testing.expectf(t, offset_of(CookingParams, convexMeshCookingType) == 8, "Wrong offset for CookingParams.convexMeshCookingType, expected 8 got %v", offset_of(CookingParams, convexMeshCookingType))
+    testing.expectf(t, size_of(CookingParams{}.convexMeshCookingType) == 4, "Wrong size for CookingParams.convexMeshCookingType, expected 4 got %v", size_of(CookingParams{}.convexMeshCookingType))
     testing.expectf(t, offset_of(CookingParams, suppressTriangleMeshRemapTable) == 12, "Wrong offset for CookingParams.suppressTriangleMeshRemapTable, expected 12 got %v", offset_of(CookingParams, suppressTriangleMeshRemapTable))
+    testing.expectf(t, size_of(CookingParams{}.suppressTriangleMeshRemapTable) == 1, "Wrong size for CookingParams.suppressTriangleMeshRemapTable, expected 1 got %v", size_of(CookingParams{}.suppressTriangleMeshRemapTable))
     testing.expectf(t, offset_of(CookingParams, buildTriangleAdjacencies) == 13, "Wrong offset for CookingParams.buildTriangleAdjacencies, expected 13 got %v", offset_of(CookingParams, buildTriangleAdjacencies))
+    testing.expectf(t, size_of(CookingParams{}.buildTriangleAdjacencies) == 1, "Wrong size for CookingParams.buildTriangleAdjacencies, expected 1 got %v", size_of(CookingParams{}.buildTriangleAdjacencies))
     testing.expectf(t, offset_of(CookingParams, buildGPUData) == 14, "Wrong offset for CookingParams.buildGPUData, expected 14 got %v", offset_of(CookingParams, buildGPUData))
+    testing.expectf(t, size_of(CookingParams{}.buildGPUData) == 1, "Wrong size for CookingParams.buildGPUData, expected 1 got %v", size_of(CookingParams{}.buildGPUData))
     testing.expectf(t, offset_of(CookingParams, scale) == 16, "Wrong offset for CookingParams.scale, expected 16 got %v", offset_of(CookingParams, scale))
+    testing.expectf(t, size_of(CookingParams{}.scale) == 8, "Wrong size for CookingParams.scale, expected 8 got %v", size_of(CookingParams{}.scale))
     testing.expectf(t, offset_of(CookingParams, meshPreprocessParams) == 24, "Wrong offset for CookingParams.meshPreprocessParams, expected 24 got %v", offset_of(CookingParams, meshPreprocessParams))
+    testing.expectf(t, size_of(CookingParams{}.meshPreprocessParams) == 4, "Wrong size for CookingParams.meshPreprocessParams, expected 4 got %v", size_of(CookingParams{}.meshPreprocessParams))
     testing.expectf(t, offset_of(CookingParams, meshWeldTolerance) == 28, "Wrong offset for CookingParams.meshWeldTolerance, expected 28 got %v", offset_of(CookingParams, meshWeldTolerance))
+    testing.expectf(t, size_of(CookingParams{}.meshWeldTolerance) == 4, "Wrong size for CookingParams.meshWeldTolerance, expected 4 got %v", size_of(CookingParams{}.meshWeldTolerance))
     testing.expectf(t, offset_of(CookingParams, midphaseDesc) == 32, "Wrong offset for CookingParams.midphaseDesc, expected 32 got %v", offset_of(CookingParams, midphaseDesc))
+    testing.expectf(t, size_of(CookingParams{}.midphaseDesc) == 16, "Wrong size for CookingParams.midphaseDesc, expected 16 got %v", size_of(CookingParams{}.midphaseDesc))
     testing.expectf(t, offset_of(CookingParams, gaussMapLimit) == 48, "Wrong offset for CookingParams.gaussMapLimit, expected 48 got %v", offset_of(CookingParams, gaussMapLimit))
+    testing.expectf(t, size_of(CookingParams{}.gaussMapLimit) == 4, "Wrong size for CookingParams.gaussMapLimit, expected 4 got %v", size_of(CookingParams{}.gaussMapLimit))
     testing.expectf(t, offset_of(CookingParams, maxWeightRatioInTet) == 52, "Wrong offset for CookingParams.maxWeightRatioInTet, expected 52 got %v", offset_of(CookingParams, maxWeightRatioInTet))
+    testing.expectf(t, size_of(CookingParams{}.maxWeightRatioInTet) == 4, "Wrong size for CookingParams.maxWeightRatioInTet, expected 4 got %v", size_of(CookingParams{}.maxWeightRatioInTet))
     testing.expectf(t, size_of(CookingParams) == 56, "Wrong size for type CookingParams, expected 56 got %v", size_of(CookingParams))
 }
 
@@ -2286,13 +3170,17 @@ test_layout_DefaultAllocator :: proc(t: ^testing.T) {
 test_layout_Joint :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(Joint, userData) == 16, "Wrong offset for Joint.userData, expected 16 got %v", offset_of(Joint, userData))
+    testing.expectf(t, size_of(Joint{}.userData) == 8, "Wrong size for Joint.userData, expected 8 got %v", size_of(Joint{}.userData))
     testing.expectf(t, size_of(Joint) == 24, "Wrong size for type Joint, expected 24 got %v", size_of(Joint))
 }
 
 @(test)
 test_layout_Spring :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(Spring, stiffness) == 0, "Wrong offset for Spring.stiffness, expected 0 got %v", offset_of(Spring, stiffness))
+    testing.expectf(t, size_of(Spring{}.stiffness) == 4, "Wrong size for Spring.stiffness, expected 4 got %v", size_of(Spring{}.stiffness))
     testing.expectf(t, offset_of(Spring, damping) == 4, "Wrong offset for Spring.damping, expected 4 got %v", offset_of(Spring, damping))
+    testing.expectf(t, size_of(Spring{}.damping) == 4, "Wrong size for Spring.damping, expected 4 got %v", size_of(Spring{}.damping))
     testing.expectf(t, size_of(Spring) == 8, "Wrong size for type Spring, expected 8 got %v", size_of(Spring))
 }
 
@@ -2305,9 +3193,14 @@ test_layout_DistanceJoint :: proc(t: ^testing.T) {
 @(test)
 test_layout_JacobianRow :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(JacobianRow, linear0) == 0, "Wrong offset for JacobianRow.linear0, expected 0 got %v", offset_of(JacobianRow, linear0))
+    testing.expectf(t, size_of(JacobianRow{}.linear0) == 12, "Wrong size for JacobianRow.linear0, expected 12 got %v", size_of(JacobianRow{}.linear0))
     testing.expectf(t, offset_of(JacobianRow, linear1) == 12, "Wrong offset for JacobianRow.linear1, expected 12 got %v", offset_of(JacobianRow, linear1))
+    testing.expectf(t, size_of(JacobianRow{}.linear1) == 12, "Wrong size for JacobianRow.linear1, expected 12 got %v", size_of(JacobianRow{}.linear1))
     testing.expectf(t, offset_of(JacobianRow, angular0) == 24, "Wrong offset for JacobianRow.angular0, expected 24 got %v", offset_of(JacobianRow, angular0))
+    testing.expectf(t, size_of(JacobianRow{}.angular0) == 12, "Wrong size for JacobianRow.angular0, expected 12 got %v", size_of(JacobianRow{}.angular0))
     testing.expectf(t, offset_of(JacobianRow, angular1) == 36, "Wrong offset for JacobianRow.angular1, expected 36 got %v", offset_of(JacobianRow, angular1))
+    testing.expectf(t, size_of(JacobianRow{}.angular1) == 12, "Wrong size for JacobianRow.angular1, expected 12 got %v", size_of(JacobianRow{}.angular1))
     testing.expectf(t, size_of(JacobianRow) == 48, "Wrong size for type JacobianRow, expected 48 got %v", size_of(JacobianRow))
 }
 
@@ -2326,10 +3219,16 @@ test_layout_FixedJoint :: proc(t: ^testing.T) {
 @(test)
 test_layout_JointLimitParameters :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(JointLimitParameters, restitution) == 0, "Wrong offset for JointLimitParameters.restitution, expected 0 got %v", offset_of(JointLimitParameters, restitution))
+    testing.expectf(t, size_of(JointLimitParameters{}.restitution) == 4, "Wrong size for JointLimitParameters.restitution, expected 4 got %v", size_of(JointLimitParameters{}.restitution))
     testing.expectf(t, offset_of(JointLimitParameters, bounceThreshold) == 4, "Wrong offset for JointLimitParameters.bounceThreshold, expected 4 got %v", offset_of(JointLimitParameters, bounceThreshold))
+    testing.expectf(t, size_of(JointLimitParameters{}.bounceThreshold) == 4, "Wrong size for JointLimitParameters.bounceThreshold, expected 4 got %v", size_of(JointLimitParameters{}.bounceThreshold))
     testing.expectf(t, offset_of(JointLimitParameters, stiffness) == 8, "Wrong offset for JointLimitParameters.stiffness, expected 8 got %v", offset_of(JointLimitParameters, stiffness))
+    testing.expectf(t, size_of(JointLimitParameters{}.stiffness) == 4, "Wrong size for JointLimitParameters.stiffness, expected 4 got %v", size_of(JointLimitParameters{}.stiffness))
     testing.expectf(t, offset_of(JointLimitParameters, damping) == 12, "Wrong offset for JointLimitParameters.damping, expected 12 got %v", offset_of(JointLimitParameters, damping))
+    testing.expectf(t, size_of(JointLimitParameters{}.damping) == 4, "Wrong size for JointLimitParameters.damping, expected 4 got %v", size_of(JointLimitParameters{}.damping))
     testing.expectf(t, offset_of(JointLimitParameters, contactDistance_deprecated) == 16, "Wrong offset for JointLimitParameters.contactDistance_deprecated, expected 16 got %v", offset_of(JointLimitParameters, contactDistance_deprecated))
+    testing.expectf(t, size_of(JointLimitParameters{}.contactDistance_deprecated) == 4, "Wrong size for JointLimitParameters.contactDistance_deprecated, expected 4 got %v", size_of(JointLimitParameters{}.contactDistance_deprecated))
     testing.expectf(t, size_of(JointLimitParameters) == 20, "Wrong size for type JointLimitParameters, expected 20 got %v", size_of(JointLimitParameters))
 }
 
@@ -2337,6 +3236,7 @@ test_layout_JointLimitParameters :: proc(t: ^testing.T) {
 test_layout_JointLinearLimit :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(JointLinearLimit, value) == 20, "Wrong offset for JointLinearLimit.value, expected 20 got %v", offset_of(JointLinearLimit, value))
+    testing.expectf(t, size_of(JointLinearLimit{}.value) == 4, "Wrong size for JointLinearLimit.value, expected 4 got %v", size_of(JointLinearLimit{}.value))
     testing.expectf(t, size_of(JointLinearLimit) == 24, "Wrong size for type JointLinearLimit, expected 24 got %v", size_of(JointLinearLimit))
 }
 
@@ -2344,7 +3244,9 @@ test_layout_JointLinearLimit :: proc(t: ^testing.T) {
 test_layout_JointLinearLimitPair :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(JointLinearLimitPair, upper) == 20, "Wrong offset for JointLinearLimitPair.upper, expected 20 got %v", offset_of(JointLinearLimitPair, upper))
+    testing.expectf(t, size_of(JointLinearLimitPair{}.upper) == 4, "Wrong size for JointLinearLimitPair.upper, expected 4 got %v", size_of(JointLinearLimitPair{}.upper))
     testing.expectf(t, offset_of(JointLinearLimitPair, lower) == 24, "Wrong offset for JointLinearLimitPair.lower, expected 24 got %v", offset_of(JointLinearLimitPair, lower))
+    testing.expectf(t, size_of(JointLinearLimitPair{}.lower) == 4, "Wrong size for JointLinearLimitPair.lower, expected 4 got %v", size_of(JointLinearLimitPair{}.lower))
     testing.expectf(t, size_of(JointLinearLimitPair) == 28, "Wrong size for type JointLinearLimitPair, expected 28 got %v", size_of(JointLinearLimitPair))
 }
 
@@ -2352,7 +3254,9 @@ test_layout_JointLinearLimitPair :: proc(t: ^testing.T) {
 test_layout_JointAngularLimitPair :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(JointAngularLimitPair, upper) == 20, "Wrong offset for JointAngularLimitPair.upper, expected 20 got %v", offset_of(JointAngularLimitPair, upper))
+    testing.expectf(t, size_of(JointAngularLimitPair{}.upper) == 4, "Wrong size for JointAngularLimitPair.upper, expected 4 got %v", size_of(JointAngularLimitPair{}.upper))
     testing.expectf(t, offset_of(JointAngularLimitPair, lower) == 24, "Wrong offset for JointAngularLimitPair.lower, expected 24 got %v", offset_of(JointAngularLimitPair, lower))
+    testing.expectf(t, size_of(JointAngularLimitPair{}.lower) == 4, "Wrong size for JointAngularLimitPair.lower, expected 4 got %v", size_of(JointAngularLimitPair{}.lower))
     testing.expectf(t, size_of(JointAngularLimitPair) == 28, "Wrong size for type JointAngularLimitPair, expected 28 got %v", size_of(JointAngularLimitPair))
 }
 
@@ -2360,7 +3264,9 @@ test_layout_JointAngularLimitPair :: proc(t: ^testing.T) {
 test_layout_JointLimitCone :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(JointLimitCone, yAngle) == 20, "Wrong offset for JointLimitCone.yAngle, expected 20 got %v", offset_of(JointLimitCone, yAngle))
+    testing.expectf(t, size_of(JointLimitCone{}.yAngle) == 4, "Wrong size for JointLimitCone.yAngle, expected 4 got %v", size_of(JointLimitCone{}.yAngle))
     testing.expectf(t, offset_of(JointLimitCone, zAngle) == 24, "Wrong offset for JointLimitCone.zAngle, expected 24 got %v", offset_of(JointLimitCone, zAngle))
+    testing.expectf(t, size_of(JointLimitCone{}.zAngle) == 4, "Wrong size for JointLimitCone.zAngle, expected 4 got %v", size_of(JointLimitCone{}.zAngle))
     testing.expectf(t, size_of(JointLimitCone) == 28, "Wrong size for type JointLimitCone, expected 28 got %v", size_of(JointLimitCone))
 }
 
@@ -2368,9 +3274,13 @@ test_layout_JointLimitCone :: proc(t: ^testing.T) {
 test_layout_JointLimitPyramid :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(JointLimitPyramid, yAngleMin) == 20, "Wrong offset for JointLimitPyramid.yAngleMin, expected 20 got %v", offset_of(JointLimitPyramid, yAngleMin))
+    testing.expectf(t, size_of(JointLimitPyramid{}.yAngleMin) == 4, "Wrong size for JointLimitPyramid.yAngleMin, expected 4 got %v", size_of(JointLimitPyramid{}.yAngleMin))
     testing.expectf(t, offset_of(JointLimitPyramid, yAngleMax) == 24, "Wrong offset for JointLimitPyramid.yAngleMax, expected 24 got %v", offset_of(JointLimitPyramid, yAngleMax))
+    testing.expectf(t, size_of(JointLimitPyramid{}.yAngleMax) == 4, "Wrong size for JointLimitPyramid.yAngleMax, expected 4 got %v", size_of(JointLimitPyramid{}.yAngleMax))
     testing.expectf(t, offset_of(JointLimitPyramid, zAngleMin) == 28, "Wrong offset for JointLimitPyramid.zAngleMin, expected 28 got %v", offset_of(JointLimitPyramid, zAngleMin))
+    testing.expectf(t, size_of(JointLimitPyramid{}.zAngleMin) == 4, "Wrong size for JointLimitPyramid.zAngleMin, expected 4 got %v", size_of(JointLimitPyramid{}.zAngleMin))
     testing.expectf(t, offset_of(JointLimitPyramid, zAngleMax) == 32, "Wrong offset for JointLimitPyramid.zAngleMax, expected 32 got %v", offset_of(JointLimitPyramid, zAngleMax))
+    testing.expectf(t, size_of(JointLimitPyramid{}.zAngleMax) == 4, "Wrong size for JointLimitPyramid.zAngleMax, expected 4 got %v", size_of(JointLimitPyramid{}.zAngleMax))
     testing.expectf(t, size_of(JointLimitPyramid) == 36, "Wrong size for type JointLimitPyramid, expected 36 got %v", size_of(JointLimitPyramid))
 }
 
@@ -2396,7 +3306,9 @@ test_layout_SphericalJoint :: proc(t: ^testing.T) {
 test_layout_D6JointDrive :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(D6JointDrive, forceLimit) == 8, "Wrong offset for D6JointDrive.forceLimit, expected 8 got %v", offset_of(D6JointDrive, forceLimit))
+    testing.expectf(t, size_of(D6JointDrive{}.forceLimit) == 4, "Wrong size for D6JointDrive.forceLimit, expected 4 got %v", size_of(D6JointDrive{}.forceLimit))
     testing.expectf(t, offset_of(D6JointDrive, flags) == 12, "Wrong offset for D6JointDrive.flags, expected 12 got %v", offset_of(D6JointDrive, flags))
+    testing.expectf(t, size_of(D6JointDrive{}.flags) == 4, "Wrong size for D6JointDrive.flags, expected 4 got %v", size_of(D6JointDrive{}.flags))
     testing.expectf(t, size_of(D6JointDrive) == 16, "Wrong size for type D6JointDrive, expected 16 got %v", size_of(D6JointDrive))
 }
 
@@ -2421,9 +3333,14 @@ test_layout_RackAndPinionJoint :: proc(t: ^testing.T) {
 @(test)
 test_layout_GroupsMask :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(GroupsMask, bits0) == 0, "Wrong offset for GroupsMask.bits0, expected 0 got %v", offset_of(GroupsMask, bits0))
+    testing.expectf(t, size_of(GroupsMask{}.bits0) == 2, "Wrong size for GroupsMask.bits0, expected 2 got %v", size_of(GroupsMask{}.bits0))
     testing.expectf(t, offset_of(GroupsMask, bits1) == 2, "Wrong offset for GroupsMask.bits1, expected 2 got %v", offset_of(GroupsMask, bits1))
+    testing.expectf(t, size_of(GroupsMask{}.bits1) == 2, "Wrong size for GroupsMask.bits1, expected 2 got %v", size_of(GroupsMask{}.bits1))
     testing.expectf(t, offset_of(GroupsMask, bits2) == 4, "Wrong offset for GroupsMask.bits2, expected 4 got %v", offset_of(GroupsMask, bits2))
+    testing.expectf(t, size_of(GroupsMask{}.bits2) == 2, "Wrong size for GroupsMask.bits2, expected 2 got %v", size_of(GroupsMask{}.bits2))
     testing.expectf(t, offset_of(GroupsMask, bits3) == 6, "Wrong offset for GroupsMask.bits3, expected 6 got %v", offset_of(GroupsMask, bits3))
+    testing.expectf(t, size_of(GroupsMask{}.bits3) == 2, "Wrong size for GroupsMask.bits3, expected 2 got %v", size_of(GroupsMask{}.bits3))
     testing.expectf(t, size_of(GroupsMask) == 8, "Wrong size for type GroupsMask, expected 8 got %v", size_of(GroupsMask))
 }
 
@@ -2437,8 +3354,12 @@ test_layout_DefaultErrorCallback :: proc(t: ^testing.T) {
 @(test)
 test_layout_MassProperties :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(MassProperties, inertiaTensor) == 0, "Wrong offset for MassProperties.inertiaTensor, expected 0 got %v", offset_of(MassProperties, inertiaTensor))
+    testing.expectf(t, size_of(MassProperties{}.inertiaTensor) == 36, "Wrong size for MassProperties.inertiaTensor, expected 36 got %v", size_of(MassProperties{}.inertiaTensor))
     testing.expectf(t, offset_of(MassProperties, centerOfMass) == 36, "Wrong offset for MassProperties.centerOfMass, expected 36 got %v", offset_of(MassProperties, centerOfMass))
+    testing.expectf(t, size_of(MassProperties{}.centerOfMass) == 12, "Wrong size for MassProperties.centerOfMass, expected 12 got %v", size_of(MassProperties{}.centerOfMass))
     testing.expectf(t, offset_of(MassProperties, mass) == 48, "Wrong offset for MassProperties.mass, expected 48 got %v", offset_of(MassProperties, mass))
+    testing.expectf(t, size_of(MassProperties{}.mass) == 4, "Wrong size for MassProperties.mass, expected 4 got %v", size_of(MassProperties{}.mass))
     testing.expectf(t, size_of(MassProperties) == 52, "Wrong size for type MassProperties, expected 52 got %v", size_of(MassProperties))
 }
 
@@ -2453,7 +3374,10 @@ test_layout_MeshOverlapUtil :: proc(t: ^testing.T) {
 @(test)
 test_layout_XmlMiscParameter :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(XmlMiscParameter, upVector) == 0, "Wrong offset for XmlMiscParameter.upVector, expected 0 got %v", offset_of(XmlMiscParameter, upVector))
+    testing.expectf(t, size_of(XmlMiscParameter{}.upVector) == 12, "Wrong size for XmlMiscParameter.upVector, expected 12 got %v", size_of(XmlMiscParameter{}.upVector))
     testing.expectf(t, offset_of(XmlMiscParameter, scale) == 12, "Wrong offset for XmlMiscParameter.scale, expected 12 got %v", offset_of(XmlMiscParameter, scale))
+    testing.expectf(t, size_of(XmlMiscParameter{}.scale) == 8, "Wrong size for XmlMiscParameter.scale, expected 8 got %v", size_of(XmlMiscParameter{}.scale))
     testing.expectf(t, size_of(XmlMiscParameter) == 20, "Wrong size for type XmlMiscParameter, expected 20 got %v", size_of(XmlMiscParameter))
 }
 
@@ -2502,8 +3426,12 @@ test_layout_TriangleMeshPoissonSampler :: proc(t: ^testing.T) {
 @(test)
 test_layout_RepXObject :: proc(t: ^testing.T) {
     using physx
+    testing.expectf(t, offset_of(RepXObject, typeName) == 0, "Wrong offset for RepXObject.typeName, expected 0 got %v", offset_of(RepXObject, typeName))
+    testing.expectf(t, size_of(RepXObject{}.typeName) == 8, "Wrong size for RepXObject.typeName, expected 8 got %v", size_of(RepXObject{}.typeName))
     testing.expectf(t, offset_of(RepXObject, serializable) == 8, "Wrong offset for RepXObject.serializable, expected 8 got %v", offset_of(RepXObject, serializable))
+    testing.expectf(t, size_of(RepXObject{}.serializable) == 8, "Wrong size for RepXObject.serializable, expected 8 got %v", size_of(RepXObject{}.serializable))
     testing.expectf(t, offset_of(RepXObject, id) == 16, "Wrong offset for RepXObject.id, expected 16 got %v", offset_of(RepXObject, id))
+    testing.expectf(t, size_of(RepXObject{}.id) == 8, "Wrong size for RepXObject.id, expected 8 got %v", size_of(RepXObject{}.id))
     testing.expectf(t, size_of(RepXObject) == 24, "Wrong size for type RepXObject, expected 24 got %v", size_of(RepXObject))
 }
 
@@ -2511,7 +3439,9 @@ test_layout_RepXObject :: proc(t: ^testing.T) {
 test_layout_RepXInstantiationArgs :: proc(t: ^testing.T) {
     using physx
     testing.expectf(t, offset_of(RepXInstantiationArgs, cooker) == 8, "Wrong offset for RepXInstantiationArgs.cooker, expected 8 got %v", offset_of(RepXInstantiationArgs, cooker))
+    testing.expectf(t, size_of(RepXInstantiationArgs{}.cooker) == 8, "Wrong size for RepXInstantiationArgs.cooker, expected 8 got %v", size_of(RepXInstantiationArgs{}.cooker))
     testing.expectf(t, offset_of(RepXInstantiationArgs, stringTable) == 16, "Wrong offset for RepXInstantiationArgs.stringTable, expected 16 got %v", offset_of(RepXInstantiationArgs, stringTable))
+    testing.expectf(t, size_of(RepXInstantiationArgs{}.stringTable) == 8, "Wrong size for RepXInstantiationArgs.stringTable, expected 8 got %v", size_of(RepXInstantiationArgs{}.stringTable))
     testing.expectf(t, size_of(RepXInstantiationArgs) == 24, "Wrong size for type RepXInstantiationArgs, expected 24 got %v", size_of(RepXInstantiationArgs))
 }
 

--- a/types_linux.odin
+++ b/types_linux.odin
@@ -2007,7 +2007,7 @@ ProfilerCallback :: struct {
 
 ProfileScoped :: struct {
     mCallback: ^ProfilerCallback,
-    mEventName: ^_c.char,
+    mEventName: cstring,
     mProfilerData: rawptr,
     mContextId: _c.uint64_t,
     mDetached: _c.bool,
@@ -2091,7 +2091,7 @@ DebugText :: struct {
     size: _c.float,
     color: _c.uint32_t,
     _pad3: [4]u8,
-    string: ^_c.char,
+    string: cstring,
 }
 
 
@@ -2192,8 +2192,8 @@ Serializer :: struct {
 
 
 MetaDataEntry :: struct {
-    type: ^_c.char,
-    name: ^_c.char,
+    type: cstring,
+    name: cstring,
     offset: _c.uint32_t,
     size: _c.uint32_t,
     count: _c.uint32_t,
@@ -3252,7 +3252,7 @@ RaycastCallback :: struct {
     block: RaycastHit,
     hasBlock: _c.bool,
     _pad3: [7]u8,
-    touches: ^RaycastHit,
+    touches: [^]RaycastHit,
     maxNbTouches: _c.uint32_t,
     nbTouches: _c.uint32_t,
 }
@@ -3263,7 +3263,7 @@ OverlapCallback :: struct {
     block: OverlapHit,
     hasBlock: _c.bool,
     _pad3: [7]u8,
-    touches: ^OverlapHit,
+    touches: [^]OverlapHit,
     maxNbTouches: _c.uint32_t,
     nbTouches: _c.uint32_t,
 }
@@ -3274,7 +3274,7 @@ SweepCallback :: struct {
     block: SweepHit,
     hasBlock: _c.bool,
     _pad3: [7]u8,
-    touches: ^SweepHit,
+    touches: [^]SweepHit,
     maxNbTouches: _c.uint32_t,
     nbTouches: _c.uint32_t,
 }
@@ -3285,7 +3285,7 @@ RaycastBuffer :: struct {
     block: RaycastHit,
     hasBlock: _c.bool,
     _pad3: [7]u8,
-    touches: ^RaycastHit,
+    touches: [^]RaycastHit,
     maxNbTouches: _c.uint32_t,
     nbTouches: _c.uint32_t,
 }
@@ -3296,7 +3296,7 @@ OverlapBuffer :: struct {
     block: OverlapHit,
     hasBlock: _c.bool,
     _pad3: [7]u8,
-    touches: ^OverlapHit,
+    touches: [^]OverlapHit,
     maxNbTouches: _c.uint32_t,
     nbTouches: _c.uint32_t,
 }
@@ -3307,7 +3307,7 @@ SweepBuffer :: struct {
     block: SweepHit,
     hasBlock: _c.bool,
     _pad3: [7]u8,
-    touches: ^SweepHit,
+    touches: [^]SweepHit,
     maxNbTouches: _c.uint32_t,
     nbTouches: _c.uint32_t,
 }
@@ -4258,7 +4258,7 @@ TetrahedronMeshExt :: struct {
 };
 
 RepXObject :: struct {
-    typeName: ^_c.char,
+    typeName: cstring,
     serializable: rawptr,
     id: _c.uint64_t,
 }

--- a/types_windows.odin
+++ b/types_windows.odin
@@ -2007,7 +2007,7 @@ ProfilerCallback :: struct {
 
 ProfileScoped :: struct {
     mCallback: ^ProfilerCallback,
-    mEventName: ^_c.char,
+    mEventName: [^]_c.char,
     mProfilerData: rawptr,
     mContextId: _c.uint64_t,
     mDetached: _c.bool,
@@ -2091,7 +2091,7 @@ DebugText :: struct {
     size: _c.float,
     color: _c.uint32_t,
     _pad3: [4]u8,
-    string: ^_c.char,
+    string: [^]_c.char,
 }
 
 
@@ -2192,8 +2192,8 @@ Serializer :: struct {
 
 
 MetaDataEntry :: struct {
-    type: ^_c.char,
-    name: ^_c.char,
+    type: [^]_c.char,
+    name: [^]_c.char,
     offset: _c.uint32_t,
     size: _c.uint32_t,
     count: _c.uint32_t,
@@ -3700,9 +3700,9 @@ ContactPairPoint :: struct {
 
 ContactPair :: struct {
     shapes: [2]^Shape,
-    contactPatches: ^_c.uint8_t,
-    contactPoints: ^_c.uint8_t,
-    contactImpulses: ^_c.float,
+    contactPatches: [^]_c.uint8_t,
+    contactPoints: [^]_c.uint8_t,
+    contactImpulses: [^]_c.float,
     requiredBufferSize: _c.uint32_t,
     contactCount: _c.uint8_t,
     patchCount: _c.uint8_t,
@@ -4266,7 +4266,7 @@ TetrahedronMeshExt :: struct {
 };
 
 RepXObject :: struct {
-    typeName: ^_c.char,
+    typeName: [^]_c.char,
     serializable: rawptr,
     id: _c.uint64_t,
 }

--- a/types_windows.odin
+++ b/types_windows.odin
@@ -2007,7 +2007,7 @@ ProfilerCallback :: struct {
 
 ProfileScoped :: struct {
     mCallback: ^ProfilerCallback,
-    mEventName: [^]_c.char,
+    mEventName: cstring,
     mProfilerData: rawptr,
     mContextId: _c.uint64_t,
     mDetached: _c.bool,
@@ -2091,7 +2091,7 @@ DebugText :: struct {
     size: _c.float,
     color: _c.uint32_t,
     _pad3: [4]u8,
-    string: [^]_c.char,
+    string: cstring,
 }
 
 
@@ -2192,8 +2192,8 @@ Serializer :: struct {
 
 
 MetaDataEntry :: struct {
-    type: [^]_c.char,
-    name: [^]_c.char,
+    type: cstring,
+    name: cstring,
     offset: _c.uint32_t,
     size: _c.uint32_t,
     count: _c.uint32_t,
@@ -3257,7 +3257,7 @@ RaycastCallback :: struct {
     block: RaycastHit,
     hasBlock: _c.bool,
     _pad3: [7]u8,
-    touches: ^RaycastHit,
+    touches: [^]RaycastHit,
     maxNbTouches: _c.uint32_t,
     nbTouches: _c.uint32_t,
 }
@@ -3268,7 +3268,7 @@ OverlapCallback :: struct {
     block: OverlapHit,
     hasBlock: _c.bool,
     _pad3: [7]u8,
-    touches: ^OverlapHit,
+    touches: [^]OverlapHit,
     maxNbTouches: _c.uint32_t,
     nbTouches: _c.uint32_t,
 }
@@ -3279,7 +3279,7 @@ SweepCallback :: struct {
     block: SweepHit,
     hasBlock: _c.bool,
     _pad3: [7]u8,
-    touches: ^SweepHit,
+    touches: [^]SweepHit,
     maxNbTouches: _c.uint32_t,
     nbTouches: _c.uint32_t,
 }
@@ -3290,7 +3290,7 @@ RaycastBuffer :: struct {
     block: RaycastHit,
     hasBlock: _c.bool,
     _pad3: [7]u8,
-    touches: ^RaycastHit,
+    touches: [^]RaycastHit,
     maxNbTouches: _c.uint32_t,
     nbTouches: _c.uint32_t,
 }
@@ -3301,7 +3301,7 @@ OverlapBuffer :: struct {
     block: OverlapHit,
     hasBlock: _c.bool,
     _pad3: [7]u8,
-    touches: ^OverlapHit,
+    touches: [^]OverlapHit,
     maxNbTouches: _c.uint32_t,
     nbTouches: _c.uint32_t,
 }
@@ -3312,7 +3312,7 @@ SweepBuffer :: struct {
     block: SweepHit,
     hasBlock: _c.bool,
     _pad3: [7]u8,
-    touches: ^SweepHit,
+    touches: [^]SweepHit,
     maxNbTouches: _c.uint32_t,
     nbTouches: _c.uint32_t,
 }
@@ -3700,9 +3700,9 @@ ContactPairPoint :: struct {
 
 ContactPair :: struct {
     shapes: [2]^Shape,
-    contactPatches: [^]_c.uint8_t,
-    contactPoints: [^]_c.uint8_t,
-    contactImpulses: [^]_c.float,
+    contactPatches: ^_c.uint8_t,
+    contactPoints: ^_c.uint8_t,
+    contactImpulses: ^_c.float,
     requiredBufferSize: _c.uint32_t,
     contactCount: _c.uint8_t,
     patchCount: _c.uint8_t,
@@ -4266,7 +4266,7 @@ TetrahedronMeshExt :: struct {
 };
 
 RepXObject :: struct {
-    typeName: [^]_c.char,
+    typeName: cstring,
     serializable: rawptr,
     id: _c.uint64_t,
 }

--- a/types_windows.odin
+++ b/types_windows.odin
@@ -2058,7 +2058,7 @@ StridedData :: struct {
 BoundedData :: struct {
     using _: StridedData,
     count: _c.uint32_t,
-    _pad5: [4]u8,
+    _pad4: [4]u8,
 }
 
 
@@ -2295,10 +2295,10 @@ MeshScale :: struct {
 ConvexMeshGeometry :: struct {
     using _: Geometry,
     scale: MeshScale,
-    _pad4: [4]u8,
+    _pad3: [4]u8,
     convexMesh: ^ConvexMesh,
     meshFlags: ConvexMeshGeometryFlags_Set,
-    _pad7: [7]u8,
+    _pad6: [7]u8,
 }
 
 
@@ -2317,7 +2317,7 @@ TriangleMeshGeometry :: struct {
     using _: Geometry,
     scale: MeshScale,
     meshFlags: MeshGeometryFlags_Set,
-    _pad5: [3]u8,
+    _pad4: [3]u8,
     triangleMesh: ^TriangleMesh,
 }
 
@@ -2329,7 +2329,7 @@ HeightFieldGeometry :: struct {
     rowScale: _c.float,
     columnScale: _c.float,
     heightFieldFlags: MeshGeometryFlags_Set,
-    _pad8: [3]u8,
+    _pad7: [3]u8,
 }
 
 
@@ -2358,7 +2358,7 @@ QueryHit :: struct {
 LocationHit :: struct {
     using _: QueryHit,
     flags: HitFlags_Set,
-    _pad3: [2]u8,
+    _pad2: [2]u8,
     position: Vec3,
     normal: Vec3,
     distance: _c.float,
@@ -3234,24 +3234,21 @@ ActorShape :: struct {
 }
 
 
-RaycastHit :: struct #packed {
+RaycastHit :: struct {
     using _: GeomRaycastHit,
     using _: ActorShape,
-    _pad12: [4]u8,
 }
 
 
-OverlapHit :: struct #packed {
+OverlapHit :: struct {
     using _: GeomOverlapHit,
     using _: ActorShape,
-    _pad4: [4]u8,
 }
 
 
-SweepHit :: struct #packed {
+SweepHit :: struct {
     using _: GeomSweepHit,
     using _: ActorShape,
-    _pad10: [4]u8,
 }
 
 
@@ -3497,13 +3494,13 @@ SceneDesc :: struct {
     ccdContactModifyCallback: ^CCDContactModifyCallback,
     filterShaderData: rawptr,
     filterShaderDataSize: _c.uint32_t,
-    _pad16: [4]u8,
+    _pad15: [4]u8,
     filterShader: rawptr,
     filterCallback: ^SimulationFilterCallback,
     kineKineFilteringMode: PairFilteringMode,
     staticKineFilteringMode: PairFilteringMode,
     broadPhaseType: BroadPhaseType,
-    _pad22: [4]u8,
+    _pad21: [4]u8,
     broadPhaseCallback: ^BroadPhaseCallback,
     limits: SceneLimits,
     frictionType: FrictionType,
@@ -3513,7 +3510,7 @@ SceneDesc :: struct {
     frictionCorrelationDistance: _c.float,
     flags: SceneFlags_Set,
     cpuDispatcher: ^CpuDispatcher,
-    _pad32: [8]u8,
+    _pad31: [8]u8,
     userData: rawptr,
     solverBatchSize: _c.uint32_t,
     solverArticulationBatchSize: _c.uint32_t,
@@ -3532,7 +3529,7 @@ SceneDesc :: struct {
     gpuComputeVersion: _c.uint32_t,
     contactPairSlabSize: _c.uint32_t,
     sceneQuerySystem: ^SceneQuerySystem,
-    _pad51: [8]u8,
+    _pad50: [8]u8,
 }
 
 
@@ -3649,7 +3646,7 @@ ContactPairExtraDataItem :: struct {
 
 ContactPairVelocity :: struct {
     using _: ContactPairExtraDataItem,
-    _pad1: [3]u8,
+    _pad1: [2]u8,
     linearVelocity: [2]Vec3,
     angularVelocity: [2]Vec3,
 }
@@ -3657,14 +3654,13 @@ ContactPairVelocity :: struct {
 
 ContactPairPose :: struct {
     using _: ContactPairExtraDataItem,
-    _pad1: [3]u8,
+    _pad1: [2]u8,
     globalPose: [2]Transform,
 }
 
 
 ContactPairIndex :: struct {
     using _: ContactPairExtraDataItem,
-    _pad1: [1]u8,
     index: _c.uint16_t,
 }
 
@@ -3775,7 +3771,7 @@ Obstacle :: struct {
 BoxObstacle :: struct {
     using _: Obstacle,
     mHalfExtents: Vec3,
-    _pad6: [4]u8,
+    _pad5: [4]u8,
 }
 
 
@@ -3896,7 +3892,6 @@ Controller :: struct {
 
 BoxControllerDesc :: struct {
     using _: ControllerDesc,
-    _pad22: [4]u8,
     halfHeight: _c.float,
     halfSideExtent: _c.float,
     halfForwardExtent: _c.float,
@@ -3911,7 +3906,6 @@ BoxController :: struct {
 
 CapsuleControllerDesc :: struct {
     using _: ControllerDesc,
-    _pad22: [4]u8,
     radius: _c.float,
     height: _c.float,
     climbingMode: CapsuleClimbingMode,


### PR DESCRIPTION
There were a few API's that either returned a pointer to a C-style array, or mapped to one (userBuffers). Odin usually maps those kinds of pointers to multipointers, so this PR adds a field to type-db called `"is_array_like"` that will write the pointer out as a multi-pointer `[^]`

For example, this is now possible:
```odin
rb := physx.scene_get_render_buffer_mut(scene)

for i in 0..<physx.render_buffer_get_nb_lines(rb) {
	line := physx.render_buffer_get_lines(rb)[i] // Returns [^]PxDebugLine instead of ^PxDebugLine
	...
}
```